### PR TITLE
Fix compiler warning in FuncOps.cpp

### DIFF
--- a/lib/Dialect/ZKIR/IR/FuncOps.cpp
+++ b/lib/Dialect/ZKIR/IR/FuncOps.cpp
@@ -260,7 +260,7 @@ LogicalResult ReturnOp::verify() {
   auto function = cast<FuncOp>((*this)->getParentOp());
 
   // The operand number and types must match the function signature.
-  const auto &results = function.getFunctionType().getResults();
+  const auto results = function.getFunctionType().getResults();
   if (getNumOperands() != results.size()) {
     return emitOpError("has ") << getNumOperands() << " operands, but enclosing function (@"
                                << function.getName() << ") returns " << results.size();


### PR DESCRIPTION
`function.getFunctionType().getResults()` returns an `ArrayRef`value which is already a reference wrapper class for a vector. I was getting this compiler warning:

```
[20/25] Building CXX object lib/Dialect/ZKIR/CMakeFiles/ZKIRDialect.dir/IR/FuncOps.cpp.o
/home/foldr/code/veridise/zkir-lib/lib/Dialect/ZKIR/IR/FuncOps.cpp: In member function ‘mlir::LogicalResult zkir::ReturnOp::verify()’:
/home/foldr/code/veridise/zkir-lib/lib/Dialect/ZKIR/IR/FuncOps.cpp:263:15: aviso: possibly dangling reference to a temporary [-Wdangling-reference]
  263 |   const auto &results = function.getFunctionType().getResults();
      |               ^~~~~~~
/home/foldr/code/veridise/zkir-lib/lib/Dialect/ZKIR/IR/FuncOps.cpp:263:62: nota: the temporary was destroyed at the end of the full expression ‘function.zkir::FuncOp::getFunctionType().mlir::FunctionType::getRes
ults()’
  263 |   const auto &results = function.getFunctionType().getResults();
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~

```

It is probably ok but doesn't hurt to change it I guess