### PR TITLE
simplify FeltConstAttr::getValue() API

### DIFF
--- a/changelogs/unreleased/th__simplify_FeltConstAttr_getValue.yaml
+++ b/changelogs/unreleased/th__simplify_FeltConstAttr_getValue.yaml
@@ -1,0 +1,2 @@
+changed:
+  - Simplify the implementation of FeltConstAttr::getValue() to directly return the stored APInt without additional calls

--- a/include/llzk/Analysis/ConstrainRef.h
+++ b/include/llzk/Analysis/ConstrainRef.h
@@ -193,7 +193,7 @@ public:
 
   mlir::APInt getConstantFeltValue() const {
     ensure(isConstantFelt(), __FUNCTION__ + mlir::Twine(" requires a constant felt!"));
-    return std::get<felt::FeltConstantOp>(*constantVal).getValueAttr().getValue();
+    return std::get<felt::FeltConstantOp>(*constantVal).getValue();
   }
   mlir::APInt getConstantIndexValue() const {
     ensure(isConstantIndex(), __FUNCTION__ + mlir::Twine(" requires a constant index!"));

--- a/include/llzk/Dialect/Felt/IR/Attrs.td
+++ b/include/llzk/Dialect/Felt/IR/Attrs.td
@@ -26,6 +26,9 @@ def LLZK_FeltConstAttr
 
   let parameters = (ins APIntParameter<"The felt constant value">:$value);
 
+  let returnType = "::llvm::APInt";
+  let convertFromStorage = "$_self.getValue()";
+
   let assemblyFormat = [{ $value }];
 
   let extraClassDeclaration = [{

--- a/lib/Analysis/IntervalAnalysis.cpp
+++ b/lib/Analysis/IntervalAnalysis.cpp
@@ -642,7 +642,7 @@ llvm::APSInt IntervalDataFlowAnalysis::getConst(Operation *op) const {
   llvm::APInt fieldConst =
       TypeSwitch<Operation *, llvm::APInt>(op)
           .Case<FeltConstantOp>([&](FeltConstantOp feltConst) {
-    llvm::APSInt constOpVal(feltConst.getValueAttr().getValue());
+    llvm::APSInt constOpVal(feltConst.getValue());
     return field.get().reduce(constOpVal);
   })
           .Case<arith::ConstantIndexOp>([&](arith::ConstantIndexOp indexConst) {
@@ -992,7 +992,7 @@ IntervalDataFlowAnalysis::getGeneralizedDecompInterval(
       if (failed(handleRefValue())) {
         return failure();
       }
-      auto constInt = APSInt(c.getValueAttr().getValue());
+      auto constInt = APSInt(c.getValue());
       consts.push_back(field.get().reduce(constInt));
       continue;
     } else if (m_RefValue(&signalVal).match(v)) {

--- a/lib/Dialect/Felt/IR/Ops.cpp
+++ b/lib/Dialect/Felt/IR/Ops.cpp
@@ -31,11 +31,11 @@ void FeltConstantOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
   llvm::SmallString<32> buf;
   llvm::raw_svector_ostream os(buf);
   os << "felt_const_";
-  getValue().getValue().toStringUnsigned(buf);
+  getValue().toStringUnsigned(buf);
   setNameFn(getResult(), buf);
 }
 
-OpFoldResult FeltConstantOp::fold(FeltConstantOp::FoldAdaptor) { return getValue(); }
+OpFoldResult FeltConstantOp::fold(FeltConstantOp::FoldAdaptor) { return getValueAttr(); }
 
 //===------------------------------------------------------------------===//
 // FeltNonDetOp

--- a/lib/Transforms/LLZKLoweringUtils.cpp
+++ b/lib/Transforms/LLZKLoweringUtils.cpp
@@ -75,7 +75,7 @@ Value rebuildExprInCompute(
   }
 
   if (auto c = val.getDefiningOp<FeltConstantOp>()) {
-    return memo[val] = builder.create<FeltConstantOp>(c.getLoc(), c.getValue());
+    return memo[val] = builder.create<FeltConstantOp>(c.getLoc(), c.getValueAttr());
   }
 
   llvm::errs() << "Unhandled op in rebuildExprInCompute: " << val << '\n';

--- a/lib/Transforms/LLZKR1CSLoweringPass.cpp
+++ b/lib/Transforms/LLZKR1CSLoweringPass.cpp
@@ -437,7 +437,7 @@ private:
         R1CSConstraint inner = constraintMap[op->getOperand(0)];
         constraintMap[v] = inner.negated();
       } else if (auto cst = dyn_cast<FeltConstantOp>(op)) {
-        R1CSConstraint c(APSInt(cst.getValueAttr().getValue(), false));
+        R1CSConstraint c(APSInt(cst.getValue(), false));
         constraintMap[v] = c;
       } else {
         llvm::errs() << "Unhandled op in R1CS lowering: " << *op << '\n';

--- a/lib/Transforms/LLZKRedundantReadAndWriteEliminationPass.cpp
+++ b/lib/Transforms/LLZKRedundantReadAndWriteEliminationPass.cpp
@@ -56,7 +56,7 @@ public:
         v.getImpl() == reinterpret_cast<mlir::detail::ValueImpl *>(2)) {
       identifier = v;
     } else if (auto constVal = dyn_cast_if_present<FeltConstantOp>(v.getDefiningOp())) {
-      identifier = constVal.getValue().getValue();
+      identifier = constVal.getValue();
     } else if (auto constIdxVal = dyn_cast_if_present<arith::ConstantIndexOp>(v.getDefiningOp())) {
       identifier = llvm::cast<IntegerAttr>(constIdxVal.getValue()).getValue();
     } else {


### PR DESCRIPTION
Gets rid of the annoying `.getValue().getValue()` or `.getValueAttr().getValue()` by directly returning the APInt value.