### PR TITLE
Clarify Terminology: Change "infrastructure" to "infrastructure" in LLZK Workflow Description

### DIFF
--- a/doc/doxygen/0_overview.md
+++ b/doc/doxygen/0_overview.md
@@ -12,7 +12,7 @@ The LLZK project consists of three main components:
 
 The general workflow of using LLZK is therefore as follows:
 1. Translate the source language into LLZK using [a frontend tool](\ref frontends).
-2. Use the [llzk-opt tool](\ref llzk-opt) to perform any transformations using LLZK's [pass infrastucture](\ref pass-overview).
+2. Use the [llzk-opt tool](\ref llzk-opt) to perform any transformations using LLZK's [pass infrastructure](\ref pass-overview).
 3. Provide the transformed IR to a [backend](\ref backends) for further analysis or use.
 
 ### Frontends {#frontends}


### PR DESCRIPTION


Description:  
This pull request updates the documentation in doc/doxygen/0_overview.md to correct the terminology in the LLZK workflow section. Specifically, it changes "pass infrastructure" to "pass infrastructure" for consistency and clarity when describing the use of the llzk-opt tool for transformations. No functional changes are introduced; this is a documentation improvement for better readability and accuracy.
