### PR TITLE
Fix array dialect op doc generation

### DIFF
--- a/changelogs/unreleased/iangneal__LLZK-369-array-dialect-ops-docs.yaml
+++ b/changelogs/unreleased/iangneal__LLZK-369-array-dialect-ops-docs.yaml
@@ -1,0 +1,2 @@
+fixed:
+  - Fixed documentation for array dialect ops

--- a/include/llzk/Dialect/Array/IR/CMakeLists.txt
+++ b/include/llzk/Dialect/Array/IR/CMakeLists.txt
@@ -8,13 +8,13 @@ set(LLVM_TARGET_DEFINITIONS "Types.td")
 mlir_tablegen(Types.h.inc -gen-typedef-decls -typedefs-dialect=array)
 mlir_tablegen(Types.cpp.inc -gen-typedef-defs -typedefs-dialect=array)
 
-set(LLVM_TARGET_DEFINITIONS "Ops.td")
-mlir_tablegen(Ops.h.inc -gen-op-decls -dialect=array)
-mlir_tablegen(Ops.cpp.inc -gen-op-defs -dialect=array)
-
 set(LLVM_TARGET_DEFINITIONS "OpInterfaces.td")
 mlir_tablegen(OpInterfaces.h.inc --gen-op-interface-decls)
 mlir_tablegen(OpInterfaces.cpp.inc --gen-op-interface-defs)
+
+set(LLVM_TARGET_DEFINITIONS "Ops.td")
+mlir_tablegen(Ops.h.inc -gen-op-decls -dialect=array)
+mlir_tablegen(Ops.cpp.inc -gen-op-defs -dialect=array)
 
 llzk_add_mlir_doc(ArrayOpsDocGen dialect/ArrayDialect.md -gen-dialect-doc -dialect=array)
 


### PR DESCRIPTION
Reordering the ops doc generation allows the op documentation to be emitted into doxygen.