### PR TITLE
upgrade actions/checkout to v6

### DIFF
--- a/.github/workflows/bump-llzk-rs.yml
+++ b/.github/workflows/bump-llzk-rs.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Check out llzk-rs main
         if: steps.existing-pr.outputs.pr_number == ''
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: project-llzk/llzk-rs
           token: ${{ steps.app-token.outputs.token }}
@@ -61,7 +61,7 @@ jobs:
 
       - name: Check out existing PR branch
         if: steps.existing-pr.outputs.pr_number != ''
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: project-llzk/llzk-rs
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/ci-build-docs.yml
+++ b/.github/workflows/ci-build-docs.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
       # v37.1.0

--- a/.github/workflows/ci-check-nix.yml
+++ b/.github/workflows/ci-check-nix.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
       # v37.1.0

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
       # v37.1.0

--- a/.github/workflows/clang-format.yaml
+++ b/.github/workflows/clang-format.yaml
@@ -15,7 +15,7 @@ jobs:
         run: |
           echo "PR_COMMIT_COUNT=${{ github.event.pull_request.commits }}" >> "${GITHUB_ENV}"
           echo "PR_FETCH_DEPTH=$(( ${{ github.event.pull_request.commits }} + 1 ))" >> "${GITHUB_ENV}"
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # Checkout head commit and all commits in the PR, including the merge base.
           # Use head.repo.full_name and head.sha so this works for PRs from upstream and forks.

--- a/.github/workflows/deploy-github-pages.yml
+++ b/.github/workflows/deploy-github-pages.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
 
       - name: Checkout github pages branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           persist-credentials: true
           path: gh-pages

--- a/.github/workflows/update-docs-on-main.yml
+++ b/.github/workflows/update-docs-on-main.yml
@@ -12,7 +12,7 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-tags: true
           persist-credentials: false

--- a/flake.lock
+++ b/flake.lock
@@ -22,11 +22,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1765385817,
-        "narHash": "sha256-eqfdZp/VGnC1HVBmujpTwI76nSrQhfnwpXacmR+g02s=",
+        "lastModified": 1775793233,
+        "narHash": "sha256-MDo3X2dV2Mc+tG9ve476E0WIUlxOaFs97GZrT3heiKw=",
         "owner": "project-llzk",
         "repo": "llzk-nix-pkgs",
-        "rev": "e78d7afcba4898b37a7629fb7f8b097f136103b7",
+        "rev": "0002f52bf1b3bbe810c2b55184b64b8e3bdc865b",
         "type": "github"
       },
       "original": {
@@ -69,11 +69,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1762369885,
-        "narHash": "sha256-j7aARWOa10cranctQ39cfEELMlEAeZsRrJIGKPJ5o88=",
+        "lastModified": 1762544039,
+        "narHash": "sha256-Esd4SAzUt5G3esTa6fTmivKpRScEROwSME4nN/SAU4w=",
         "owner": "Veridise",
         "repo": "pcl-mlir",
-        "rev": "a82620c4dabf6e51ceda66bba2abb19f7f74ac7d",
+        "rev": "55cf619b032314198aacafc305871fb66b12b70e",
         "type": "github"
       },
       "original": {
@@ -94,11 +94,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747068965,
-        "narHash": "sha256-px7s7IVHnR3SiShc7FKCUiL6vfqew5AM6jnkH7qO03I=",
+        "lastModified": 1775793201,
+        "narHash": "sha256-q129kMo7c75Fgb+lMDOiYkkggoze0Z/6x7cV5uekVKg=",
         "owner": "project-llzk",
         "repo": "open-source-release-helpers",
-        "rev": "c3d1ab6082cc62b167927d074f2836f290b9e3b7",
+        "rev": "aeec44f1169dd1cedc37df750556177a937c4445",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Due to deprecation of Node 20
see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/