### PR TITLE
Enable further simplification of `poly.expr` body

### DIFF
--- a/changelogs/unreleased/th__opt_readconst_nondet.yaml
+++ b/changelogs/unreleased/th__opt_readconst_nondet.yaml
@@ -2,3 +2,6 @@ added:
   - "`Pure` trait on `poly.read_const` op"
   - "`AlwaysSpeculatable` trait on `llzk.nondet` op"
   - "canonicalizer for `llzk.nondet` op to remove it when its result is not used"
+
+fixed:
+  - "assertion failure in `remove-dead-values` pass when there are empty `else` regions"

--- a/changelogs/unreleased/th__opt_readconst_nondet.yaml
+++ b/changelogs/unreleased/th__opt_readconst_nondet.yaml
@@ -1,0 +1,4 @@
+added:
+  - "`Pure` trait on `poly.read_const` op"
+  - "`AlwaysSpeculatable` trait on `llzk.nondet` op"
+  - "canonicalizer for `llzk.nondet` op to remove it when its result is not used"

--- a/include/llzk/Dialect/LLZK/IR/Ops.td
+++ b/include/llzk/Dialect/LLZK/IR/Ops.td
@@ -46,9 +46,11 @@ def LLZK_NonDetOp
     %0 = llzk.nondet : !felt.type
     ```
 
-    Note that `llzk.nondet` is not `ConstantLike` or `Pure` because different SSA
-    variables initialized with `llzk.nondet` may be constrained in different ways
-    so they cannot be treated as identical values.
+    Note that `llzk.nondet` does not have the `ConstantLike` or `NoMemoryEffect`
+    traits because different SSA variables initialized with `llzk.nondet` may be
+    constrained in different ways so they cannot be treated as identical values.
+    However, it does have the `AlwaysSpeculatable` trait to denote that it is
+    free to move, hoist, and sick without changing the semantics.
 
     Example:
 

--- a/include/llzk/Dialect/LLZK/IR/Ops.td
+++ b/include/llzk/Dialect/LLZK/IR/Ops.td
@@ -26,8 +26,9 @@ class LLZKDialectOp<string mnemonic, list<Trait> traits = []>
     : Op<LLZKDialect, mnemonic, traits>;
 
 def LLZK_NonDetOp
-    : LLZKDialectOp<"nondet", [DeclareOpInterfaceMethods<
-                                  OpAsmOpInterface, ["getAsmResultNames"]>]> {
+    : LLZKDialectOp<"nondet", [AlwaysSpeculatable,
+                               DeclareOpInterfaceMethods<
+                                   OpAsmOpInterface, ["getAsmResultNames"]>]> {
   let summary = "uninitialized variable";
   let description = [{
     This operation produces an SSA variable of the specified type but with
@@ -80,6 +81,7 @@ def LLZK_NonDetOp
 
   let results = (outs AnyLLZKType:$res);
   let assemblyFormat = [{ `:` type($res) attr-dict }];
+  let hasCanonicalizer = 1;
 }
 
 #endif // LLZK_OPS

--- a/include/llzk/Dialect/Polymorphic/IR/Ops.td
+++ b/include/llzk/Dialect/Polymorphic/IR/Ops.td
@@ -223,8 +223,8 @@ def LLZK_YieldOp
 }
 
 def LLZK_ConstReadOp
-    : PolymorphicDialectOp<
-          "read_const", [DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {
+    : PolymorphicDialectOp<"read_const", [Pure, DeclareOpInterfaceMethods<
+                                                    SymbolUserOpInterface>]> {
   let summary = "read value of a struct parameter";
   let description = [{
     This operation reads the value from the named constant parameter of

--- a/lib/Dialect/LLZK/IR/Ops.cpp
+++ b/lib/Dialect/LLZK/IR/Ops.cpp
@@ -11,6 +11,8 @@
 
 #include "llzk/Util/TypeHelper.h"
 
+#include <mlir/IR/PatternMatch.h>
+
 // TableGen'd implementation files
 #define GET_OP_CLASSES
 #include "llzk/Dialect/LLZK/IR/Ops.cpp.inc"
@@ -19,12 +21,32 @@ using namespace mlir;
 
 namespace llzk {
 
+namespace {
+
+struct RemoveUnusedNonDetPattern : public OpRewritePattern<NonDetOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(NonDetOp op, PatternRewriter &rewriter) const override {
+    if (!op.getResult().use_empty()) {
+      return failure();
+    }
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+} // namespace
+
 //===------------------------------------------------------------------===//
 // NonDetOp
 //===------------------------------------------------------------------===//
 
 void NonDetOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
   setNameFn(getResult(), "nondet");
+}
+
+void NonDetOp::getCanonicalizationPatterns(RewritePatternSet &results, MLIRContext *context) {
+  results.add<RemoveUnusedNonDetPattern>(context);
 }
 
 } // namespace llzk

--- a/test/Dialect/LLZK_and_Builtin/nondet_preservation.llzk
+++ b/test/Dialect/LLZK_and_Builtin/nondet_preservation.llzk
@@ -1,5 +1,7 @@
 // RUN: llzk-opt -split-input-file --pass-pipeline='builtin.module(cse, canonicalize)' -verify-diagnostics %s | FileCheck --enable-var-scope %s
 
+// Ensures that `cse` and `canonicalize` passes do not combine multiple `llzk.nondet` operations because
+// adding a constraint to a nondet value makes it non-interchangeable with other nondet values.
 module attributes {llzk.lang} {
   struct.def @A {
     function.def @compute() -> !struct.type<@A> attributes {function.allow_witness} {
@@ -17,20 +19,19 @@ module attributes {llzk.lang} {
     }
   }
 }
-
 // CHECK-LABEL: module attributes {llzk.lang} {
 // CHECK-NEXT:    struct.def @A {
 // CHECK-NEXT:      function.def @compute() -> !struct.type<@A> attributes {function.allow_witness} {
-// CHECK-NEXT:        %self = struct.new : <@A>
-// CHECK-NEXT:        function.return %self : !struct.type<@A>
+// CHECK-NEXT:        %[[VAL_0:[0-9a-zA-Z_\.]+]] = struct.new : <@A>
+// CHECK-NEXT:        function.return %[[VAL_0]] : !struct.type<@A>
 // CHECK-NEXT:      }
-// CHECK-NEXT:      function.def @constrain(%arg0: !struct.type<@A>) attributes {function.allow_constraint} {
-// CHECK-NEXT:        %felt_const_9 = felt.const  9
-// CHECK-NEXT:        %felt_const_7 = felt.const  7
-// CHECK-NEXT:        %nondet = llzk.nondet : !felt.type
-// CHECK-NEXT:        %nondet_0 = llzk.nondet : !felt.type
-// CHECK-NEXT:        constrain.eq %nondet, %felt_const_7 : !felt.type, !felt.type
-// CHECK-NEXT:        constrain.eq %nondet_0, %felt_const_9 : !felt.type, !felt.type
+// CHECK-NEXT:      function.def @constrain(%[[VAL_1:[0-9a-zA-Z_\.]+]]: !struct.type<@A>) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = felt.const  9
+// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = felt.const  7
+// CHECK-NEXT:        %[[VAL_4:[0-9a-zA-Z_\.]+]] = llzk.nondet : !felt.type
+// CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = llzk.nondet : !felt.type
+// CHECK-NEXT:        constrain.eq %[[VAL_4]], %[[VAL_3]] : !felt.type, !felt.type
+// CHECK-NEXT:        constrain.eq %[[VAL_5]], %[[VAL_2]] : !felt.type, !felt.type
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }

--- a/test/FrontendLang/Circom/poly_expr_cleanup_1.llzk
+++ b/test/FrontendLang/Circom/poly_expr_cleanup_1.llzk
@@ -1,0 +1,173 @@
+// RUN: llzk-opt -split-input-file --pass-pipeline='any(canonicalize,sccp,canonicalize,remove-dead-values,canonicalize)' %s 2>&1 | FileCheck --enable-var-scope %s
+
+module attributes {llzk.lang = "circom"} {
+  poly.template @T {
+    poly.expr @"a[1]@307" {
+      %felt_const_1 = felt.const  1 : <"bn128">
+      %felt_const_675 = felt.const  675 : <"bn128">
+      %felt_const_123 = felt.const  123 : <"bn128">
+      %nondet = llzk.nondet : !array.type<2 x !felt.type<"bn128">>
+      %array = array.new %felt_const_123, %felt_const_675 : <2 x !felt.type<"bn128">>
+      %0 = cast.toindex %felt_const_1 : !felt.type<"bn128">
+      %1 = array.read %array[%0] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+      poly.yield %1 : !felt.type<"bn128">
+    }
+  }
+}
+// CHECK-LABEL: module attributes {llzk.lang = "circom"} {
+// CHECK-NEXT:    poly.template @T {
+// CHECK-NEXT:      poly.expr @"a[1]@307" {
+// CHECK-NEXT:        %[[VAL_0:[0-9a-zA-Z_\.]+]] = felt.const  123 : <"bn128">
+// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = felt.const  675 : <"bn128">
+// CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:        %[[VAL_4:[0-9a-zA-Z_\.]+]] = array.new %[[VAL_0]], %[[VAL_1]] : <2 x !felt.type<"bn128">>
+// CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_2]] : !felt.type<"bn128">
+// CHECK-NEXT:        %[[VAL_6:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_4]]{{\[}}%[[VAL_5]]] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:        poly.yield %[[VAL_6]] : !felt.type<"bn128">
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }
+// -----
+
+module attributes {llzk.lang = "circom"} {
+  poly.template @T {
+    poly.param @N
+    poly.expr @"N_Greater_12?a[0]_Add_a[1]:0@411" {
+      %felt_const_1 = felt.const  1 : <"bn128">
+      %felt_const_6 = felt.const  6 : <"bn128">
+      %felt_const_675 = felt.const  675 : <"bn128">
+      %felt_const_123 = felt.const  123 : <"bn128">
+      %felt_const_0 = felt.const  0 : <"bn128">
+      %felt_const_12 = felt.const  12 : <"bn128">
+      %0 = poly.read_const @N : !felt.type<"bn128">
+      %nondet = llzk.nondet : !felt.type<"bn128">
+      %nondet_0 = llzk.nondet : !array.type<2 x !felt.type<"bn128">>
+      %array = array.new %felt_const_123, %felt_const_675 : <2 x !felt.type<"bn128">>
+      %1 = felt.add %0, %felt_const_6 : !felt.type<"bn128">, !felt.type<"bn128">
+      %2 = cast.toindex %felt_const_1 : !felt.type<"bn128">
+      array.write %array[%2] = %1 : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+      %3 = bool.cmp gt(%0, %felt_const_12) : !felt.type<"bn128">, !felt.type<"bn128">
+      %4 = scf.if %3 -> (!felt.type<"bn128">) {
+        %5 = cast.toindex %felt_const_0 : !felt.type<"bn128">
+        %6 = array.read %array[%5] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+        %7 = cast.toindex %felt_const_1 : !felt.type<"bn128">
+        %8 = array.read %array[%7] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+        %9 = felt.add %6, %8 : !felt.type<"bn128">, !felt.type<"bn128">
+        scf.yield %9 : !felt.type<"bn128">
+      } else {
+        scf.yield %felt_const_0 : !felt.type<"bn128">
+      }
+      poly.yield %4 : !felt.type<"bn128">
+    }
+    poly.expr @"a[1]@381" {
+      %felt_const_1 = felt.const  1 : <"bn128">
+      %felt_const_6 = felt.const  6 : <"bn128">
+      %felt_const_675 = felt.const  675 : <"bn128">
+      %felt_const_123 = felt.const  123 : <"bn128">
+      %0 = poly.read_const @N : !felt.type<"bn128">
+      %nondet = llzk.nondet : !felt.type<"bn128">
+      %nondet_0 = llzk.nondet : !array.type<2 x !felt.type<"bn128">>
+      %array = array.new %felt_const_123, %felt_const_675 : <2 x !felt.type<"bn128">>
+      %1 = felt.add %0, %felt_const_6 : !felt.type<"bn128">, !felt.type<"bn128">
+      %2 = cast.toindex %felt_const_1 : !felt.type<"bn128">
+      array.write %array[%2] = %1 : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+      %3 = cast.toindex %felt_const_1 : !felt.type<"bn128">
+      %4 = array.read %array[%3] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+      poly.yield %4 : !felt.type<"bn128">
+    }
+    poly.expr @x {
+      %felt_const_6 = felt.const  6 : <"bn128">
+      %0 = poly.read_const @N : !felt.type<"bn128">
+      %nondet = llzk.nondet : !felt.type<"bn128">
+      %nondet_0 = llzk.nondet : !array.type<2 x !felt.type<"bn128">>
+      poly.yield %felt_const_6 : !felt.type<"bn128">
+    }
+  }
+}
+// CHECK-LABEL: module attributes {llzk.lang = "circom"} {
+// CHECK-NEXT:    poly.template @T {
+// CHECK-NEXT:      poly.param @N
+// CHECK-NEXT:      poly.expr @"N_Greater_12?a[0]_Add_a[1]:0@411" {
+// CHECK-NEXT:        %[[VAL_0:[0-9a-zA-Z_\.]+]] = felt.const  12 : <"bn128">
+// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = felt.const  123 : <"bn128">
+// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = felt.const  675 : <"bn128">
+// CHECK-NEXT:        %[[VAL_4:[0-9a-zA-Z_\.]+]] = felt.const  6 : <"bn128">
+// CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:        %[[VAL_6:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type<"bn128">
+// CHECK-NEXT:        %[[VAL_9:[0-9a-zA-Z_\.]+]] = array.new %[[VAL_2]], %[[VAL_3]] : <2 x !felt.type<"bn128">>
+// CHECK-NEXT:        %[[VAL_10:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_6]], %[[VAL_4]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:        %[[VAL_11:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_5]] : !felt.type<"bn128">
+// CHECK-NEXT:        array.write %[[VAL_9]]{{\[}}%[[VAL_11]]] = %[[VAL_10]] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:        %[[VAL_12:[0-9a-zA-Z_\.]+]] = bool.cmp gt(%[[VAL_6]], %[[VAL_0]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:        %[[VAL_13:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_12]] -> (!felt.type<"bn128">) {
+// CHECK-NEXT:          %[[VAL_14:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_1]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_15:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_9]]{{\[}}%[[VAL_14]]] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_16:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_5]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_17:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_9]]{{\[}}%[[VAL_16]]] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_18:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_15]], %[[VAL_17]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          scf.yield %[[VAL_18]] : !felt.type<"bn128">
+// CHECK-NEXT:        } else {
+// CHECK-NEXT:          scf.yield %[[VAL_1]] : !felt.type<"bn128">
+// CHECK-NEXT:        }
+// CHECK-NEXT:        poly.yield %[[VAL_13]] : !felt.type<"bn128">
+// CHECK-NEXT:      }
+// CHECK-NEXT:      poly.expr @"a[1]@381" {
+// CHECK-NEXT:        %[[VAL_19:[0-9a-zA-Z_\.]+]] = felt.const  123 : <"bn128">
+// CHECK-NEXT:        %[[VAL_20:[0-9a-zA-Z_\.]+]] = felt.const  675 : <"bn128">
+// CHECK-NEXT:        %[[VAL_21:[0-9a-zA-Z_\.]+]] = felt.const  6 : <"bn128">
+// CHECK-NEXT:        %[[VAL_22:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:        %[[VAL_23:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type<"bn128">
+// CHECK-NEXT:        %[[VAL_26:[0-9a-zA-Z_\.]+]] = array.new %[[VAL_19]], %[[VAL_20]] : <2 x !felt.type<"bn128">>
+// CHECK-NEXT:        %[[VAL_27:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_23]], %[[VAL_21]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:        %[[VAL_28:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_22]] : !felt.type<"bn128">
+// CHECK-NEXT:        array.write %[[VAL_26]]{{\[}}%[[VAL_28]]] = %[[VAL_27]] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:        %[[VAL_29:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_22]] : !felt.type<"bn128">
+// CHECK-NEXT:        %[[VAL_30:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_26]]{{\[}}%[[VAL_29]]] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:        poly.yield %[[VAL_30]] : !felt.type<"bn128">
+// CHECK-NEXT:      }
+// CHECK-NEXT:      poly.expr @x {
+// CHECK-NEXT:        %[[VAL_31:[0-9a-zA-Z_\.]+]] = felt.const  6 : <"bn128">
+// CHECK-NEXT:        poly.yield %[[VAL_31]] : !felt.type<"bn128">
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }
+// -----
+
+module attributes {llzk.lang = "circom"} {
+  poly.template @T {
+    poly.param @N
+    poly.expr @UnusedIfResult {
+      %felt_const_1 = felt.const  1 : <"bn128">
+      %felt_const_6 = felt.const  6 : <"bn128">
+      %felt_const_675 = felt.const  675 : <"bn128">
+      %felt_const_123 = felt.const  123 : <"bn128">
+      %felt_const_0 = felt.const  0 : <"bn128">
+      %felt_const_12 = felt.const  12 : <"bn128">
+      %0 = poly.read_const @N : !felt.type<"bn128">
+      %array = array.new %felt_const_123, %felt_const_675 : <2 x !felt.type<"bn128">>
+      %1 = felt.add %0, %felt_const_6 : !felt.type<"bn128">, !felt.type<"bn128">
+      %2 = cast.toindex %felt_const_1 : !felt.type<"bn128">
+      %3 = bool.cmp gt(%0, %felt_const_12) : !felt.type<"bn128">, !felt.type<"bn128">
+      %4 = scf.if %3 -> (!felt.type<"bn128">) {
+        %5 = cast.toindex %felt_const_0 : !felt.type<"bn128">
+        %7 = cast.toindex %felt_const_1 : !felt.type<"bn128">
+        %9 = felt.add %felt_const_675, %felt_const_123 : !felt.type<"bn128">, !felt.type<"bn128">
+        scf.yield %9 : !felt.type<"bn128">
+      } else {
+        scf.yield %felt_const_0 : !felt.type<"bn128">
+      }
+      %5 = poly.read_const @N : !felt.type<"bn128">
+      poly.yield %5 : !felt.type<"bn128">
+    }
+  }
+}
+// CHECK-LABEL: module attributes {llzk.lang = "circom"} {
+// CHECK-NEXT:    poly.template @T {
+// CHECK-NEXT:      poly.param @N
+// CHECK-NEXT:      poly.expr @UnusedIfResult {
+// CHECK-NEXT:        %[[VAL_0:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type<"bn128">
+// CHECK-NEXT:        poly.yield %[[VAL_0]] : !felt.type<"bn128">
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/test/FrontendLang/Circom/poly_expr_cleanup_1.llzk
+++ b/test/FrontendLang/Circom/poly_expr_cleanup_1.llzk
@@ -171,3 +171,102 @@ module attributes {llzk.lang = "circom"} {
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
+// -----
+
+module attributes {llzk.lang = "circom"} {
+  poly.template @T {
+    poly.param @N
+    poly.expr @UnusedIfResult_HitsDeadValueRemovalBug {
+      %felt_const_1 = felt.const  1 : <"bn128">
+      %felt_const_6 = felt.const  6 : <"bn128">
+      %felt_const_675 = felt.const  675 : <"bn128">
+      %felt_const_123 = felt.const  123 : <"bn128">
+      %felt_const_0 = felt.const  0 : <"bn128">
+      %felt_const_12 = felt.const  12 : <"bn128">
+      %0 = poly.read_const @N : !felt.type<"bn128">
+      %array = array.new %felt_const_123, %felt_const_675 : <2 x !felt.type<"bn128">>
+      %1 = felt.add %0, %felt_const_6 : !felt.type<"bn128">, !felt.type<"bn128">
+      %2 = cast.toindex %felt_const_1 : !felt.type<"bn128">
+      array.write %array[%2] = %1 : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+      %3 = bool.cmp gt(%0, %felt_const_12) : !felt.type<"bn128">, !felt.type<"bn128">
+      %4 = scf.if %3 -> (!felt.type<"bn128">) {
+        %5 = cast.toindex %felt_const_0 : !felt.type<"bn128">
+        %6 = array.read %array[%5] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+        %7 = cast.toindex %felt_const_1 : !felt.type<"bn128">
+        %8 = array.read %array[%7] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+        %9 = felt.add %6, %8 : !felt.type<"bn128">, !felt.type<"bn128">
+        scf.yield %9 : !felt.type<"bn128">
+      } else {
+        scf.yield %felt_const_0 : !felt.type<"bn128">
+      }
+      %5 = poly.read_const @N : !felt.type<"bn128">
+      poly.yield %5 : !felt.type<"bn128">
+    }
+  }
+}
+// CHECK-LABEL: module attributes {llzk.lang = "circom"} {
+// CHECK-NEXT:    poly.template @T {
+// CHECK-NEXT:      poly.param @N
+// CHECK-NEXT:      poly.expr @UnusedIfResult_HitsDeadValueRemovalBug {
+// CHECK-NEXT:        %[[VAL_0:[0-9a-zA-Z_\.]+]] = felt.const  12 : <"bn128">
+// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = felt.const  123 : <"bn128">
+// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = felt.const  675 : <"bn128">
+// CHECK-NEXT:        %[[VAL_4:[0-9a-zA-Z_\.]+]] = felt.const  6 : <"bn128">
+// CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:        %[[VAL_6:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type<"bn128">
+// CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = array.new %[[VAL_2]], %[[VAL_3]] : <2 x !felt.type<"bn128">>
+// CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_6]], %[[VAL_4]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:        %[[VAL_9:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_5]] : !felt.type<"bn128">
+// CHECK-NEXT:        array.write %[[VAL_7]]{{\[}}%[[VAL_9]]] = %[[VAL_8]] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:        %[[VAL_10:[0-9a-zA-Z_\.]+]] = bool.cmp gt(%[[VAL_6]], %[[VAL_0]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:        scf.if %[[VAL_10]] {
+// CHECK-NEXT:          %[[VAL_11:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_1]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_12:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_7]]{{\[}}%[[VAL_11]]] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_13:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_5]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_14:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_7]]{{\[}}%[[VAL_13]]] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[VAL_15:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type<"bn128">
+// CHECK-NEXT:        poly.yield %[[VAL_15]] : !felt.type<"bn128">
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }
+// -----
+
+module attributes {llzk.lang = "circom"} {
+  poly.template @T {
+    poly.param @N
+    poly.expr @UnusedIfResult_HitsDeadValueRemovalBug {
+      %felt_const_1 = felt.const  1 : <"bn128">
+      %felt_const_6 = felt.const  6 : <"bn128">
+      %felt_const_675 = felt.const  675 : <"bn128">
+      %felt_const_123 = felt.const  123 : <"bn128">
+      %felt_const_0 = felt.const  0 : <"bn128">
+      %felt_const_12 = felt.const  12 : <"bn128">
+      %0 = poly.read_const @N : !felt.type<"bn128">
+      %array = array.new %felt_const_123, %felt_const_675 : <2 x !felt.type<"bn128">>
+      %1 = felt.add %0, %felt_const_6 : !felt.type<"bn128">, !felt.type<"bn128">
+      %2 = cast.toindex %felt_const_1 : !felt.type<"bn128">
+      %3 = bool.cmp gt(%0, %felt_const_12) : !felt.type<"bn128">, !felt.type<"bn128">
+      %4 = scf.if %3 -> (!felt.type<"bn128">) {
+        %5 = cast.toindex %felt_const_0 : !felt.type<"bn128">
+        %7 = cast.toindex %felt_const_1 : !felt.type<"bn128">
+        %9 = felt.add %felt_const_123, %felt_const_675 : !felt.type<"bn128">, !felt.type<"bn128">
+        scf.yield %9 : !felt.type<"bn128">
+      } else {
+        scf.yield %felt_const_0 : !felt.type<"bn128">
+      }
+      %5 = poly.read_const @N : !felt.type<"bn128">
+      poly.yield %5 : !felt.type<"bn128">
+    }
+  }
+}
+// CHECK-LABEL: module attributes {llzk.lang = "circom"} {
+// CHECK-NEXT:    poly.template @T {
+// CHECK-NEXT:      poly.param @N
+// CHECK-NEXT:      poly.expr @UnusedIfResult_HitsDeadValueRemovalBug {
+// CHECK-NEXT:        %[[VAL_0:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type<"bn128">
+// CHECK-NEXT:        poly.yield %[[VAL_0]] : !felt.type<"bn128">
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/test/FrontendLang/Circom/poly_expr_cleanup_2.llzk
+++ b/test/FrontendLang/Circom/poly_expr_cleanup_2.llzk
@@ -1,0 +1,62 @@
+// RUN: llzk-opt -split-input-file --pass-pipeline='any(remove-dead-values)' %s 2>&1 | FileCheck --enable-var-scope %s
+
+// This one results in an empty "else" region after running the LLVM 20 hotfix
+// `remove-dead-values` pass which necessitates the post-pass cleanup step.
+module attributes {llzk.lang = "circom"} {
+  poly.template @T {
+    poly.param @N
+    poly.expr @UnusedIfResult_HitsDeadValueRemovalBug {
+      %felt_const_1 = felt.const  1 : <"bn128">
+      %felt_const_6 = felt.const  6 : <"bn128">
+      %felt_const_675 = felt.const  675 : <"bn128">
+      %felt_const_123 = felt.const  123 : <"bn128">
+      %felt_const_0 = felt.const  0 : <"bn128">
+      %felt_const_12 = felt.const  12 : <"bn128">
+      %0 = poly.read_const @N : !felt.type<"bn128">
+      %array = array.new %felt_const_123, %felt_const_675 : <2 x !felt.type<"bn128">>
+      %1 = felt.add %0, %felt_const_6 : !felt.type<"bn128">, !felt.type<"bn128">
+      %2 = cast.toindex %felt_const_1 : !felt.type<"bn128">
+      array.write %array[%2] = %1 : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+      %3 = bool.cmp gt(%0, %felt_const_12) : !felt.type<"bn128">, !felt.type<"bn128">
+      %4 = scf.if %3 -> (!felt.type<"bn128">) {
+        %5 = cast.toindex %felt_const_0 : !felt.type<"bn128">
+        %6 = array.read %array[%5] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+        %7 = cast.toindex %felt_const_1 : !felt.type<"bn128">
+        %8 = array.read %array[%7] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+        %9 = felt.add %6, %8 : !felt.type<"bn128">, !felt.type<"bn128">
+        scf.yield %9 : !felt.type<"bn128">
+      } else {
+        scf.yield %felt_const_0 : !felt.type<"bn128">
+      }
+      %5 = poly.read_const @N : !felt.type<"bn128">
+      poly.yield %5 : !felt.type<"bn128">
+    }
+  }
+}
+// CHECK-LABEL: module attributes {llzk.lang = "circom"} {
+// CHECK-NEXT:    poly.template @T {
+// CHECK-NEXT:      poly.param @N
+// CHECK-NEXT:      poly.expr @UnusedIfResult_HitsDeadValueRemovalBug {
+// CHECK-NEXT:        %[[VAL_0:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = felt.const  6 : <"bn128">
+// CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = felt.const  675 : <"bn128">
+// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = felt.const  123 : <"bn128">
+// CHECK-NEXT:        %[[VAL_4:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = felt.const  12 : <"bn128">
+// CHECK-NEXT:        %[[VAL_6:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type<"bn128">
+// CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = array.new %[[VAL_3]], %[[VAL_2]] : <2 x !felt.type<"bn128">>
+// CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_6]], %[[VAL_1]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:        %[[VAL_9:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_0]] : !felt.type<"bn128">
+// CHECK-NEXT:        array.write %[[VAL_7]]{{\[}}%[[VAL_9]]] = %[[VAL_8]] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:        %[[VAL_10:[0-9a-zA-Z_\.]+]] = bool.cmp gt(%[[VAL_6]], %[[VAL_5]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:        scf.if %[[VAL_10]] {
+// CHECK-NEXT:          %[[VAL_11:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_4]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_12:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_7]]{{\[}}%[[VAL_11]]] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_13:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_0]] : !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_14:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_7]]{{\[}}%[[VAL_13]]] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[VAL_15:[0-9a-zA-Z_\.]+]] = poly.read_const @N : !felt.type<"bn128">
+// CHECK-NEXT:        poly.yield %[[VAL_15]] : !felt.type<"bn128">
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/test/Transforms/Flattening/partial_instantiation_4.llzk
+++ b/test/Transforms/Flattening/partial_instantiation_4.llzk
@@ -56,7 +56,6 @@ module attributes {llzk.lang} {
 // CHECK-NEXT:        function.return %[[V0]] : !struct.type<@"TZip_f_f_\1A"::@Zip<[@N]>>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[V3:[0-9a-zA-Z_\.]+]]: !struct.type<@"TZip_f_f_\1A"::@Zip<[@N]>>) attributes {function.allow_constraint} {
-// CHECK-NEXT:        %[[V4:[0-9a-zA-Z_\.]+]] = poly.read_const @N : index
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }

--- a/tools/llzk-opt/llzk-opt.cpp
+++ b/tools/llzk-opt/llzk-opt.cpp
@@ -34,6 +34,7 @@
 
 #include <mlir/Dialect/Func/Extensions/InlinerExtension.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
+#include <mlir/Dialect/SCF/IR/SCF.h>
 #include <mlir/IR/DialectRegistry.h>
 #include <mlir/Pass/PassManager.h>
 #include <mlir/Pass/PassRegistry.h>
@@ -61,6 +62,85 @@ static llvm::cl::list<std::string> IncludeDirs(
 static llvm::cl::opt<bool>
     PrintAllOps("print-llzk-ops", llvm::cl::desc("Print a list of all ops registered in LLZK"));
 
+/// Replace `mlir::registerTransformsPasses()` to register a custom `remove-dead-values` pass
+/// because MLIR version 20 has a bug in that pass which causes an assertion failure when it
+/// encounters an `scf.if` op with an empty else region.
+namespace mlir_hotfix {
+
+class RemoveDeadValuesWorkaroundPass
+    : public mlir::PassWrapper<RemoveDeadValuesWorkaroundPass, mlir::OperationPass<>> {
+public:
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(RemoveDeadValuesWorkaroundPass)
+
+  llvm::StringRef getArgument() const override { return "remove-dead-values"; }
+  llvm::StringRef getDescription() const override { return "Remove dead values"; }
+
+  void runOnOperation() final {
+    // pre-pass: add trivial block to empty "else" regions of scf.if ops
+    getOperation()->walk([](mlir::scf::IfOp ifOp) {
+      if (ifOp.getElseRegion().empty()) {
+        mlir::Block &elseBlock = ifOp.getElseRegion().emplaceBlock();
+        mlir::OpBuilder builder(ifOp.getContext());
+        builder.setInsertionPointToEnd(&elseBlock);
+        builder.create<mlir::scf::YieldOp>(ifOp.getLoc());
+      }
+    });
+
+    mlir::OpPassManager pm(getOperation()->getName().getStringRef());
+    pm.addPass(mlir::createRemoveDeadValuesPass());
+    if (mlir::failed(runPipeline(pm, getOperation()))) {
+      signalPassFailure();
+    }
+
+    // post-pass: cleanup trival "else" blocks that remain after the pass
+    getOperation()->walk([](mlir::scf::IfOp ifOp) {
+      if (ifOp.getResults().empty()) {
+        mlir::Region &elseRegion = ifOp.getElseRegion();
+        if (!llvm::hasSingleElement(elseRegion)) {
+          return;
+        }
+        mlir::Block &elseBlock = elseRegion.front();
+        if (!llvm::hasSingleElement(elseBlock)) {
+          return;
+        }
+        if (!llvm::isa<mlir::scf::YieldOp>(elseBlock.front())) {
+          return;
+        }
+        elseRegion.dropAllReferences();
+        elseBlock.clear();
+        elseRegion.getBlocks().clear();
+      }
+    });
+  }
+};
+
+inline static void registerTransformsPasses() {
+  mlir::registerCSE();
+  mlir::registerCanonicalizer();
+  mlir::registerCompositeFixedPointPass();
+  mlir::registerControlFlowSink();
+  mlir::registerGenerateRuntimeVerification();
+  mlir::registerInliner();
+  mlir::registerLocationSnapshot();
+  mlir::registerLoopInvariantCodeMotion();
+  mlir::registerLoopInvariantSubsetHoisting();
+  mlir::registerMem2Reg();
+  mlir::registerPrintIRPass();
+  mlir::registerPrintOpStats();
+  mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {
+    return std::make_unique<RemoveDeadValuesWorkaroundPass>();
+  });
+  mlir::registerSCCP();
+  mlir::registerSROA();
+  mlir::registerStripDebugInfo();
+  mlir::registerSymbolDCE();
+  mlir::registerSymbolPrivatize();
+  mlir::registerTopologicalSort();
+  mlir::registerViewOpGraph();
+}
+
+} // namespace mlir_hotfix
+
 int main(int argc, char **argv) {
   llvm::sys::PrintStackTraceOnErrorSignal(llvm::StringRef());
   llvm::setBugReportMsg(
@@ -75,7 +155,7 @@ int main(int argc, char **argv) {
   // MLIR initialization
   mlir::DialectRegistry registry;
   // registers CSE, etc
-  mlir::registerTransformsPasses();
+  mlir_hotfix::registerTransformsPasses();
   llzk::registerAllDialects(registry);
   r1cs::registerAllDialects(registry);
   zklean::registerAllDialects(registry);


### PR DESCRIPTION
Additions to allow `remove-dead-values` pass to further simplify `poly.expr` body:
  - `Pure` trait on `poly.read_const` op
  - `AlwaysSpeculatable` trait on `llzk.nondet` op (actually this was just unintentionally removed when `Pure` was dropped by a prior PR)
  - canonicalizer for `llzk.nondet` op to remove it when its result is not used

Fixes an assertion failure in `remove-dead-values` pass when there are empty `else` regions. Wraps the `remove-dead-values` pass with updates to `scf.if` ops to avoid the assertion failure. The bug is likely fixed in more recent versions of LLVM because https://github.com/llvm/llvm-project/blob/main/mlir/lib/Transforms/RemoveDeadValues.cpp is substantially different from LLVM 20, containing no calls to `Region::front()` which is where the assertion came from.