### PR TITLE
Fix incorrect behavior in `pod.new` constructor

### DIFF
--- a/changelogs/unreleased/dani__fix-capi-ctor-2.yaml
+++ b/changelogs/unreleased/dani__fix-capi-ctor-2.yaml
@@ -1,0 +1,2 @@
+fixed:
+  - Fixed incorrect behavior in `pod.new` constructor that accepts both record initialization operands and map operands.

--- a/lib/Dialect/POD/IR/Ops.cpp
+++ b/lib/Dialect/POD/IR/Ops.cpp
@@ -66,7 +66,9 @@ void NewPodOp::build(
     DenseI32ArrayAttr numDimsPerMap, InitializedRecords initialValues
 ) {
   buildCommon(builder, state, result, initialValues);
-  affineMapHelpers::buildInstantiationAttrs<NewPodOp>(builder, state, mapOperands, numDimsPerMap, llzk::checkedCast<int32_t>(initialValues.size()));
+  affineMapHelpers::buildInstantiationAttrs<NewPodOp>(
+      builder, state, mapOperands, numDimsPerMap, llzk::checkedCast<int32_t>(initialValues.size())
+  );
 }
 
 void NewPodOp::build(

--- a/lib/Dialect/POD/IR/Ops.cpp
+++ b/lib/Dialect/POD/IR/Ops.cpp
@@ -66,7 +66,7 @@ void NewPodOp::build(
     DenseI32ArrayAttr numDimsPerMap, InitializedRecords initialValues
 ) {
   buildCommon(builder, state, result, initialValues);
-  affineMapHelpers::buildInstantiationAttrs<NewPodOp>(builder, state, mapOperands, numDimsPerMap);
+  affineMapHelpers::buildInstantiationAttrs<NewPodOp>(builder, state, mapOperands, numDimsPerMap, llzk::checkedCast<int32_t>(initialValues.size()));
 }
 
 void NewPodOp::build(

--- a/unittests/CAPI/Dialect/POD.cpp
+++ b/unittests/CAPI/Dialect/POD.cpp
@@ -11,6 +11,7 @@
 
 #include "../CAPITestBase.h"
 
+#include "llzk-c/Builder.h"
 #include "llzk-c/Support.h"
 
 #include "llzk/CAPI/Support.h"
@@ -148,6 +149,38 @@ TEST_F(PODDialectTests, llzkPod_PodTypeGetRecords) {
   llzkPod_PodTypeGetRecords(type, output);
   ASSERT_NE(output[0].ptr, nullptr);
   ASSERT_EQ(output[0].ptr, record.ptr);
+}
+
+TEST_F(PODDialectTests, llzkPod_NewPodOpBuildWithMapOperands) {
+  auto builder = mlirOpBuilderCreate(context);
+  auto loc = mlirLocationUnknownGet(context);
+
+  auto initOps = createNOps(2, createIndexType());
+  MlirType type =
+      wrap(llzk::pod::PodType::get(unwrap(context), {testRecord("x"), testRecord("y")}));
+
+  LlzkRecordValue initialValues[] = {
+      LlzkRecordValue {
+          .name = mlirStringRefCreateFromCString("x"),
+          .value = mlirOperationGetResult(initOps[0], 0)
+      },
+      LlzkRecordValue {
+          .name = mlirStringRefCreateFromCString("y"),
+          .value = mlirOperationGetResult(initOps[1], 0)
+      },
+  };
+  LlzkAffineMapOperandsBuilder mapOperands = llzkAffineMapOperandsBuilderCreate();
+
+  auto op = llzkPod_NewPodOpBuildWithMapOperands(builder, loc, type, 2, initialValues, mapOperands);
+
+  ASSERT_TRUE(mlirOperationVerify(op));
+  mlirOperationDestroy(op);
+  llzkAffineMapOperandsBuilderDestroy(&mapOperands);
+  mlirOpBuilderDestroy(builder);
+
+  for (auto initOp : initOps) {
+    mlirOperationDestroy(initOp);
+  }
 }
 
 // Implementation for `ReadPodOp_build_pass` test


### PR DESCRIPTION
Fixes the incorrect construction of a `pod.new` op when is has both record initialization operands and map operands. 
The size of the first segment was not initialized to the length of the record initialization operands list, 
causing a validation error since it was expecting the default amount of 0 record initialization operands.

This issue triggered even if the map operands list was empty as long as the op was explicitly constructed with that constructor 
(i.e. by using the `pod::new_with_affine_init` factory function in the Rust bindings).
