### PR TITLE
add wildcard template parameter option

### DIFF
--- a/changelogs/unreleased/th__wildcard_template_param.yaml
+++ b/changelogs/unreleased/th__wildcard_template_param.yaml
@@ -1,2 +1,2 @@
 added:
-  - Wildcard '?' option for template paramters to function.call
+  - Wildcard '?' option for template parameters to function.call

--- a/changelogs/unreleased/th__wildcard_template_param.yaml
+++ b/changelogs/unreleased/th__wildcard_template_param.yaml
@@ -1,0 +1,2 @@
+added:
+  - Wildcard '?' option for template paramters to function.call

--- a/include/llzk/Dialect/Function/IR/Ops.td
+++ b/include/llzk/Dialect/Function/IR/Ops.td
@@ -293,6 +293,15 @@ def CallOp : FunctionDialectOp<
     #M = affine_map<(i)[] -> (5*i+1)>
     %r = function.call @A::@compute(%x){(%i)} : (!felt.type) -> !struct.type<@A<[#M]>>
     ```
+
+    When the call targets a free function within a `poly.template` region, the optional
+    template parameter list can be used to instantiate all `poly.param` symbols within
+    the template. If all `poly.param` symbols are used within the function signature,
+    this can be elided. Otherwise, it is required to instantiate the function. The `?`
+    wildcard can be used for any `poly.param` with a `poly.tvar` type restriction, even
+    those that cannot be inferred from the function signature. The wildcard allows for
+    inferrence of the type within the function body itself during the flattening pass
+    but may fail if the type cannot be inferred from the function body.
   }];
 
   // See `VerifySizesForMultiAffineOps` for more explanation of these arguments.
@@ -302,9 +311,7 @@ def CallOp : FunctionDialectOp<
       // List of arguments to call the target function.
       Variadic<AnyLLZKType>:$argOperands,
       // List of parameters to instantiate all `poly.param` symbols when the
-      // callee is a free function inside a `poly.template` region. If all
-      // `poly.param` symbols are used within the function signature, this can
-      // be elided. Otherwise, it is required to instantiate the function.
+      // callee is a free function inside a `poly.template` region.
       OptionalAttr<ArrayAttr>:$templateParams,
       // List of AffineMap operand groups where each group provides the
       // arguments to instantiate the next (left-to-right) AffineMap used as a

--- a/include/llzk/Dialect/Function/IR/Ops.td
+++ b/include/llzk/Dialect/Function/IR/Ops.td
@@ -300,7 +300,7 @@ def CallOp : FunctionDialectOp<
     this can be elided. Otherwise, it is required to instantiate the function. The `?`
     wildcard can be used for any `poly.param` with a `poly.tvar` type restriction, even
     those that cannot be inferred from the function signature. The wildcard allows for
-    inferrence of the type within the function body itself during the flattening pass
+    inference of the type within the function body itself during the flattening pass
     but may fail if the type cannot be inferred from the function body.
   }];
 

--- a/include/llzk/Dialect/Shared/OpHelpers.h
+++ b/include/llzk/Dialect/Shared/OpHelpers.h
@@ -15,6 +15,7 @@
 #include "llzk/Util/ErrorHelper.h"
 #include "llzk/Util/TypeHelper.h"
 
+#include <mlir/IR/BuiltinTypes.h>
 #include <mlir/IR/OpImplementation.h>
 #include <mlir/IR/Operation.h>
 #include <mlir/IR/SymbolTable.h>
@@ -159,19 +160,34 @@ inline void printAttrDictWithWarnings(
 }
 
 inline mlir::ParseResult parseTemplateParams(mlir::AsmParser &parser, mlir::ArrayAttr &value) {
-  auto parseResult = mlir::FieldParser<mlir::ArrayAttr>::parse(parser);
-  if (mlir::failed(parseResult)) {
-    return parser.emitError(parser.getCurrentLocation(), "failed to parse template parameters");
-  }
-  auto emitError = [&parser] {
-    return llzk::InFlightDiagnosticWrapper(parser.emitError(parser.getCurrentLocation()));
+  mlir::SmallVector<mlir::Attribute> elements;
+  auto parseElement = [&]() -> mlir::ParseResult {
+    // `?` is a wildcard meaning "infer this parameter"; only valid for tvar-restricted params.
+    if (mlir::succeeded(parser.parseOptionalQuestion())) {
+      elements.push_back(parser.getBuilder().getIndexAttr(mlir::ShapedType::kDynamic));
+      return mlir::success();
+    }
+    auto attrParseResult = mlir::FieldParser<mlir::Attribute>::parse(parser);
+    if (mlir::failed(attrParseResult)) {
+      return parser.emitError(
+          parser.getCurrentLocation(), "failed to parse template parameter attribute"
+      );
+    }
+    auto emitError = [&parser] {
+      return llzk::InFlightDiagnosticWrapper(parser.emitError(parser.getCurrentLocation()));
+    };
+    mlir::FailureOr<mlir::Attribute> forced = forceIntAttrType(*attrParseResult, emitError);
+    if (mlir::failed(forced)) {
+      return mlir::failure();
+    }
+    elements.push_back(*forced);
+    return mlir::success();
   };
-  mlir::FailureOr<mlir::SmallVector<mlir::Attribute>> res =
-      forceIntAttrTypes(parseResult->getValue(), emitError);
+  auto res = parser.parseCommaSeparatedList(mlir::AsmParser::Delimiter::Square, parseElement);
   if (mlir::failed(res)) {
-    return mlir::failure();
+    return res; // parseElement() already emits a sufficient error message
   }
-  value = parser.getBuilder().getArrayAttr(*res);
+  value = parser.getBuilder().getArrayAttr(elements);
   return mlir::success();
 }
 

--- a/lib/Dialect/Function/IR/Ops.cpp
+++ b/lib/Dialect/Function/IR/Ops.cpp
@@ -522,6 +522,27 @@ void CallOp::build(
 
 LogicalResult
 CallOp::verifyTemplateParamCompatibility(Attribute paramFromCallOp, TemplateParamOp targetParam) {
+  // A wildcard `?` (represented as kDynamic) defers inference to a later pass.
+  // It is only valid for parameters with a `!poly.tvar` type restriction.
+  if (auto intAttr = llvm::dyn_cast<IntegerAttr>(paramFromCallOp)) {
+    if (isDynamic(intAttr)) {
+      std::optional<Type> declaredType = targetParam.getTypeOpt();
+      if (!declaredType || !llvm::isa<TypeVarType>(*declaredType)) {
+        auto diag = this->emitOpError().append(
+            "wildcard `?` can only be used for template parameters with `!poly.tvar` "
+            "type restriction, but parameter \"@",
+            targetParam.getName(), "\" has "
+        );
+        if (declaredType) {
+          diag.append("type restriction ", *declaredType);
+        } else {
+          diag.append("no type restriction");
+        }
+        return diag;
+      }
+      return success();
+    }
+  }
   if (std::optional<Type> declaredType = targetParam.getTypeOpt()) {
     // Note: `declaredType` is restricted by `isValidConstReadType()`
     bool compatible = false;
@@ -574,6 +595,12 @@ LogicalResult CallOp::verifyTemplateParamsMatchInferred(
   assert((callParams.size() == llvm::range_size(targetParamDefs)) && "pre-condition");
 
   for (auto [paramOp, attr] : llvm::zip_equal(targetParamDefs, callParams.getValue())) {
+    // Skip wildcards (`?` / kDynamic) - their value will be resolved by a later inference pass.
+    if (auto intAttr = llvm::dyn_cast<IntegerAttr>(attr)) {
+      if (isDynamic(intAttr)) {
+        continue;
+      }
+    }
     auto it = unifications.find({FlatSymbolRefAttr::get(paramOp.getNameAttr()), Side::RHS});
     if (it != unifications.end() && !typeParamsUnify({attr}, {it->second})) {
       // Tested in call_with_template_params_fail.llzk

--- a/test/Dialect/Poly/typevar_pass.llzk
+++ b/test/Dialect/Poly/typevar_pass.llzk
@@ -946,7 +946,7 @@ module attributes {llzk.lang} {
   poly.template @synth {
     poly.param @T_return : !poly.tvar<@T_return>
     function.def @synth() {
-      // original call goes here
+      %0 = function.call @f::@f() : () -> !poly.tvar<@T_return>
       function.return
     }
   }
@@ -975,15 +975,16 @@ module attributes {llzk.lang} {
 // CHECK-NEXT:    poly.template @synth {
 // CHECK-NEXT:      poly.param @T_return : !poly.tvar<@T_return>
 // CHECK-NEXT:      function.def @synth() {
+// CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = function.call @f::@f() : () -> !poly.tvar<@T_return>
 // CHECK-NEXT:        function.return
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }
 // CHECK-NEXT:    poly.template @ComponentC {
 // CHECK-NEXT:      struct.def @ComponentC {
 // CHECK-NEXT:        function.def @compute() -> !struct.type<@ComponentC::@ComponentC<[]>> attributes {function.allow_witness} {
-// CHECK-NEXT:          %[[VAL_2:[0-9a-zA-Z_\.]+]] = struct.new : <@ComponentC::@ComponentC<[]>>
+// CHECK-NEXT:          %[[VAL_3:[0-9a-zA-Z_\.]+]] = struct.new : <@ComponentC::@ComponentC<[]>>
 // CHECK-NEXT:          function.call @synth::@synth<[?]>() : () -> ()
-// CHECK-NEXT:          function.return %[[VAL_2]] : !struct.type<@ComponentC::@ComponentC<[]>>
+// CHECK-NEXT:          function.return %[[VAL_3]] : !struct.type<@ComponentC::@ComponentC<[]>>
 // CHECK-NEXT:        }
 // CHECK-NEXT:        function.def @constrain(%[[VAL_3:[0-9a-zA-Z_\.]+]]: !struct.type<@ComponentC::@ComponentC<[]>>) attributes {function.allow_constraint} {
 // CHECK-NEXT:          function.return

--- a/test/Dialect/Poly/typevar_pass.llzk
+++ b/test/Dialect/Poly/typevar_pass.llzk
@@ -931,3 +931,63 @@ module attributes {llzk.lang} {
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
+// -----
+
+module attributes {llzk.lang} {
+  poly.template @f {
+    poly.param @T_return : !poly.tvar<@T_return>
+    function.def @f() -> !poly.tvar<@T_return> {
+      %0 = felt.const  0 : <"bn128">
+      %1 = poly.unifiable_cast %0 : (!felt.type<"bn128">) -> !poly.tvar<@T_return>
+      function.return %1 : !poly.tvar<@T_return>
+    }
+  }
+
+  poly.template @synth {
+    poly.param @T_return : !poly.tvar<@T_return>
+    function.def @synth() {
+      // original call goes here
+      function.return
+    }
+  }
+
+  poly.template @ComponentC {
+    struct.def @ComponentC {
+      function.def @compute() -> !struct.type<@ComponentC::@ComponentC<[]>> {
+        %self = struct.new : !struct.type<@ComponentC::@ComponentC<[]>>
+        function.call @synth::@synth<[?]>() : () -> ()
+        function.return %self : !struct.type<@ComponentC::@ComponentC<[]>>
+      }
+
+      function.def @constrain(%self: !struct.type<@ComponentC::@ComponentC<[]>>) { function.return }
+    }
+  }
+}
+// CHECK-LABEL: module attributes {llzk.lang} {
+// CHECK-NEXT:    poly.template @f {
+// CHECK-NEXT:      poly.param @T_return : !poly.tvar<@T_return>
+// CHECK-NEXT:      function.def @f() -> !poly.tvar<@T_return> {
+// CHECK-NEXT:        %[[VAL_0:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = poly.unifiable_cast %[[VAL_0]] : (!felt.type<"bn128">) -> !poly.tvar<@T_return>
+// CHECK-NEXT:        function.return %[[VAL_1]] : !poly.tvar<@T_return>
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:    poly.template @synth {
+// CHECK-NEXT:      poly.param @T_return : !poly.tvar<@T_return>
+// CHECK-NEXT:      function.def @synth() {
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:    poly.template @ComponentC {
+// CHECK-NEXT:      struct.def @ComponentC {
+// CHECK-NEXT:        function.def @compute() -> !struct.type<@ComponentC::@ComponentC<[]>> attributes {function.allow_witness} {
+// CHECK-NEXT:          %[[VAL_2:[0-9a-zA-Z_\.]+]] = struct.new : <@ComponentC::@ComponentC<[]>>
+// CHECK-NEXT:          function.call @synth::@synth<[?]>() : () -> ()
+// CHECK-NEXT:          function.return %[[VAL_2]] : !struct.type<@ComponentC::@ComponentC<[]>>
+// CHECK-NEXT:        }
+// CHECK-NEXT:        function.def @constrain(%[[VAL_3:[0-9a-zA-Z_\.]+]]: !struct.type<@ComponentC::@ComponentC<[]>>) attributes {function.allow_constraint} {
+// CHECK-NEXT:          function.return
+// CHECK-NEXT:        }
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/test/Dialect/Struct/struct_params_fail.llzk
+++ b/test/Dialect/Struct/struct_params_fail.llzk
@@ -604,10 +604,10 @@ module attributes {llzk.lang} {
           !struct.type<@TDeepInvalidArrayTypeA::@DeepInvalidArrayTypeA<[
             !struct.type<@TDeepInvalidArrayTypeA::@DeepInvalidArrayTypeA<[
               !array.type<2 x !array.type<4 x i1>> // expected-error {{'array.type' element type cannot be 'array.type'}}
-            ]>> // expected-error {{failed to parse template parameters}}
-          ]>> // expected-error {{failed to parse template parameters}}
+            ]>> // expected-error {{failed to parse template parameter attribute}}
+          ]>> // expected-error {{failed to parse template parameter attribute}}
         > // expected-error {{failed to parse LLZK_ArrayType parameter 'elementType' which is to be a `::mlir::Type`}}
-      ]>> // expected-error {{failed to parse template parameters}}
+      ]>> // expected-error {{failed to parse template parameter attribute}}
     > // expected-error {{failed to parse LLZK_ArrayType parameter 'elementType' which is to be a `::mlir::Type`}}
 }
 


### PR DESCRIPTION
I think this is the best solution to the issue of unknown call target result types in the circom frontend. It touches the least surface area of LLZK among the options discussed there.