### PR TITLE
Remove `felt.bitnot` in favor of older `felt.bit_not`

### DIFF
--- a/changelogs/unreleased/iangneal__remove-redundant-op.yaml
+++ b/changelogs/unreleased/iangneal__remove-redundant-op.yaml
@@ -1,0 +1,2 @@
+removed:
+  - The `felt.bitnot` op was removed because `felt.bit_not` already existed

--- a/include/llzk/Analysis/IntervalAnalysis.h
+++ b/include/llzk/Analysis/IntervalAnalysis.h
@@ -330,9 +330,9 @@ private:
     return llvm::isa<
         felt::AddFeltOp, felt::SubFeltOp, felt::MulFeltOp, felt::DivFeltOp, felt::UnsignedModFeltOp,
         felt::SignedModFeltOp, felt::SignedIntDivFeltOp, felt::UnsignedIntDivFeltOp,
-        felt::NegFeltOp, felt::InvFeltOp, felt::ComplementFeltOp, felt::AndFeltOp, felt::OrFeltOp,
-        felt::XorFeltOp, felt::NotFeltOp, felt::ShlFeltOp, felt::ShrFeltOp, boolean::CmpOp,
-        boolean::AndBoolOp, boolean::OrBoolOp, boolean::XorBoolOp, boolean::NotBoolOp>(op);
+        felt::NegFeltOp, felt::InvFeltOp, felt::AndFeltOp, felt::OrFeltOp, felt::XorFeltOp,
+        felt::NotFeltOp, felt::ShlFeltOp, felt::ShrFeltOp, boolean::CmpOp, boolean::AndBoolOp,
+        boolean::OrBoolOp, boolean::XorBoolOp, boolean::NotBoolOp>(op);
   }
 
   ExpressionValue

--- a/include/llzk/Dialect/Felt/IR/Ops.td
+++ b/include/llzk/Dialect/Felt/IR/Ops.td
@@ -176,16 +176,6 @@ def LLZK_InvFeltOp : FeltDialectUnaryOp<"inv", LLZK_FeltType, [WitnessGen]> {
   let description = [{}];
 }
 
-def LLZK_ComplementFeltOp
-    : FeltDialectUnaryOp<"bitnot", LLZK_FeltType, [WitnessGen]> {
-  let summary = "integer complement (bitwise-not) operator for field elements";
-  let description = [{
-    Treats the operand as an integer with a bitwidth equal to the bitwidth
-    of the prime field's modulus and compute the one's complement of the integer.
-    The result is converted back to a field element by applying the prime modulus.
-  }];
-}
-
 def LLZK_AndFeltOp
     : FeltDialectBinaryOp<"bit_and", LLZK_FeltType, [WitnessGen, Commutative]> {
   let summary = "bitwise AND operator for field elements";
@@ -206,8 +196,12 @@ def LLZK_XorFeltOp
 
 def LLZK_NotFeltOp
     : FeltDialectUnaryOp<"bit_not", LLZK_FeltType, [WitnessGen]> {
-  let summary = "bit flip operator for field elements";
-  let description = [{}];
+  let summary = "integer complement (bitwise-not) operator for field elements";
+  let description = [{
+    Treats the operand as an integer with a bitwidth equal to the bitwidth
+    of the prime field's modulus and compute the one's complement of the integer.
+    The result is converted back to a field element by applying the prime modulus.
+  }];
 }
 
 def LLZK_ShlFeltOp : FeltDialectBinaryOp<"shl", LLZK_FeltType, [WitnessGen]> {

--- a/test/Dialect/Felt/felt_arith_pass.llzk
+++ b/test/Dialect/Felt/felt_arith_pass.llzk
@@ -133,17 +133,6 @@ function.def @f_inv(%a: !felt.type) -> !felt.type attributes {function.allow_wit
 //CHECK-NEXT:   }
 // -----
 
-function.def @f_bitnot(%a: !felt.type) -> !felt.type attributes {function.allow_witness} {
-  %c = felt.bitnot %a
-  function.return %c: !felt.type
-}
-//CHECK-LABEL:  function.def @f_bitnot
-//CHECK-SAME:   (%[[A0:[0-9a-zA-Z_\.]+]]: !felt.type) -> !felt.type attributes {function.allow_witness} {
-//CHECK-NEXT:     %[[T1:[0-9a-zA-Z_\.]+]] = felt.bitnot %[[A0]]
-//CHECK-NEXT:     function.return %[[T1]] : !felt.type
-//CHECK-NEXT:   }
-// -----
-
 function.def @f_bit_and(%a: !felt.type, %b: !felt.type) -> !felt.type attributes {function.allow_witness} {
   %c = felt.bit_and %a, %b
   function.return %c: !felt.type


### PR DESCRIPTION
Accidentally added a redundant op in #282.