### PR TITLE
Migrate to public dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,27 +13,20 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - uses: cachix/install-nix-action@v27
+      # v37.1.0
+      - uses: cachix/install-nix-action@d1ca217b388ee87b2507a9a93bf01368bde7cec2
         with:
           install_url: https://releases.nixos.org/nix/nix-2.23.3/install
-          github_access_token: "${{ secrets.CI_BUILD_TOKEN }}"
+          github_access_token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Set Git credentials
         run: |
           git config --global 'url.https://api@github.com/'.insteadOf 'https://github.com/'
           git config --global 'url.https://ssh@github.com/'.insteadOf 'ssh://git@github.com/'
           git config --global 'url.https://git@github.com/'.insteadOf 'git@github.com:'
-          echo 'echo "$CI_BOT_PAT"' > ~/.git-askpass
-          chmod 500 ~/.git-askpass
-          git config --global core.askPass "$HOME"/.git-askpass
-      - uses: cachix/cachix-action@v15
+       # v16
+      - uses: cachix/cachix-action@0fc020193b5a1fa3ac4575aa3a7d3aa6a35435ad
         with:
-          name: veridise-private
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-          pushFilter: '(-source$)'
+          name: veridise-public
+          authToken: '${{ secrets.CACHIX_PUBLIC_TOKEN }}'
       - name: Build
         run: nix --print-build-logs build '.#checks.x86_64-linux.llzkInstallCheck'
-        env:
-          CI_BOT_PAT: "${{ secrets.CI_BUILD_TOKEN }}"
-      - name: Clear Git credentials
-        if: "${{ always() }}"
-        run: rm -rf "~/.git-askpass"

--- a/.github/workflows/debug-ci.yml
+++ b/.github/workflows/debug-ci.yml
@@ -22,40 +22,33 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - uses: cachix/install-nix-action@v27
+      # v37.1.0
+      - uses: cachix/install-nix-action@d1ca217b388ee87b2507a9a93bf01368bde7cec2
         with:
           install_url: https://releases.nixos.org/nix/nix-2.23.3/install
-          github_access_token: "${{ secrets.CI_BUILD_TOKEN }}"
+          github_access_token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Set Git credentials
         run: |
           git config --global 'url.https://api@github.com/'.insteadOf 'https://github.com/'
           git config --global 'url.https://ssh@github.com/'.insteadOf 'ssh://git@github.com/'
           git config --global 'url.https://git@github.com/'.insteadOf 'git@github.com:'
-          echo 'echo "$CI_BOT_PAT"' > ~/.git-askpass
-          chmod 500 ~/.git-askpass
-          git config --global core.askPass "$HOME"/.git-askpass
-      - uses: cachix/cachix-action@v15
+      # v16
+      - uses: cachix/cachix-action@0fc020193b5a1fa3ac4575aa3a7d3aa6a35435ad
         with:
-          name: veridise-private
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-          pushFilter: '(-source$)'
+          name: veridise-public
+          authToken: '${{ secrets.CACHIX_PUBLIC_TOKEN }}'
       - name: 'Build with ${{ matrix.compiler.name }}'
         run: "nix --print-build-logs build '${{ matrix.compiler.derivation }}'"
-        env:
-          CI_BOT_PAT: "${{ secrets.CI_BUILD_TOKEN }}"
-      - name: Upload test results 
+      - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: "Test results (${{ matrix.compiler.name }})"
           path: "result/artifacts/${{ matrix.compiler.report }}"
-      - name: Clear Git credentials
-        if: "${{ always() }}"
-        run: rm -rf "~/.git-askpass"
-   
+
   publish-tests:
     name: "Publish test results"
-    needs: build 
+    needs: build
     runs-on: ubuntu-24.04
     if: always()
     steps:
@@ -69,5 +62,3 @@ jobs:
         with:
           files: artifacts/**/*.xml
           comment_mode: failures
-
-

--- a/flake.lock
+++ b/flake.lock
@@ -26,16 +26,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1743530434,
-        "narHash": "sha256-xugjy5SEaiZIUeEYKtgacj3Ns+tnn0yrheeXS+9D+Ws=",
+        "lastModified": 1743550662,
+        "narHash": "sha256-8bGHrgk3RdlAour8ch8LqsQG7vnA2LpoufljrMt6U4o=",
         "owner": "Veridise",
         "repo": "llzk-nix-pkgs",
-        "rev": "9fbef12a2d5712be06f16d7a08a98e7c7e2dbfe6",
+        "rev": "11410bbc0ff373f0a05aca4433afc374e35baf30",
         "type": "github"
       },
       "original": {
         "owner": "Veridise",
-        "ref": "iangneal/tweaks",
+        "ref": "main",
         "repo": "llzk-nix-pkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
     flake-utils.url = "github:numtide/flake-utils/v1.0.0";
 
     llzk-pkgs = {
-      url = "github:Veridise/llzk-nix-pkgs?ref=iangneal/tweaks";
+      url = "github:Veridise/llzk-nix-pkgs?ref=main";
       inputs = {
         nixpkgs.follows = "nixpkgs";
         flake-utils.follows = "flake-utils";


### PR DESCRIPTION
- Replace veridise-nix-pkgs (private) with llzk-nix-pkgs (public)
- Replace CI use of veridise-private cachix with veridise-public

- [x] Merge will be pending the latest PR on llzk-nix-pkgs: Veridise/llzk-nix-pkgs#1
- [ ] After other outstanding PRs are merged, the private cachix auth token needs to be removed from the repo by @Technius 
