### PR TITLE
minor fix and code quality

### DIFF
--- a/changelogs/unreleased/th__minor_fixes.yaml
+++ b/changelogs/unreleased/th__minor_fixes.yaml
@@ -1,0 +1,5 @@
+added:
+  - NoRegionArguments to StructDefOp
+
+fixed:
+  - use GraphRegionNoTerminator trait list correctly (per usage in LLVM upstream)

--- a/include/llzk/Dialect/Struct/IR/Ops.td
+++ b/include/llzk/Dialect/Struct/IR/Ops.td
@@ -42,8 +42,9 @@ def SetFuncAllowAttrs : NativeOpTrait<"SetFuncAllowAttrs">, StructuralOpTrait {
 def LLZK_StructDefOp
     : StructDialectOp<
           "def", [HasParent<"::mlir::ModuleOp">, Symbol, SymbolTable,
-                  IsolatedFromAbove, GraphRegionNoTerminator, SetFuncAllowAttrs,
-                  DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {
+                  IsolatedFromAbove, SetFuncAllowAttrs,
+                  DeclareOpInterfaceMethods<SymbolUserOpInterface>,
+                  NoRegionArguments]#GraphRegionNoTerminator.traits> {
   let summary = "circuit component definition";
   let description = [{
       This operation describes a component in a circuit. It can contain any number

--- a/include/llzk/Dialect/Struct/IR/Ops.td
+++ b/include/llzk/Dialect/Struct/IR/Ops.td
@@ -28,9 +28,8 @@ include "mlir/IR/SymbolInterfaces.td"
 class StructDialectOp<string mnemonic, list<Trait> traits = []>
     : Op<StructDialect, mnemonic, traits>;
 
-/// Only valid/implemented for StructDefOp. Sets the proper
-/// `AllowConstraintAttr` and `AllowWitnessAttr` on the functions defined within
-/// the StructDefOp.
+/// Only valid/implemented for StructDefOp. Sets the proper `AllowWitnessAttr`
+/// and `AllowConstraintAttr` on the functions defined within the StructDefOp.
 def SetFuncAllowAttrs : NativeOpTrait<"SetFuncAllowAttrs">, StructuralOpTrait {
   string cppNamespace = "::llzk::component";
 }


### PR DESCRIPTION
Adds the restriction on StructDefOp that its regions cannot have arguments. This just closes a possible source of unexpected stuff happening in the IR since such arguments are not expected to be used in LLZK IR.