### PR TITLE
fix bug in `llzkFieldReadOpBuildWithLiteralDistance`

### DIFF
--- a/changelogs/unreleased/th__fix_capi_bug_FieldReadOp.yaml
+++ b/changelogs/unreleased/th__fix_capi_bug_FieldReadOp.yaml
@@ -1,0 +1,2 @@
+fixed:
+  - llzkFieldReadOpBuildWithLiteralDistance() would always fail verify because of wrong type produced

--- a/lib/CAPI/Dialect/Struct.cpp
+++ b/lib/CAPI/Dialect/Struct.cpp
@@ -206,7 +206,7 @@ LLZK_DEFINE_SUFFIX_OP_BUILD_METHOD(
   return wrap(
       create<FieldReadOp>(
           builder, location, unwrap(fieldType), unwrap(component), nameAttr,
-          unwrap(builder)->getI64IntegerAttr(distance)
+          unwrap(builder)->getIndexAttr(distance)
       )
   );
 }


### PR DESCRIPTION
produced the wrong type of attribute so verify would always fail