### PR TITLE
[LLZK-245] Generalize `constrain.in`

### DIFF
--- a/changelogs/unreleased/iangneal__LLZK-245-generalize-emit_in.yaml
+++ b/changelogs/unreleased/iangneal__LLZK-245-generalize-emit_in.yaml
@@ -1,0 +1,5 @@
+changed:
+  - Generalize semantics of `constrain.in` op
+
+fixed:
+  - Restrict types accepted by `constrain.in` to match `constrain.eq` types

--- a/include/llzk/Dialect/Constrain/IR/Ops.td
+++ b/include/llzk/Dialect/Constrain/IR/Ops.td
@@ -81,7 +81,7 @@ def EmitContainmentOp : EmitOp<"in"> {
   let description = [{
     Emits a containment constraint between lhs and rhs (rhs must be contained
     within lhs). If lhs is an N-dimensional array (N >= 1), rhs must be an
-    M-dimensional array, where N > M (M=0 means that rhs is a scalar element
+    M-dimensional array, where N >= M (M=0 means that rhs is a scalar element
     of type accepted by the `constrain.eq` operation).
   }];
 

--- a/include/llzk/Dialect/Constrain/IR/Ops.td
+++ b/include/llzk/Dialect/Constrain/IR/Ops.td
@@ -28,7 +28,18 @@ include "mlir/IR/SymbolInterfaces.td"
 class EmitOp<string mnemonic, list<Trait> traits = []>
     : Op<ConstrainDialect, mnemonic,
          traits#[ConstraintOpInterface, ConstraintGen,
-                 DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {
+                 DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {}
+
+def EmitEqualityOp
+    : EmitOp<"eq", [Commutative, ElementwiseMappable, TypesUnify<"lhs", "rhs">,
+]> {
+  let summary = "emit an equality constraint";
+  let description = [{
+    Emits an equality constraint between lhs and rhs. For the built-in Signal
+    struct, the constraint is performed on the Signal's inner `@reg` felt field.
+  }];
+
+  let arguments = (ins EmitEqType:$lhs, EmitEqType:$rhs);
 
   let assemblyFormat = [{
     $lhs `,` $rhs `:` type($lhs)
@@ -65,23 +76,22 @@ class EmitOp<string mnemonic, list<Trait> traits = []>
   }];
 }
 
-def EmitEqualityOp
-    : EmitOp<"eq", [Commutative, ElementwiseMappable, TypesUnify<"lhs", "rhs">,
-]> {
-  let summary = "emit an equality constraint";
+def EmitContainmentOp : EmitOp<"in"> {
+  let summary = "emit a containment constraint";
   let description = [{
-    Emits an equality constraint between lhs and rhs. For the built-in Signal
-    struct, the constraint is performed on the Signal's inner `@reg` felt field.
+    Emits a containment constraint between lhs and rhs (rhs must be contained
+    within lhs). If lhs is an N-dimensional array (N >= 1), rhs must be an
+    M-dimensional array, where N > M (M=0 means that rhs is a scalar element
+    of type accepted by the `constrain.eq` operation).
   }];
 
-  let arguments = (ins EmitEqType:$lhs, EmitEqType:$rhs);
-}
+  let arguments = (ins LLZK_ArrayType:$lhs, AnyLLZKType:$rhs);
 
-def EmitContainmentOp : EmitOp<"in", [ArrayElemTypeUnifyWith<"lhs", "rhs">]> {
-  let summary = "emit a containment constraint";
-  let description = [{}];
+  let assemblyFormat = [{
+    $lhs `,` $rhs `:` type($lhs) `,` type($rhs) attr-dict
+  }];
 
-  let arguments = (ins LLZK_ArrayType:$lhs, ArrayElemType:$rhs);
+  let hasVerifier = true;
 }
 
 #endif // LLZK_CONSTRAIN_OPS

--- a/include/llzk/Dialect/Shared/Types.td
+++ b/include/llzk/Dialect/Shared/Types.td
@@ -22,6 +22,10 @@ def EmitEqType
     : Type<CPred<"::llzk::isValidEmitEqType($_self)">,
            "any LLZK type, excluding non-Signal struct and string types">;
 
+def EmitContainmentType
+    : Type<CPred<"::llzk::isValidEmitContainmentType($_self)">,
+           "an array of EmitEqTypes or a single EmitEqType">;
+
 def ConstReadType : Type<CPred<"::llzk::isValidConstReadType($_self)">,
                          "integral, felt, or typevar type">;
 

--- a/include/llzk/Dialect/Shared/Types.td
+++ b/include/llzk/Dialect/Shared/Types.td
@@ -22,10 +22,6 @@ def EmitEqType
     : Type<CPred<"::llzk::isValidEmitEqType($_self)">,
            "any LLZK type, excluding non-Signal struct and string types">;
 
-def EmitContainmentType
-    : Type<CPred<"::llzk::isValidEmitContainmentType($_self)">,
-           "an array of EmitEqTypes or a single EmitEqType">;
-
 def ConstReadType : Type<CPred<"::llzk::isValidConstReadType($_self)">,
                          "integral, felt, or typevar type">;
 

--- a/include/llzk/Util/TypeHelper.h
+++ b/include/llzk/Util/TypeHelper.h
@@ -287,4 +287,20 @@ mlir::LogicalResult verifyArrayType(
     EmitErrorFn emitError, mlir::Type elementType, mlir::ArrayRef<mlir::Attribute> dimensionSizes
 );
 
+/// Determine if the `subArrayType` is a valid subarray of `arrayType`.
+/// `arrayType` must be an array of dimension N and `subArrayType` must be
+/// an array of dimension M, where N > M >= 1.
+/// For example, <3,7 x int> is a valid subarray of <5,3,7 x int>, but
+/// <8 x int> is not an neither is <3,7 x string>.
+mlir::LogicalResult verifySubArrayType(
+    EmitErrorFn emitError, array::ArrayType arrayType, array::ArrayType subArrayType
+);
+
+/// Determine if the `subArrayOrElemType` is either a valid subarray of `arrayType`
+/// (see `verifySubArrayType`), or if `subArrayOrElemType` matches the element
+/// type of `arrayType`.
+mlir::LogicalResult verifySubArrayOrElementType(
+    EmitErrorFn emitError, array::ArrayType arrayType, mlir::Type subArrayOrElemType
+);
+
 } // namespace llzk

--- a/lib/Dialect/Array/IR/Ops.cpp
+++ b/lib/Dialect/Array/IR/Ops.cpp
@@ -445,9 +445,6 @@ LogicalResult InsertArrayOp::verify() {
   if (numIndices > lhsDims) {
     return emitOpError("cannot select more dimensions than exist in the source array");
   }
-  if (lhsDims < rhsDims) {
-    return emitOpError("cannot insert array into destination with fewer dimensions");
-  }
 
   // Ensure the rValue dimension count equals the base reduced dimension count
   auto compare = (numIndices + rhsDims) <=> lhsDims;
@@ -458,7 +455,9 @@ LogicalResult InsertArrayOp::verify() {
     );
   }
 
-  // Having verified the dimensions are of appropriate size, we verify the subarray type.
+  // Having verified the indices are of appropriate size, we verify the subarray type.
+  // This will verify the dimensions of the subarray, which is why we only check the
+  // size of the indices above.
   return verifySubArrayType(getEmitOpErrFn(this), baseArrRefArrType, rValueArrType);
 }
 

--- a/lib/Dialect/Array/IR/Ops.cpp
+++ b/lib/Dialect/Array/IR/Ops.cpp
@@ -431,53 +431,35 @@ LogicalResult InsertArrayOp::verifySymbolUses(SymbolTableCollection &tables) {
 }
 
 LogicalResult InsertArrayOp::verify() {
-  size_t numIndices = getIndices().size();
-
   ArrayType baseArrRefArrType = getArrRefType();
-
   Type rValueType = getRvalue().getType();
   assert(llvm::isa<ArrayType>(rValueType)); // per ODS spec of InsertArrayOp
   ArrayType rValueArrType = llvm::cast<ArrayType>(rValueType);
 
-  ArrayRef<Attribute> dimsFromBase = baseArrRefArrType.getDimensionSizes();
+  // size of lhs dimensions == numIndices + size of rhs dimensions
+  size_t lhsDims = baseArrRefArrType.getDimensionSizes().size();
+  size_t numIndices = getIndices().size();
+  size_t rhsDims = rValueArrType.getDimensionSizes().size();
+
   // Ensure the number of indices specified does not exceed base dimension count.
-  if (numIndices > dimsFromBase.size()) {
+  if (numIndices > lhsDims) {
     return emitOpError("cannot select more dimensions than exist in the source array");
   }
+  if (lhsDims < rhsDims) {
+    return emitOpError("cannot insert array into destination with fewer dimensions");
+  }
 
-  ArrayRef<Attribute> dimsFromRValue = rValueArrType.getDimensionSizes();
-  ArrayRef<Attribute> dimsFromBaseReduced = dimsFromBase.drop_front(numIndices);
   // Ensure the rValue dimension count equals the base reduced dimension count
-  auto compare = dimsFromRValue.size() <=> dimsFromBaseReduced.size();
+  auto compare = (numIndices + rhsDims) <=> lhsDims;
   if (compare != 0) {
     return emitOpError().append(
         "has ", (compare < 0 ? "insufficient" : "too many"), " indexed dimensions: expected ",
-        (dimsFromBase.size() - dimsFromRValue.size()), " but found ", numIndices
+        (lhsDims - rhsDims), " but found ", numIndices
     );
   }
 
-  // Ensure dimension sizes are compatible (ignoring the indexed dimensions)
-  if (!typeParamsUnify(dimsFromBaseReduced, dimsFromRValue)) {
-    std::string message;
-    llvm::raw_string_ostream ss(message);
-    auto appendOne = [&ss](Attribute a) { appendWithoutType(ss, a); };
-    ss << "cannot unify array dimensions [";
-    llvm::interleaveComma(dimsFromBaseReduced, ss, appendOne);
-    ss << "] with [";
-    llvm::interleaveComma(dimsFromRValue, ss, appendOne);
-    ss << "]";
-    return emitOpError().append(message);
-  }
-
-  // Ensure element types of the arrays are compatible
-  if (!typesUnify(baseArrRefArrType.getElementType(), rValueArrType.getElementType())) {
-    return emitOpError().append(
-        "incorrect array element type; expected: ", baseArrRefArrType.getElementType(),
-        ", found: ", rValueArrType.getElementType()
-    );
-  }
-
-  return success();
+  // Having verified the dimensions are of appropriate size, we verify the subarray type.
+  return verifySubArrayType(getEmitOpErrFn(this), baseArrRefArrType, rValueArrType);
 }
 
 //===------------------------------------------------------------------===//

--- a/lib/Dialect/Constrain/IR/Ops.cpp
+++ b/lib/Dialect/Constrain/IR/Ops.cpp
@@ -12,6 +12,7 @@
 #include "llzk/Dialect/Function/IR/OpTraits.h"
 #include "llzk/Dialect/Function/IR/Ops.h"
 #include "llzk/Util/BuilderHelper.h"
+#include "llzk/Util/ErrorHelper.h"
 
 // TableGen'd implementation files
 #define GET_OP_CLASSES
@@ -46,9 +47,9 @@ LogicalResult EmitContainmentOp::verifySymbolUses(SymbolTableCollection &tables)
   );
 }
 
-Type EmitContainmentOp::inferRHS(Type lhsType) {
-  assert(llvm::isa<ArrayType>(lhsType)); // per ODS spec of EmitContainmentOp
-  return llvm::cast<ArrayType>(lhsType).getElementType();
+LogicalResult EmitContainmentOp::verify() {
+  auto arrType = llvm::cast<ArrayType>(getLhs().getType()); // per the ODS definition
+  return verifySubArrayOrElementType(getEmitOpErrFn(this), arrType, getRhs().getType());
 }
 
 } // namespace llzk::constrain

--- a/lib/Util/TypeHelper.cpp
+++ b/lib/Util/TypeHelper.cpp
@@ -937,7 +937,13 @@ verifySubArrayType(EmitErrorFn emitError, ArrayType arrayType, ArrayType subArra
   size_t numArrDims = dimsFromArr.size();
   ArrayRef<Attribute> dimsFromSubArr = subArrayType.getDimensionSizes();
   size_t numSubArrDims = dimsFromSubArr.size();
-  assert(numArrDims >= numSubArrDims); // precondition
+
+  if (numArrDims < numSubArrDims) {
+    return emitError().append(
+        "subarray type ", subArrayType, " has more dimensions than array type ", arrayType
+    );
+  }
+
   size_t toDrop = numArrDims - numSubArrDims;
   ArrayRef<Attribute> dimsFromArrReduced = dimsFromArr.drop_front(toDrop);
 

--- a/test/Analysis/constraint_dependency_graph_pass.llzk
+++ b/test/Analysis/constraint_dependency_graph_pass.llzk
@@ -90,7 +90,7 @@ module attributes {veridise.lang = "llzk"} {
 module attributes {veridise.lang = "llzk"} {
   struct.def @ComponentB {
     function.def @constrain(%self: !struct.type<@ComponentB>, %a: !felt.type, %b: !array.type<5 x !felt.type>) {
-      constrain.in %b, %a : !array.type<5 x !felt.type>
+      constrain.in %b, %a : !array.type<5 x !felt.type>, !felt.type
       function.return
     }
 

--- a/test/Dialect/Constrain/emit_fail.llzk
+++ b/test/Dialect/Constrain/emit_fail.llzk
@@ -477,6 +477,8 @@ module attributes {veridise.lang = "llzk"} {
 }
 
 // -----
+
+// Test: cannot use struct type with [constrain.in] op
 module attributes {veridise.lang = "llzk"} {
   struct.def @Component26 {
     function.def @constrain(%self: !struct.type<@Component26>, %b: !array.type<89 x !struct.type<@Component26>>) {
@@ -493,6 +495,7 @@ module attributes {veridise.lang = "llzk"} {
 }
 // -----
 
+// Test: mismatched dimensions with [constrain.in] op
 module attributes {veridise.lang = "llzk"} {
   struct.def @Component27 {
     function.def @constrain(%self: !struct.type<@Component27>, %a: !array.type<7,3,2 x index>, %b: !array.type<89,2 x index>) {
@@ -504,6 +507,24 @@ module attributes {veridise.lang = "llzk"} {
     function.def @compute(%a: !array.type<7,3,2 x index>, %b: !array.type<89,2 x index>) -> !struct.type<@Component27> {
       %self = struct.new : !struct.type<@Component27>
       function.return %self : !struct.type<@Component27>
+    }
+  }
+}
+
+// -----
+
+// Test: rhs has more dimensions than lhs, not allowed for [constrain.in] op
+module attributes {veridise.lang = "llzk"} {
+  struct.def @Component28 {
+    function.def @constrain(%self: !struct.type<@ComponentE>, %a: !array.type<2 x index>, %b: !array.type<89,2 x index>) {
+      // expected-error@+1 {{'constrain.in' op subarray type '!array.type<89,2 x index>' has more dimensions than array type '!array.type<2 x index>'}}
+      constrain.in %a, %b : <2 x index>, !array.type<89,2 x index>
+      function.return
+    }
+
+    function.def @compute(%a: !array.type<2 x index>, %b: !array.type<89,2 x index>) -> !struct.type<@ComponentE> {
+      %self = struct.new : !struct.type<@ComponentE>
+      function.return %self : !struct.type<@ComponentE>
     }
   }
 }

--- a/test/Dialect/Constrain/emit_fail.llzk
+++ b/test/Dialect/Constrain/emit_fail.llzk
@@ -475,3 +475,35 @@ module attributes {veridise.lang = "llzk"} {
     }
   }
 }
+
+// -----
+module attributes {veridise.lang = "llzk"} {
+  struct.def @Component26 {
+    function.def @constrain(%self: !struct.type<@Component26>, %b: !array.type<89 x !struct.type<@Component26>>) {
+      // expected-error@+1 {{'constrain.in' op element type must be any LLZK type, excluding non-Signal struct and string types, but got '!struct.type<@Component26>'}}
+      constrain.in %b, %self : !array.type<89 x !struct.type<@Component26>>, !struct.type<@Component26>
+      function.return
+    }
+
+    function.def @compute(%b: !array.type<89 x !struct.type<@Component26>>) -> !struct.type<@Component26> {
+      %self = struct.new : !struct.type<@Component26>
+      function.return %self : !struct.type<@Component26>
+    }
+  }
+}
+// -----
+
+module attributes {veridise.lang = "llzk"} {
+  struct.def @Component27 {
+    function.def @constrain(%self: !struct.type<@Component27>, %a: !array.type<7,3,2 x index>, %b: !array.type<89,2 x index>) {
+      // expected-error@+1 {{'constrain.in' op cannot unify array dimensions [3, 2] with [89, 2]}}
+      constrain.in %a, %b : !array.type<7,3,2 x index>, !array.type<89,2 x index>
+      function.return
+    }
+
+    function.def @compute(%a: !array.type<7,3,2 x index>, %b: !array.type<89,2 x index>) -> !struct.type<@Component27> {
+      %self = struct.new : !struct.type<@Component27>
+      function.return %self : !struct.type<@Component27>
+    }
+  }
+}

--- a/test/Dialect/Constrain/emit_fail.llzk
+++ b/test/Dialect/Constrain/emit_fail.llzk
@@ -12,7 +12,7 @@ module attributes {veridise.lang = "llzk"} {
           %b: !array.type<5 x !felt.type> // expected-note {{prior use here}}
           ) {
       // expected-error@+1 {{use of value '%b' expects different type than prior uses: '!array.type<6 x !felt.type>' vs '!array.type<5 x !felt.type>'}}
-      constrain.in %b, %a : !array.type<6 x !felt.type>
+      constrain.in %b, %a : !array.type<6 x !felt.type>, !felt.type
       function.return
     }
   }
@@ -31,7 +31,7 @@ module attributes {veridise.lang = "llzk"} {
           %b: !array.type<5 x !felt.type> // expected-note {{prior use here}}
           ) {
       // expected-error@+1 {{use of value '%b' expects different type than prior uses: '!array.type<5 x index>' vs '!array.type<5 x !felt.type>'}}
-      constrain.in %b, %a : !array.type<5 x index>
+      constrain.in %b, %a : !array.type<5 x index>, index
       function.return
     }
   }
@@ -46,11 +46,11 @@ module attributes {veridise.lang = "llzk"} {
       function.return %self : !struct.type<@TestComponent03>
     }
     function.def @constrain(
-          %a: index, // expected-note {{prior use here}}
+          %a: index,
           %b: !array.type<5 x !felt.type>
           ) {
-      // expected-error@+1 {{use of value '%a' expects different type than prior uses: '!felt.type' vs 'index'}}
-      constrain.in %b, %a : !array.type<5 x !felt.type>
+      // expected-error@+1 {{'constrain.in' op incorrect array element type; expected: '!felt.type', found: 'index'}}
+      constrain.in %b, %a : !array.type<5 x !felt.type>, index
       function.return
     }
   }
@@ -66,7 +66,7 @@ module attributes {veridise.lang = "llzk"} {
     }
     function.def @constrain(%a: !felt.type, %b: !felt.type) {
       // expected-error@+1 {{custom op 'constrain.in' invalid kind of Type specified}}
-      constrain.in %b, %a : !felt.type
+      constrain.in %b, %a : !felt.type, !felt.type
       function.return
     }
   }
@@ -85,7 +85,7 @@ module attributes {veridise.lang = "llzk"} {
           %b: !felt.type  // expected-note {{prior use here}}
           ) {
       // expected-error@+1 {{use of value '%b' expects different type than prior uses: '!array.type<5 x !felt.type>' vs '!felt.type'}}
-      constrain.in %b, %a : !array.type<5 x !felt.type>
+      constrain.in %b, %a : !array.type<5 x !felt.type>, !felt.type
       function.return
     }
   }
@@ -100,11 +100,11 @@ module attributes {veridise.lang = "llzk"} {
       function.return %self : !struct.type<@TestComponent06>
     }
     function.def @constrain(
-          %a: index, // expected-note {{prior use here}}
+          %a: index,
           %b: !array.type<5 x !felt.type>
           ) {
-      // expected-error@+1 {{use of value '%a' expects different type than prior uses: '!felt.type' vs 'index'}}
-      constrain.in %b, %a : !array.type<5 x !felt.type>
+      // expected-error@+1 {{'constrain.in' op incorrect array element type; expected: '!felt.type', found: 'index'}}
+      constrain.in %b, %a : !array.type<5 x !felt.type>, index
       function.return
     }
   }
@@ -373,7 +373,7 @@ module attributes {veridise.lang = "llzk"} {
     %b = arith.constant 535 : index
     %z = array.new %a, %b: !array.type<2 x index>
     // expected-error@+1 {{'constrain.in' op only valid within a 'function.def' with 'function.allow_constraint' attribute}}
-    constrain.in %z, %a : !array.type<2 x index>
+    constrain.in %z, %a : !array.type<2 x index>, index
 }
 // -----
 
@@ -382,7 +382,7 @@ module attributes {veridise.lang = "llzk"} {
   struct.def @Component20 {
     function.def @constrain(%a: !felt.type, %b: !array.type<5 x !felt.type>) {
       // expected-error@+1 {{cannot name an operation with no results}}
-      %c = constrain.in %b, %a : !array.type<5 x !felt.type>
+      %c = constrain.in %b, %a : !array.type<5 x !felt.type>, !felt.type
       function.return
     }
 
@@ -432,7 +432,7 @@ module attributes {veridise.lang = "llzk"} {
 module attributes {veridise.lang = "llzk"} {
   struct.def @Component23 {
     function.def @constrain(%a: !array.type<4 x !felt.type>, %b: index) {
-      // expected-error@+1 {{'constrain.in' op failed to verify that rhs type matches with lhs element type}}
+      // expected-error@+1 {{'constrain.in' op incorrect array element type; expected: '!felt.type', found: 'index'}}
       constrain.in %a, %b : !array.type<4 x !felt.type>, index
       function.return
     }

--- a/test/Dialect/Constrain/emit_pass.llzk
+++ b/test/Dialect/Constrain/emit_pass.llzk
@@ -30,7 +30,7 @@ module attributes {veridise.lang = "llzk"} {
 module attributes {veridise.lang = "llzk"} {
   struct.def @ComponentB {
     function.def @constrain(%self: !struct.type<@ComponentB>, %a: !felt.type, %b: !array.type<5 x !felt.type>) {
-      constrain.in %b, %a : !array.type<5 x !felt.type>
+      constrain.in %b, %a : !array.type<5 x !felt.type>, !felt.type
       function.return
     }
 
@@ -57,7 +57,7 @@ module attributes {veridise.lang = "llzk"} {
 module attributes {veridise.lang = "llzk"} {
   struct.def @ComponentC {
     function.def @constrain(%self: !struct.type<@ComponentC>, %a: index, %b: !array.type<89 x index>) {
-      constrain.in %b, %a : !array.type<89 x index>
+      constrain.in %b, %a : !array.type<89 x index>, index
       function.return
     }
 
@@ -85,7 +85,7 @@ module attributes {veridise.lang = "llzk"} {
 module attributes {veridise.lang = "llzk"} {
   struct.def @ComponentD {
     function.def @constrain(%self: !struct.type<@ComponentD>, %b: !array.type<89 x !struct.type<@ComponentD>>) {
-      constrain.in %b, %self : !array.type<89 x !struct.type<@ComponentD>>
+      constrain.in %b, %self : !array.type<89 x !struct.type<@ComponentD>>, !struct.type<@ComponentD>
       function.return
     }
 
@@ -111,7 +111,7 @@ module attributes {veridise.lang = "llzk"} {
 module attributes {veridise.lang = "llzk"} {
   struct.def @ComponentE {
     function.def @constrain(%self: !struct.type<@ComponentE>, %a: index, %b: !array.type<89,2 x index>) {
-      constrain.in %b, %a : !array.type<89,2 x index>
+      constrain.in %b, %a : !array.type<89,2 x index>, index
       function.return
     }
 

--- a/test/Dialect/Constrain/emit_pass.llzk
+++ b/test/Dialect/Constrain/emit_pass.llzk
@@ -81,27 +81,27 @@ module attributes {veridise.lang = "llzk"} {
 //CHECK-NEXT:   }
 // -----
 
-
 module attributes {veridise.lang = "llzk"} {
   struct.def @ComponentD {
-    function.def @constrain(%self: !struct.type<@ComponentD>, %b: !array.type<89 x !struct.type<@ComponentD>>) {
-      constrain.in %b, %self : !array.type<89 x !struct.type<@ComponentD>>, !struct.type<@ComponentD>
+    function.def @constrain(%self: !struct.type<@ComponentD>, %a: !array.type<2 x index>, %b: !array.type<89,2 x index>) {
+      constrain.in %b, %a : !array.type<89,2 x index>, !array.type<2 x index>
       function.return
     }
 
-    function.def @compute(%b: !array.type<89 x !struct.type<@ComponentD>>) -> !struct.type<@ComponentD> {
+    function.def @compute(%a: !array.type<2 x index>, %b: !array.type<89,2 x index>) -> !struct.type<@ComponentD> {
       %self = struct.new : !struct.type<@ComponentD>
       function.return %self : !struct.type<@ComponentD>
     }
   }
 }
 //CHECK-LABEL:  struct.def @ComponentD {
-//CHECK-NEXT:     function.def @constrain(%[[A0:[0-9a-zA-Z_\.]+]]: !struct.type<@ComponentD>,
-//CHECK-SAME:         %[[A1:[0-9a-zA-Z_\.]+]]: !array.type<89 x !struct.type<@ComponentD>>) attributes {function.allow_constraint} {
-//CHECK-NEXT:       constrain.in %[[A1]], %[[A0]] : <89 x !struct.type<@ComponentD>>, !struct.type<@ComponentD>
+//CHECK-NEXT:     function.def @constrain(%[[SELF:[0-9a-zA-Z_\.]+]]: !struct.type<@ComponentD>,
+//CHECK-SAME:         %[[A0:[0-9a-zA-Z_\.]+]]: !array.type<2 x index>, %[[A1:[0-9a-zA-Z_\.]+]]: !array.type<89,2 x index>) attributes {function.allow_constraint} {
+//CHECK-NEXT:       constrain.in %[[A1]], %[[A0]] : <89,2 x index>, !array.type<2 x index>
 //CHECK-NEXT:       function.return
 //CHECK-NEXT:     }
-//CHECK-NEXT:     function.def @compute(%[[A1:[0-9a-zA-Z_\.]+]]: !array.type<89 x !struct.type<@ComponentD>>) -> !struct.type<@ComponentD> attributes {function.allow_witness} {
+//CHECK-NEXT:     function.def @compute(%[[A0:[0-9a-zA-Z_\.]+]]: !array.type<2 x index>,
+//CHECK-SAME:         %[[A1:[0-9a-zA-Z_\.]+]]: !array.type<89,2 x index>) -> !struct.type<@ComponentD>  attributes {function.allow_witness} {
 //CHECK-NEXT:       %[[SELF:[0-9a-zA-Z_\.]+]] = struct.new : <@ComponentD>
 //CHECK-NEXT:       function.return %[[SELF]] : !struct.type<@ComponentD>
 //CHECK-NEXT:     }
@@ -133,7 +133,6 @@ module attributes {veridise.lang = "llzk"} {
 //CHECK-NEXT:       function.return %[[SELF]] : !struct.type<@ComponentE>
 //CHECK-NEXT:     }
 //CHECK-NEXT:   }
-
 // -----
 
 !Signal = !struct.type<@Signal>

--- a/test/Dialect/Function/function_restrictions_fail.llzk
+++ b/test/Dialect/Function/function_restrictions_fail.llzk
@@ -56,7 +56,7 @@ module attributes {veridise.lang = "llzk"} {
   struct.def @emitin_in_compute {
     function.def @compute(%a: !felt.type, %b: !array.type<5 x !felt.type>) -> !struct.type<@emitin_in_compute> {
       // expected-error@+1 {{'constrain.in' op only valid within a 'function.def' with 'function.allow_constraint' attribute}}
-      constrain.in %b, %a : !array.type<5 x !felt.type>
+      constrain.in %b, %a : !array.type<5 x !felt.type>, !felt.type
       %self = struct.new : !struct.type<@emitin_in_compute>
       function.return %self : !struct.type<@emitin_in_compute>
     }
@@ -73,8 +73,8 @@ module attributes {veridise.lang = "llzk"} {
       %step = arith.constant 1 : index
       scf.for %iv = %lb to %up step %step {
         // expected-error@+1 {{'constrain.in' op only valid within a 'function.def' with 'function.allow_constraint' attribute}}
-        constrain.in %b, %a : !array.type<5 x !felt.type>
-        constrain.in %b, %a : !array.type<5 x !felt.type>
+        constrain.in %b, %a : !array.type<5 x !felt.type>, !felt.type
+        constrain.in %b, %a : !array.type<5 x !felt.type>, !felt.type
       }
       %self = struct.new : !struct.type<@emitin_in_compute_in_loop>
       function.return %self : !struct.type<@emitin_in_compute_in_loop>
@@ -91,8 +91,8 @@ module attributes {veridise.lang = "llzk"} {
         scf.if %b {
           scf.if %c {
             // expected-error@+1 {{'constrain.in' op only valid within a 'function.def' with 'function.allow_constraint' attribute}}
-            constrain.in %y, %x : !array.type<5 x index>
-            constrain.in %y, %x : !array.type<5 x index>
+            constrain.in %y, %x : !array.type<5 x index>, index
+            constrain.in %y, %x : !array.type<5 x index>, index
           }
         }
       }
@@ -113,8 +113,8 @@ function.def @constrain(%a: !felt.type, %b: !felt.type) {
 // -----
 function.def @constrain(%x: index, %y: !array.type<5 x index>) {
   // expected-error@+1 {{'constrain.in' op only valid within a 'function.def' with 'function.allow_constraint' attribute}}
-  constrain.in %y, %x : !array.type<5 x index>
-  constrain.in %y, %x : !array.type<5 x index>
+  constrain.in %y, %x : !array.type<5 x index>, index
+  constrain.in %y, %x : !array.type<5 x index>, index
   function.return
 }
 // -----

--- a/test/Dialect/Function/function_restrictions_pass.llzk
+++ b/test/Dialect/Function/function_restrictions_pass.llzk
@@ -86,7 +86,7 @@ module attributes {veridise.lang = "llzk"} {
       %up = arith.constant 4 : index
       %step = arith.constant 1 : index
       scf.for %iv = %lb to %up step %step {
-        constrain.in %b, %a : !array.type<5 x !felt.type>
+        constrain.in %b, %a : !array.type<5 x !felt.type>, !felt.type
       }
       function.return
     }
@@ -122,7 +122,7 @@ module attributes {veridise.lang = "llzk"} {
       scf.if %a {
         scf.if %b {
           scf.if %c {
-            constrain.in %y, %x : !array.type<5 x index>
+            constrain.in %y, %x : !array.type<5 x index>, index
           }
         }
       }

--- a/test/Dialect/LLZK_and_Builtin/bad_symref_type_param_fail.llzk
+++ b/test/Dialect/LLZK_and_Builtin/bad_symref_type_param_fail.llzk
@@ -564,7 +564,7 @@ module attributes {veridise.lang = "llzk"} {
       %b = felt.const 3
       // See NOTE on line 4.
       // expected-error@+1 {{use of value '%a' expects different type than prior uses: '!array.type<@Unknown x !felt.type>' vs '!array.type<5 x !felt.type>'}}
-      constrain.in %a, %b : !array.type<@Unknown x !felt.type>
+      constrain.in %a, %b : !array.type<@Unknown x !felt.type>, !felt.type
       function.return
     }
 

--- a/test/Dialect/Poly/typevar_pass.llzk
+++ b/test/Dialect/Poly/typevar_pass.llzk
@@ -439,7 +439,7 @@ module attributes {veridise.lang = "llzk"} {
       function.return %self : !struct.type<@ComponentF1<[@C, @T]>>
     }
     function.def @constrain(%self: !struct.type<@ComponentF1<[@C, @T]>>, %a: !poly.tvar<@T>, %b: !array.type<@C x !poly.tvar<@T>>) {
-      constrain.in %b, %a : !array.type<@C x !poly.tvar<@T>>
+      constrain.in %b, %a : !array.type<@C x !poly.tvar<@T>>, !poly.tvar<@T>
       function.return
     }
   }


### PR DESCRIPTION
- `constrain.in` now checks if an M dimension array is contained within an N dimensional array, where N >= 1 and N >= M >= 0 (a "0-dimensional array" in this case is a scalar value).
  - Since `array.insert` supports N == M dimensioned arrays (where this kind of insert completely overwrites the array), it made sense to support `constrain.in` with arrays of equal dimensions---in this case, both arrays would need to be equal entirely.
- `constrain.in` now requires the type of the rhs argument to be specified, since it cannot automatically be derived from the lhs type. 
- Refactored `array.insert` verification to use shared dimension checks.
- Updated docs, added tests