### PR TITLE
Fix -Wshadow error on SymbolUserHelper::benefit parameter

### DIFF
--- a/lib/Dialect/Polymorphic/Transforms/FlatteningPass.cpp
+++ b/lib/Dialect/Polymorphic/Transforms/FlatteningPass.cpp
@@ -219,10 +219,10 @@ private:
   const DenseMap<Attribute, Attribute> &paramNameToValue;
 
   SymbolUserHelper(
-      TypeConverter &converter, MLIRContext *ctx, unsigned benefit,
+      TypeConverter &converter, MLIRContext *ctx, unsigned patternBenefit,
       const DenseMap<Attribute, Attribute> &paramNameToInstantiatedValue
   )
-      : OpConversionPattern<Op>(converter, ctx, benefit),
+      : OpConversionPattern<Op>(converter, ctx, patternBenefit),
         paramNameToValue(paramNameToInstantiatedValue) {}
 
 public:
@@ -274,7 +274,7 @@ public:
       SmallVector<Diagnostic> &instantiationDiagnostics
   )
       // benefit>0 so this applies instead of GeneralTypeReplacePattern<ConstReadOp>
-      : super(converter, ctx, /*benefit=*/1, paramNameToInstantiatedValue),
+      : super(converter, ctx, /*patternBenefit=*/1, paramNameToInstantiatedValue),
         diagnostics(instantiationDiagnostics) {}
 
   Attribute getNameAttr(ConstReadOp op) const override { return op.getConstNameAttr(); }
@@ -553,7 +553,7 @@ class StructCloner {
         const DenseMap<Attribute, Attribute> &paramNameToInstantiatedValue
     )
         // benefit>0 so this applies instead of GeneralTypeReplacePattern<MemberReadOp>
-        : super(converter, ctx, /*benefit=*/1, paramNameToInstantiatedValue) {}
+        : super(converter, ctx, /*patternBenefit=*/1, paramNameToInstantiatedValue) {}
 
     Attribute getNameAttr(MemberReadOp op) const override {
       return op.getTableOffset().value_or(nullptr);


### PR DESCRIPTION
The `SymbolUserHelper` constructor parameter `benefit` (introduced in #378)
shadows the inherited `mlir::Pattern::benefit` member. GCC's `-Wshadow` fires
on this when MLIR headers are included via `-I` (non-system) rather than
`-isystem`, breaking downstream builds that consume LLZK as a library.

Rename the parameter to `patternBenefit` to avoid the collision. Updates the
two `/*benefit=*/` argument comments at `super(...)` call sites for
consistency; leaves the two direct calls to `OpConversionPattern<...>(...)`
untouched since MLIR's own parameter is named `benefit`.

No behavior change.
