### PR TITLE
[LLZK-315] Address CAPI change from LLVM 18 -> LLVM 20 for `OpBuilder` callbacks

### DIFF
--- a/changelogs/unreleased/iangneal__LLZK-315-Address-CAPI-change-from-LLVM-20.yaml
+++ b/changelogs/unreleased/iangneal__LLZK-315-Address-CAPI-change-from-LLVM-20.yaml
@@ -1,0 +1,2 @@
+changed:
+  - Enable CAPI callbacks from LLVM 20 upgrade

--- a/include/llzk-c/Builder.h
+++ b/include/llzk-c/Builder.h
@@ -33,9 +33,6 @@ DEFINE_C_API_STRUCT(MlirOpBuilderListener, void);
 
 #undef DEFINE_C_API_STRUCT
 
-// Commented out because they are not used for the callbacks in MLIR 18
-// but are used for MLIR 20+, which we plan to move on in the near future.
-#if 0
 struct MlirOpInsertionPoint {
   MlirBlock block;
   MlirOperation point;
@@ -47,7 +44,6 @@ struct MlirBlockInsertionPoint {
   MlirBlock point;
 };
 typedef struct MlirBlockInsertionPoint MlirBlockInsertionPoint;
-#endif
 
 typedef void (*MlirNotifyOperationInserted)(MlirOperation, void *);
 typedef void (*MlirNotifyBlockInserted)(MlirBlock, void *);

--- a/include/llzk-c/Builder.h
+++ b/include/llzk-c/Builder.h
@@ -33,20 +33,14 @@ DEFINE_C_API_STRUCT(MlirOpBuilderListener, void);
 
 #undef DEFINE_C_API_STRUCT
 
-struct MlirOpInsertionPoint {
+struct MlirOpBuilderInsertPoint {
   MlirBlock block;
   MlirOperation point;
 };
-typedef struct MlirOpInsertionPoint MlirOpInsertionPoint;
+typedef struct MlirOpBuilderInsertPoint MlirOpBuilderInsertPoint;
 
-struct MlirBlockInsertionPoint {
-  MlirRegion region;
-  MlirBlock point;
-};
-typedef struct MlirBlockInsertionPoint MlirBlockInsertionPoint;
-
-typedef void (*MlirNotifyOperationInserted)(MlirOperation, void *);
-typedef void (*MlirNotifyBlockInserted)(MlirBlock, void *);
+typedef void (*MlirNotifyOperationInserted)(MlirOperation, MlirOpBuilderInsertPoint, void *);
+typedef void (*MlirNotifyBlockInserted)(MlirBlock, MlirRegion, MlirBlock, void *);
 
 //===----------------------------------------------------------------------===//
 // MlirOpBuilder

--- a/lib/CAPI/Builder.cpp
+++ b/lib/CAPI/Builder.cpp
@@ -28,13 +28,15 @@ public:
   ListenerT(MlirNotifyOperationInserted op, MlirNotifyBlockInserted block, void *data)
       : opInsertedCb(op), blockInsertedCb(block), userData(data) {}
 
-  void notifyOperationInserted(Operation *op, OpBuilder::InsertPoint /*previous*/) final {
-    opInsertedCb(wrap(op), userData);
+  void notifyOperationInserted(Operation *op, OpBuilder::InsertPoint previous) final {
+    MlirOpBuilderInsertPoint i {
+        .block = wrap(previous.getBlock()), .point = wrap(&*previous.getPoint())
+    };
+    opInsertedCb(wrap(op), i, userData);
   }
 
-  void
-  notifyBlockInserted(Block *block, Region * /*previous*/, Region::iterator /*previousIt*/) final {
-    blockInsertedCb(wrap(block), userData);
+  void notifyBlockInserted(Block *block, Region *previous, Region::iterator previousIt) final {
+    blockInsertedCb(wrap(block), wrap(previous), wrap(&*previousIt), userData);
   }
 
 private:

--- a/unittests/CAPI/Builder.cpp
+++ b/unittests/CAPI/Builder.cpp
@@ -15,8 +15,8 @@ TEST_F(CAPITest, MlirOpBuilderCreate) {
   auto builder = mlirOpBuilderCreate(context);
   mlirOpBuilderDestroy(builder);
 }
-static void test_cb1(MlirOperation, void *) {}
-static void test_cb2(MlirBlock, void *) {}
+static void test_cb1(MlirOperation, MlirOpBuilderInsertPoint, void *) {}
+static void test_cb2(MlirBlock, MlirRegion, MlirBlock, void *) {}
 
 TEST_F(CAPITest, MlirOpBuilderCreateWithListener) {
   auto listener = mlirOpBuilderListenerCreate(test_cb1, test_cb2, NULL);


### PR DESCRIPTION
CAPI has been updated in accordance with updated `OpBuilder::Listener` API. See https://github.com/llvm/llvm-project/blob/87f0227cb60147a26a1eeb4fb06e3b505e9c7261/mlir/include/mlir/IR/Builders.h#L283-L311 for the original definition.

@0xddom: I would particularly like your eyes on this since the documentation on the CAPI stuff from the MLIR side...leaves something to be desired.