### PR TITLE
elaborate documentation for ArrayType and StructType parameters

### DIFF
--- a/changelogs/unreleased/th__docs_20250929.yaml
+++ b/changelogs/unreleased/th__docs_20250929.yaml
@@ -1,0 +1,2 @@
+added:
+  - elaborate documentation for ArrayType and StructType parameters

--- a/include/llzk/Dialect/Array/IR/Types.td
+++ b/include/llzk/Dialect/Array/IR/Types.td
@@ -28,10 +28,18 @@ def LLZK_ArrayType
   let summary = "n-dimensional array";
   let description = [{
     Array type with a ranked shape and homogeneous element type.
-    It can only be instantiated with the following types:
+    It can only be instantiated with the following element types:
       - Any LLZK type
       - IndexType
       - Unsigned integers of 1 bit (aka booleans)
+
+    The dimensions of the array are specified using a list of attributes, one
+    per dimension. Each attribute must be one of the following:
+      - IntegerAttr (with IndexType), specifying a fixed dimension size
+      - SymbolRefAttr, specifying a dimension size defined by a struct parameter or
+        global constant
+      - AffineMapAttr, specifying a dimension size computed from surrounding loop
+        induction variables
 
     ```llzk
     // Example array of 5 by 2 elements of `Felt` type.

--- a/include/llzk/Dialect/Struct/IR/Types.td
+++ b/include/llzk/Dialect/Struct/IR/Types.td
@@ -26,7 +26,28 @@ class StructDialectType<string name, string typeMnemonic,
 
 def LLZK_StructType : StructDialectType<"Struct", "type"> {
   let summary = "circuit component";
-  let description = [{}];
+  let description = [{
+    Type of a `struct` op instance. For structs that contain template parameters,
+    the type must contain a list of attributes that instantiate the template
+    parameters, one per parameter. Each attribute must be one of the following:
+      - IntegerAttr (with IndexType), specifying a fixed parameter value
+      - SymbolRefAttr, specifying a parameter value defined by a struct parameter
+        or global constant
+      - AffineMapAttr, for an array of struct elements whose template parameters
+        vary based on some fixed pattern.
+      - TypeAttr, for specifying a type parameter.
+
+    ```llzk
+    // Type for struct `A` with no parameters.
+    !struct.type<@A>
+
+    // Type for struct `B` with IntegerAttr and SymbolRefAttr parameters.
+    !struct.type<@B<[5, @C]>>
+
+    // Type for struct `C` with TypeAttr and IntegerAttr parameters.
+    !struct.type<@C<[!felt.type, 24]>>
+    ```
+  }];
 
   let parameters =
       (ins TypeParameter<


### PR DESCRIPTION
The major point I wanted to make is that `IntegerAttr` parameters have `IndexType` and thus must be representable in the bitwidth of `IndexType`. Additional checks are forthcoming in https://github.com/Veridise/llzk-lib/pull/176.