### PR TITLE
[VAN-269] Fix location sorting bug

### DIFF
--- a/changelogs/unreleased/iangneal__location-sorting-fix.yaml
+++ b/changelogs/unreleased/iangneal__location-sorting-fix.yaml
@@ -1,0 +1,2 @@
+fixed:
+  - Fixed bug with analyses improperly sorting struct locations, causing map collisions

--- a/test/Analysis/interval_analysis_pass.llzk
+++ b/test/Analysis/interval_analysis_pass.llzk
@@ -209,6 +209,8 @@ module attributes {veridise.lang = "llzk"} {
 
 // -----
 
+// Ensure we still report all structs if they're all at an unknown location
+#loc = loc(unknown)
 module attributes {veridise.lang = "llzk"} {
   // A correctly constrained byte decomposition checker for a 16 bit val.
   struct.def @ByteDecompCorrect {
@@ -233,7 +235,7 @@ module attributes {veridise.lang = "llzk"} {
       constrain.eq %reconstructed, %u16 : !felt.type
       function.return
     }
-  }
+  } loc(#loc)
 
   // An incorrectly constrained byte decomposition checker for a 16 bit val.
   struct.def @ByteDecompIncorrect {
@@ -255,7 +257,7 @@ module attributes {veridise.lang = "llzk"} {
       constrain.eq %reconstructed, %u16 : !felt.type
       function.return
     }
-  }
+  } loc(#loc)
 
   // Another improperly constrained byte decomposition checker for a 16 bit val.
   struct.def @ByteDecompPartial {
@@ -282,7 +284,7 @@ module attributes {veridise.lang = "llzk"} {
       constrain.eq %reconstructed, %u16 : !felt.type
       function.return
     }
-  }
+  } loc(#loc)
 }
 
 // CHECK-LABEL: @ByteDecompCorrect StructIntervals {


### PR DESCRIPTION
- `unknown` locations were not handled properly by the analysis result map, resulting in unintended conflicts that caused results to be dropped (hence the missing analysis results)
- Also adding a small utility method to expose the `mlir::DataFlowSolver` used in a particular analysis so that uses may query lattice values at a given location.