### PR TITLE
Raghav/array to scalar attr fix

### DIFF
--- a/changelogs/unreleased/raghav__array-to-scalar-attr-fix.yaml
+++ b/changelogs/unreleased/raghav__array-to-scalar-attr-fix.yaml
@@ -1,0 +1,2 @@
+fixed:
+  - In llzk-array-to-scalar the unwrapped members switched the {column} and {signal} attributes

--- a/lib/Dialect/Array/Transforms/ArrayToScalarPass.cpp
+++ b/lib/Dialect/Array/Transforms/ArrayToScalarPass.cpp
@@ -335,9 +335,8 @@ public:
 
   LogicalResult match(ExtractArrayOp op) const override { return failure(legal(op)); }
 
-  void rewrite(
-      ExtractArrayOp op, OpAdaptor adaptor, ConversionPatternRewriter &rewriter
-  ) const override {
+  void rewrite(ExtractArrayOp op, OpAdaptor adaptor, ConversionPatternRewriter &rewriter)
+      const override {
     ArrayType at = splittableArray(op.getResult().getType());
     // Generate `CreateArrayOp` in place of the current op.
     auto newArray = rewriter.replaceOpWithNewOp<CreateArrayOp>(op, at);
@@ -609,7 +608,7 @@ public:
     for (ArrayAttr idx : subIdxs.value()) {
       // Create scalar version of the member
       MemberDefOp newMember = rewriter.create<MemberDefOp>(
-          op.getLoc(), op.getSymNameAttr(), elemTy, op.getColumn(), op.getSignal()
+          op.getLoc(), op.getSymNameAttr(), elemTy, op.getSignal(), op.getColumn()
       );
       newMember.setPublicAttr(op.hasPublicAttr());
       // Use SymbolTable to give it a unique name and store to the replacement map
@@ -671,9 +670,8 @@ public:
 
   LogicalResult match(MemberRefOpClass op) const override { return failure(ImplClass::legal(op)); }
 
-  void rewrite(
-      MemberRefOpClass op, OpAdaptor adaptor, ConversionPatternRewriter &rewriter
-  ) const override {
+  void rewrite(MemberRefOpClass op, OpAdaptor adaptor, ConversionPatternRewriter &rewriter)
+      const override {
     StructType tgtStructTy = llvm::cast<MemberRefOpInterface>(op.getOperation()).getStructType();
     assert(tgtStructTy);
     auto tgtStructDef = tgtStructTy.getDefinition(tables, op);
@@ -753,9 +751,8 @@ static void baseTargetSetup(ConversionTarget &target) {
 
 class NondetToNewArray : public OpConversionPattern<NonDetOp> {
   using OpConversionPattern<NonDetOp>::OpConversionPattern;
-  LogicalResult matchAndRewrite(
-      NonDetOp nondetOp, OpAdaptor, ConversionPatternRewriter &rewriter
-  ) const override {
+  LogicalResult matchAndRewrite(NonDetOp nondetOp, OpAdaptor, ConversionPatternRewriter &rewriter)
+      const override {
     if (auto at = dyn_cast<ArrayType>(nondetOp.getType())) {
       rewriter.replaceOpWithNewOp<CreateArrayOp>(nondetOp, at);
       return success();

--- a/lib/Dialect/Array/Transforms/ArrayToScalarPass.cpp
+++ b/lib/Dialect/Array/Transforms/ArrayToScalarPass.cpp
@@ -335,8 +335,9 @@ public:
 
   LogicalResult match(ExtractArrayOp op) const override { return failure(legal(op)); }
 
-  void rewrite(ExtractArrayOp op, OpAdaptor adaptor, ConversionPatternRewriter &rewriter)
-      const override {
+  void rewrite(
+      ExtractArrayOp op, OpAdaptor adaptor, ConversionPatternRewriter &rewriter
+  ) const override {
     ArrayType at = splittableArray(op.getResult().getType());
     // Generate `CreateArrayOp` in place of the current op.
     auto newArray = rewriter.replaceOpWithNewOp<CreateArrayOp>(op, at);
@@ -670,8 +671,9 @@ public:
 
   LogicalResult match(MemberRefOpClass op) const override { return failure(ImplClass::legal(op)); }
 
-  void rewrite(MemberRefOpClass op, OpAdaptor adaptor, ConversionPatternRewriter &rewriter)
-      const override {
+  void rewrite(
+      MemberRefOpClass op, OpAdaptor adaptor, ConversionPatternRewriter &rewriter
+  ) const override {
     StructType tgtStructTy = llvm::cast<MemberRefOpInterface>(op.getOperation()).getStructType();
     assert(tgtStructTy);
     auto tgtStructDef = tgtStructTy.getDefinition(tables, op);
@@ -751,8 +753,9 @@ static void baseTargetSetup(ConversionTarget &target) {
 
 class NondetToNewArray : public OpConversionPattern<NonDetOp> {
   using OpConversionPattern<NonDetOp>::OpConversionPattern;
-  LogicalResult matchAndRewrite(NonDetOp nondetOp, OpAdaptor, ConversionPatternRewriter &rewriter)
-      const override {
+  LogicalResult matchAndRewrite(
+      NonDetOp nondetOp, OpAdaptor, ConversionPatternRewriter &rewriter
+  ) const override {
     if (auto at = dyn_cast<ArrayType>(nondetOp.getType())) {
       rewriter.replaceOpWithNewOp<CreateArrayOp>(nondetOp, at);
       return success();

--- a/test/Transforms/ArrayToScalar/array_to_scalar.llzk
+++ b/test/Transforms/ArrayToScalar/array_to_scalar.llzk
@@ -764,3 +764,25 @@ module attributes {llzk.lang} {
 // CHECK-NEXT:      function.return
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
+// -----
+
+module attributes {llzk.lang} {
+  struct.def @A {
+    struct.member @foo : !array.type<2 x !felt.type> {llzk.pub}
+    struct.member @bar : !array.type<2 x !felt.type> {signal}
+    struct.member @baz : !array.type<2 x !felt.type> {column}
+
+    function.def @product() -> !struct.type<@A> {
+      %self = struct.new : <@A>
+      function.return %self : !struct.type<@A>
+    }
+  }
+}
+
+// CHECK-LABEL: struct.def @A {
+// CHECK-NEXT: struct.member @foo_0 : !felt.type {llzk.pub}
+// CHECK-NEXT: struct.member @foo_1 : !felt.type {llzk.pub}
+// CHECK-NEXT: struct.member @bar_2 : !felt.type {signal}
+// CHECK-NEXT: struct.member @bar_3 : !felt.type {signal}
+// CHECK-NEXT: struct.member @baz_4 : !felt.type {column}
+// CHECK-NEXT: struct.member @baz_5 : !felt.type {column}


### PR DESCRIPTION
`{signal}` and `{column}` were swapped when generating scalar members from an array member