### PR TITLE
fix: allow dead value removal to be used on `poly.expr`

### DIFF
--- a/changelogs/unreleased/th__dead_value_cleanup_pass.yaml
+++ b/changelogs/unreleased/th__dead_value_cleanup_pass.yaml
@@ -1,0 +1,2 @@
+removed:
+  - "`Pure` trait from `poly.expr` operation (allows dead value removal to be used on `poly.expr`)"

--- a/include/llzk/Dialect/Polymorphic/IR/Ops.td
+++ b/include/llzk/Dialect/Polymorphic/IR/Ops.td
@@ -209,7 +209,7 @@ def LLZK_TemplateExprOp
 
 def LLZK_YieldOp
     : PolymorphicDialectOp<
-          "yield", [HasParent<"::llzk::polymorphic::TemplateExprOp">, Pure,
+          "yield", [HasParent<"::llzk::polymorphic::TemplateExprOp">,
                     ReturnLike, Terminator]> {
   let summary = "expr initialization yield and termination operation";
   let description = [{

--- a/unittests/CAPI/Transforms.cpp
+++ b/unittests/CAPI/Transforms.cpp
@@ -11,6 +11,12 @@
 
 #include "CAPITestBase.h"
 
+#include "llzk/Dialect/Felt/IR/Ops.h"
+#include "llzk/Dialect/Polymorphic/IR/Ops.h"
+
+using namespace mlir;
+using namespace llzk;
+
 TEST_F(CAPITest, RegisterTransformationPassesAndCreate) {
   mlirRegisterLLZKTransformationPasses();
   auto manager = mlirPassManagerCreate(context);
@@ -53,4 +59,83 @@ TEST_F(CAPITest, RegisterUnuusedDeclarationEliminationPassAndCreate) {
   mlirPassManagerAddOwnedPass(manager, pass);
 
   mlirPassManagerDestroy(manager);
+}
+
+static polymorphic::TemplateExprOp buildPolyExpr(MLIRContext *ctx, bool includeDeadValue = false) {
+  auto loc = UnknownLoc::get(ctx);
+
+  OpBuilder bldr(ctx);
+  auto expr = bldr.create<polymorphic::TemplateExprOp>(loc, bldr.getStringAttr("Sub_12@269"));
+  bldr.setInsertionPointToStart(&expr.getInitializerRegion().emplaceBlock());
+
+  auto feltTy = felt::FeltType::get(ctx, bldr.getStringAttr("bn128"));
+  auto const12 = felt::FeltConstAttr::get(ctx, APInt(64, 12), feltTy);
+  if (includeDeadValue) {
+    // Create a dead value that should be eliminated by the DVE pass.
+    auto _ = bldr.create<felt::FeltConstantOp>(loc, const12);
+  }
+  auto constOp = bldr.create<felt::FeltConstantOp>(loc, const12);
+  auto negOp = bldr.create<felt::NegFeltOp>(loc, constOp.getResult());
+  bldr.create<polymorphic::YieldOp>(loc, negOp.getResult());
+
+  return expr;
+}
+
+static std::string toString(auto op) {
+  std::string buffer;
+  llvm::raw_string_ostream os(buffer);
+  op.print(os, OpPrintingFlags().assumeVerified().printGenericOpForm(false));
+  return buffer;
+}
+
+static void printToStderr(MlirStringRef str, void *userData) {
+  (void)userData;
+  fwrite(str.data, 1, str.length, stderr);
+}
+
+/// Setup pass manager and run dead value elimination. Replicate how it's done in the circom
+/// frontend via `llzk-rs`.
+///
+/// Returns true on success.
+static bool runRemoveDeadValues(MlirContext context, MlirOperation op) {
+  MlirPassManager pm = mlirPassManagerCreate(context); // PassManager::new()
+  mlirRegisterAllPasses();                             // utility::register_all_passes()
+  mlirPassManagerEnableVerifier(pm, false);            // enable_verifier(false)
+  auto opm = mlirPassManagerGetAsOpPassManager(pm);    // as_operation_pass_manager()
+  auto pipeline = mlirStringRefCreateFromCString("poly.expr(remove-dead-values)");
+  mlirParsePassPipeline(opm, pipeline, printToStderr, NULL); // utility::parse_pass_pipeline()
+  bool success = mlirPassManagerRunOnOp(pm, op).value != 0;
+  mlirPassManagerDestroy(pm);
+  return success;
+}
+
+TEST_F(CAPITest, PolyExprDeadValueEliminationNoChange) {
+  auto exprOp = buildPolyExpr(unwrap(context));
+  std::string before = toString(exprOp);
+
+  ASSERT_TRUE(runRemoveDeadValues(context, wrap(exprOp))) << "failed to run pass pipeline";
+
+  // There were no dead values to eliminate, so the IR should be unchanged.
+  ASSERT_EQ(before, toString(exprOp));
+
+  // Cleanup
+  mlirOperationDestroy(wrap(exprOp));
+}
+
+TEST_F(CAPITest, PolyExprDeadValueEliminationWithChange) {
+  auto exprOp = buildPolyExpr(unwrap(context), true);
+  std::string before = toString(exprOp);
+
+  // Setup pass manager and run dead value elimination.
+  // Replicate how it's done in the circom frontend via `llzk-rs`
+  ASSERT_TRUE(runRemoveDeadValues(context, wrap(exprOp))) << "failed to run pass pipeline";
+
+  // The dead value should have been eliminated.
+  std::string after = toString(exprOp);
+  ASSERT_NE(before, after);
+  // It's the same as if built without the dead value in the first place.
+  ASSERT_EQ(after, toString(buildPolyExpr(unwrap(context))));
+
+  // Cleanup
+  mlirOperationDestroy(wrap(exprOp));
 }


### PR DESCRIPTION
Removes the `Pure` trait from `poly.yield` op so the `remove-dead-values` pass can be used on `poly.expr` ops. With the `Pure` trait, `poly.yield` was not seen as a value sink for the liveness analysis which results in everything being removed expect the `poly.yield` itself (for some reason) which resulted in an invalid Value ref for its operand.