### PR TITLE
fix llzk-tblgen bug involving variadic operands

### DIFF
--- a/changelogs/unreleased/th__fix_tblgen_bug.yaml
+++ b/changelogs/unreleased/th__fix_tblgen_bug.yaml
@@ -1,0 +1,2 @@
+fixed:
+  - fix bug in llzk-tblgen where the generated getter/setter for a variadic operand was using the wrong offset when there are multiple variadic operands.

--- a/lib/CAPI/Dialect/Array.cpp
+++ b/lib/CAPI/Dialect/Array.cpp
@@ -17,6 +17,7 @@
 #include "llzk/Dialect/Array/IR/Types.h"
 #include "llzk/Dialect/Array/Transforms/TransformationPasses.h"
 
+#include <mlir-c/BuiltinAttributes.h>
 #include <mlir-c/IR.h>
 #include <mlir-c/Pass.h>
 

--- a/lib/CAPI/Dialect/Function.cpp
+++ b/lib/CAPI/Dialect/Function.cpp
@@ -16,6 +16,7 @@
 #include "llzk/Dialect/Function/IR/Dialect.h"
 #include "llzk/Dialect/Function/IR/Ops.h"
 
+#include <mlir-c/BuiltinAttributes.h>
 #include <mlir-c/IR.h>
 #include <mlir-c/Pass.h>
 

--- a/lib/CAPI/Dialect/POD.cpp
+++ b/lib/CAPI/Dialect/POD.cpp
@@ -16,6 +16,7 @@
 #include "llzk/Dialect/POD/IR/Ops.h"
 #include "llzk/Dialect/POD/IR/Types.h"
 
+#include <mlir-c/BuiltinAttributes.h>
 #include <mlir-c/IR.h>
 
 #include <mlir/CAPI/IR.h>

--- a/tools/llzk-tblgen/OpCAPIGen.cpp
+++ b/tools/llzk-tblgen/OpCAPIGen.cpp
@@ -524,6 +524,86 @@ void {0}{1}_{2}Set{3}(MlirOperation op, intptr_t count, MlirValue const *values)
     );
   }
 
+  /// Generate getter for a variadic operand whose start index must be determined at runtime by
+  /// consulting the `operandSegmentSizes` attribute (because another operand is also variadic).
+  void genVariadicOperandGetterImplDynamic(int segmentIdx) const {
+    static constexpr char fmt[] = R"(
+intptr_t {0}{1}_{2}Get{3}Count(MlirOperation op) {{
+  MlirAttribute segSizes = mlirOperationGetAttributeByName(op, mlirStringRefCreateFromCString("operandSegmentSizes"));
+  return mlirDenseI32ArrayGetElement(segSizes, {4});
+}
+
+MlirValue {0}{1}_{2}Get{3}At(MlirOperation op, intptr_t index) {{
+  MlirAttribute segSizes = mlirOperationGetAttributeByName(op, mlirStringRefCreateFromCString("operandSegmentSizes"));
+  intptr_t startIdx = 0;
+  for (int i = 0; i < {4}; ++i)
+    startIdx += mlirDenseI32ArrayGetElement(segSizes, i);
+  return mlirOperationGetOperand(op, startIdx + index);
+}
+)";
+    assert(!className.empty() && "className must be set");
+    assert(!operandNameCapitalized.empty() && "operandName must be set");
+    os << llvm::formatv(
+        fmt,
+        FunctionPrefix,         // {0}
+        dialectNameCapitalized, // {1}
+        className,              // {2}
+        operandNameCapitalized, // {3}
+        segmentIdx              // {4}
+    );
+  }
+
+  /// Generate setter for a variadic operand whose start index must be determined at runtime by
+  /// consulting the `operandSegmentSizes` attribute (because another operand is also variadic).
+  void genVariadicOperandSetterImplDynamic(int segmentIdx) const {
+    static constexpr char fmt[] = R"(
+void {0}{1}_{2}Set{3}(MlirOperation op, intptr_t count, MlirValue const *values) {{
+  MlirAttribute segSizes = mlirOperationGetAttributeByName(op, mlirStringRefCreateFromCString("operandSegmentSizes"));
+  intptr_t startIdx = 0;
+  for (int i = 0; i < {4}; ++i)
+    startIdx += mlirDenseI32ArrayGetElement(segSizes, i);
+  intptr_t numOperands = mlirOperationGetNumOperands(op);
+  intptr_t oldCount = mlirDenseI32ArrayGetElement(segSizes, {4});
+
+  // Validate bounds
+  if (count < 0 || count > (std::numeric_limits<intptr_t>::max() - startIdx)) {{
+    return;
+  }
+
+  intptr_t newNumOperands = numOperands - oldCount + count;
+
+  std::vector<MlirValue> newOperands(newNumOperands);
+
+  // Copy operands before this variadic group
+  for (intptr_t i = 0; i < startIdx; ++i) {{
+    newOperands[i] = mlirOperationGetOperand(op, i);
+  }
+
+  // Copy new variadic operands
+  for (intptr_t i = 0; i < count; ++i) {{
+    newOperands[startIdx + i] = values[i];
+  }
+
+  // Copy operands after this variadic group
+  for (intptr_t i = startIdx + oldCount; i < numOperands; ++i) {{
+    newOperands[i - oldCount + count] = mlirOperationGetOperand(op, i);
+  }
+
+  mlirOperationSetOperands(op, newNumOperands, newOperands.data());
+}
+)";
+    assert(!className.empty() && "className must be set");
+    assert(!operandNameCapitalized.empty() && "operandName must be set");
+    os << llvm::formatv(
+        fmt,
+        FunctionPrefix,         // {0}
+        dialectNameCapitalized, // {1}
+        className,              // {2}
+        operandNameCapitalized, // {3}
+        segmentIdx              // {4}
+    );
+  }
+
   void genAttributeGetterImpl(mlir::StringRef attrName) const {
     static constexpr char fmt[] = R"(
 MlirAttribute {0}{1}_{2}Get{3}(MlirOperation op) {{
@@ -750,16 +830,29 @@ static bool emitOpCAPIImpl(const llvm::RecordKeeper &records, raw_ostream &os) {
       generator.genIsAImpl();
     }
 
+    // If the op has AttrSizedOperandSegments, each segment's count must be read from the
+    // `operandSegmentSizes` attribute at runtime rather than derived from total operand count.
+    bool hasAttrSizedOperandSegments =
+        op.getTrait("::mlir::OpTrait::AttrSizedOperandSegments") != nullptr;
+
     // Generate operand getters and setters
     for (int i = 0, e = op.getNumOperands(); i < e; ++i) {
       const auto &operand = op.getOperand(i);
       generator.setOperandName(operand.name);
       if (operand.isVariadic()) {
         if (GenOpOperandGetters) {
-          generator.genVariadicOperandGetterImpl(i);
+          if (hasAttrSizedOperandSegments) {
+            generator.genVariadicOperandGetterImplDynamic(i);
+          } else {
+            generator.genVariadicOperandGetterImpl(i);
+          }
         }
         if (GenOpOperandSetters) {
-          generator.genVariadicOperandSetterImpl(i);
+          if (hasAttrSizedOperandSegments) {
+            generator.genVariadicOperandSetterImplDynamic(i);
+          } else {
+            generator.genVariadicOperandSetterImpl(i);
+          }
         }
       } else {
         if (GenOpOperandGetters) {

--- a/tools/llzk-tblgen/OpCAPIGen.cpp
+++ b/tools/llzk-tblgen/OpCAPIGen.cpp
@@ -530,11 +530,17 @@ void {0}{1}_{2}Set{3}(MlirOperation op, intptr_t count, MlirValue const *values)
     static constexpr char fmt[] = R"(
 intptr_t {0}{1}_{2}Get{3}Count(MlirOperation op) {{
   MlirAttribute segSizes = mlirOperationGetAttributeByName(op, mlirStringRefCreateFromCString("operandSegmentSizes"));
+  assert(!mlirAttributeIsNull(segSizes) && "expected operandSegmentSizes attribute");
+  assert(mlirAttributeIsADenseI32Array(segSizes) &&
+         "expected operandSegmentSizes to be a DenseI32ArrayAttr");
   return mlirDenseI32ArrayGetElement(segSizes, {4});
 }
 
 MlirValue {0}{1}_{2}Get{3}At(MlirOperation op, intptr_t index) {{
   MlirAttribute segSizes = mlirOperationGetAttributeByName(op, mlirStringRefCreateFromCString("operandSegmentSizes"));
+  assert(!mlirAttributeIsNull(segSizes) && "expected operandSegmentSizes attribute");
+  assert(mlirAttributeIsADenseI32Array(segSizes) &&
+         "expected operandSegmentSizes to be a DenseI32ArrayAttr");
   intptr_t startIdx = 0;
   for (int i = 0; i < {4}; ++i)
     startIdx += mlirDenseI32ArrayGetElement(segSizes, i);

--- a/tools/llzk-tblgen/OpCAPIGen.cpp
+++ b/tools/llzk-tblgen/OpCAPIGen.cpp
@@ -596,6 +596,16 @@ void {0}{1}_{2}Set{3}(MlirOperation op, intptr_t count, MlirValue const *values)
   }
 
   mlirOperationSetOperands(op, newNumOperands, newOperands.data());
+
+  // Update operandSegmentSizes to reflect the new count for this segment
+  intptr_t numSegments = mlirDenseArrayGetNumElements(segSizes);
+  std::vector<int32_t> newSegSizes(numSegments);
+  for (intptr_t i = 0; i < numSegments; ++i)
+    newSegSizes[i] = mlirDenseI32ArrayGetElement(segSizes, i);
+  newSegSizes[{4}] = static_cast<int32_t>(count);
+  MlirContext ctx = mlirOperationGetContext(op);
+  MlirAttribute newSegSizesAttr = mlirDenseI32ArrayGet(ctx, numSegments, newSegSizes.data());
+  mlirOperationSetAttributeByName(op, mlirStringRefCreateFromCString("operandSegmentSizes"), newSegSizesAttr);
 }
 )";
     assert(!className.empty() && "className must be set");

--- a/unittests/CAPI/CAPITestBase.h
+++ b/unittests/CAPI/CAPITestBase.h
@@ -148,6 +148,26 @@ public:
     return newModule;
   }
 
+  /// Generate a new `ModuleOp` containing a free (non-struct) `FuncDefOp` with an empty
+  /// signature, using C++ API to avoid indirectly testing other LLZK C API functions within
+  /// the tests, and set the insertion point to the start of the function body.
+  mlir::OwningOpRef<mlir::ModuleOp>
+  cppGenFreeFuncAndSetInsertionPoint(MlirOpBuilder builder, MlirLocation location) const {
+    auto newModule = this->cppNewModuleAndSetInsertionPoint(builder, location);
+    llzk::ModuleBuilder cppBldr(newModule.get());
+    const auto *name = "func_name";
+    cppBldr.insertFreeFunc(
+        name, mlir::FunctionType::get(unwrap(context), mlir::TypeRange {}, mlir::TypeRange {}),
+        unwrap(location)
+    );
+    auto func = cppBldr.getFreeFunc(name);
+    assert(
+        mlir::succeeded(func) && "Failed to retrieve the function just inserted into the module"
+    );
+    unwrap(builder)->setInsertionPointToStart(&func->getBody().emplaceBlock());
+    return newModule;
+  }
+
   /// If the insertion point of the builder is within a `FuncDefOp`, set the
   /// 'allow_non_native_field_ops' attribute to avoid the following type of errors:
   ///

--- a/unittests/CAPI/Dialect/Array.cpp
+++ b/unittests/CAPI/Dialect/Array.cpp
@@ -302,6 +302,85 @@ std::unique_ptr<InsertArrayOpBuildFuncHelper> InsertArrayOpBuildFuncHelper::get(
   return std::make_unique<Impl>();
 }
 
+/// Test that SetElements (a variadic operand setter using the dynamic operandSegmentSizes path)
+/// correctly updates the `operandSegmentSizes` attribute so that a subsequent read of the
+/// *other* variadic operand (mapOperands) still returns the correct value.
+///
+/// Before the fix, SetElements would update the operand list but leave `operandSegmentSizes`
+/// stale (still [2, 1]). GetMapOperandsAt would then compute startIdx=2 from the stale
+/// attribute and access operand[2], which no longer exists, returning the wrong value.
+/// After the fix, `operandSegmentSizes` is updated to [1, 1], so startIdx=1 is correct.
+TEST_F(ArrayDialectTests, create_array_op_set_elements_updates_operand_segment_sizes) {
+  auto location = mlirLocationUnknownGet(context);
+  auto elt_type = createIndexType();
+
+  // Create three index-typed constant ops to serve as operands: e0, e1, m0
+  auto auxOps = create_n_ops(3, elt_type);
+  MlirValue e0 = mlirOperationGetResult(auxOps[0], 0);
+  MlirValue e1 = mlirOperationGetResult(auxOps[1], 0);
+  MlirValue m0 = mlirOperationGetResult(auxOps[2], 0);
+
+  // Manually build an `array.new` op with:
+  //   operands:            [e0, e1, m0]
+  //   operandSegmentSizes: [2, 1]  (elements=2, mapOperands=1)
+  //   mapOpGroupSizes:     [1]
+  //   numDimsPerMap:       [0]
+  //   result:              !array.type<2 x index>
+  // mlirOperationCreate does not run the verifier, so the op does not need to be
+  // semantically valid - we just need the right operand / attribute layout.
+  int64_t dims[1] = {2};
+  auto arr_type = test_array(elt_type, llvm::ArrayRef(dims, 1));
+
+  auto op_state = mlirOperationStateGet(mlirStringRefCreateFromCString("array.new"), location);
+
+  MlirValue operands[3] = {e0, e1, m0};
+  mlirOperationStateAddOperands(&op_state, 3, operands);
+  mlirOperationStateAddResults(&op_state, 1, &arr_type);
+
+  int32_t segSizes[2] = {2, 1};
+  int32_t groupSizes[1] = {1};
+  int32_t numDims[1] = {0};
+  MlirNamedAttribute attrs[3] = {
+      mlirNamedAttributeGet(
+          mlirIdentifierGet(context, mlirStringRefCreateFromCString("operandSegmentSizes")),
+          mlirDenseI32ArrayGet(context, 2, segSizes)
+      ),
+      mlirNamedAttributeGet(
+          mlirIdentifierGet(context, mlirStringRefCreateFromCString("mapOpGroupSizes")),
+          mlirDenseI32ArrayGet(context, 1, groupSizes)
+      ),
+      mlirNamedAttributeGet(
+          mlirIdentifierGet(context, mlirStringRefCreateFromCString("numDimsPerMap")),
+          mlirDenseI32ArrayGet(context, 1, numDims)
+      ),
+  };
+  mlirOperationStateAddAttributes(&op_state, 3, attrs);
+
+  auto op = mlirOperationCreate(&op_state);
+  ASSERT_NE(op.ptr, nullptr);
+
+  // Verify the initial operand layout is as expected.
+  EXPECT_EQ(llzkArray_CreateArrayOpGetElementsCount(op), 2);
+  EXPECT_EQ(llzkArray_CreateArrayOpGetMapOperandsCount(op), 1);
+  EXPECT_EQ(llzkArray_CreateArrayOpGetMapOperandsAt(op, 0).ptr, m0.ptr);
+
+  // Update elements from [e0, e1] to [e0] only.
+  // This setter must also update operandSegmentSizes from [2,1] to [1,1].
+  MlirValue newElements[1] = {e0};
+  llzkArray_CreateArrayOpSetElements(op, 1, newElements);
+
+  // mapOperands was not touched, so it should still report count=1 and return m0.
+  // Before the fix, operandSegmentSizes was not updated (still [2,1]), so
+  // GetMapOperandsAt would compute startIdx=2 and access the now-nonexistent operand[2].
+  EXPECT_EQ(llzkArray_CreateArrayOpGetMapOperandsCount(op), 1);
+  EXPECT_EQ(llzkArray_CreateArrayOpGetMapOperandsAt(op, 0).ptr, m0.ptr);
+
+  mlirOperationDestroy(op);
+  for (auto auxOp : auxOps) {
+    mlirOperationDestroy(auxOp);
+  }
+}
+
 // Implementation for `ExtractArrayOp_build_pass` test
 std::unique_ptr<ExtractArrayOpBuildFuncHelper> ExtractArrayOpBuildFuncHelper::get() {
   struct Impl : public ExtractArrayOpBuildFuncHelper {

--- a/unittests/CAPI/Dialect/Function.cpp
+++ b/unittests/CAPI/Dialect/Function.cpp
@@ -514,22 +514,7 @@ std::unique_ptr<ReturnOpBuildFuncHelper> ReturnOpBuildFuncHelper::get() {
     mlir::OwningOpRef<mlir::ModuleOp> parentModule;
     MlirOperation
     callBuild(const CAPITest &testClass, MlirOpBuilder builder, MlirLocation location) override {
-      // Use C++ API to avoid indirectly testing other LLZK C API functions here.
-      {
-        this->parentModule = testClass.cppNewModuleAndSetInsertionPoint(builder, location);
-        llzk::ModuleBuilder cppBldr(this->parentModule.get());
-        const auto *name = "func_name";
-        cppBldr.insertFreeFunc(
-            name,
-            mlir::FunctionType::get(
-                unwrap(testClass.context), mlir::TypeRange {}, mlir::TypeRange {}
-            ),
-            unwrap(location)
-        );
-        auto func = cppBldr.getFreeFunc(name);
-        assert(succeeded(func) && "Failed to retrieve the function just inserted into the module");
-        unwrap(builder)->setInsertionPointToStart(&func->getBody().emplaceBlock());
-      }
+      this->parentModule = testClass.cppGenFreeFuncAndSetInsertionPoint(builder, location);
       llvm::SmallVector<MlirValue> vals {};
       return llzkFunction_ReturnOpBuild(
           builder, location, llzk::checkedCast<intptr_t>(vals.size()), vals.data()

--- a/unittests/CAPI/Dialect/Function.cpp
+++ b/unittests/CAPI/Dialect/Function.cpp
@@ -425,6 +425,89 @@ call_pred_test(
     test_llzk_call_op_callee_is_struct_constrain, llzkFunction_CallOpCalleeIsStructConstrain, false
 );
 
+//===----------------------------------------------------------------------===//
+// CallOp operand getter tests (mixed argOperands + mapOperands)
+//
+// These tests specifically cover the bugs where the generated code used the
+// total flat operand count (or total - 1) instead of reading each segment's
+// size from `operandSegmentSizes`, and where the start index for mapOperands
+// was hardcoded to 1 instead of being computed from the attribute.
+//===----------------------------------------------------------------------===//
+
+// Builds a CallOp with 2 argOperands (v[0], v[1]) and 1 mapOperand group
+// containing 1 value (v[2]). Each value comes from a distinct index constant.
+struct MixedOperandCallOp {
+  MlirOperation constOps[3]; // owners of the three index constant ops
+  MlirValue v[3];            // results: v[0],v[1] are argOperands; v[2] is the mapOperand
+  LlzkAffineMapOperandsBuilder mapBuilder;
+  MlirOpBuilder builder;
+  MlirOperation callOp;
+
+  explicit MixedOperandCallOp(const FuncDialectTest &t) {
+    mapBuilder = llzkAffineMapOperandsBuilderCreate();
+    builder = mlirOpBuilderCreate(t.context);
+    auto loc = mlirLocationUnknownGet(t.context);
+
+    for (int i = 0; i < 3; ++i) {
+      MlirOperation op = t.createIndexOperation();
+      v[i] = mlirOperationGetResult(op, 0);
+      constOps[i] = op;
+    }
+
+    // v[2] forms a single map operand group with 0 dims (pure symbols)
+    MlirValueRange mapGroup = {.values = &v[2], .size = 1};
+    int32_t nDims = 0;
+    llzkAffineMapOperandsBuilderAppendOperandsWithDimCount(&mapBuilder, 1, &mapGroup, &nDims);
+
+    auto callee = t.test_function0();
+    MlirAttribute calleeName = mlirFlatSymbolRefAttrGet(t.context, callee.nameRef());
+    MlirType outType = t.createIndexType();
+
+    // Build: 1 result, callee, 1 map group (v[2]), 2 arg operands (v[0], v[1])
+    callOp = llzkFunction_CallOpBuildWithMapOperands(
+        builder, loc, 1, &outType, calleeName, mapBuilder, 2, &v[0]
+    );
+  }
+
+  ~MixedOperandCallOp() {
+    mlirOperationDestroy(callOp);
+    for (auto op : constOps) {
+      mlirOperationDestroy(op);
+    }
+    llzkAffineMapOperandsBuilderDestroy(&mapBuilder);
+    mlirOpBuilderDestroy(builder);
+  }
+};
+
+// GetArgOperandsCount must return the argOperands segment size (2), not the
+// total flat operand count (3). Old bug: returned `count - 0 = 3`.
+TEST_F(FuncDialectTest, llzk_call_op_get_arg_operands_count_with_map_operands) {
+  MixedOperandCallOp m(*this);
+  EXPECT_EQ(llzkFunction_CallOpGetArgOperandsCount(m.callOp), 2);
+}
+
+// GetMapOperandsCount must return the mapOperands segment size (1), not
+// `(total - 1) = 2`. Old bug: returned `count - 1 = 2`.
+TEST_F(FuncDialectTest, llzk_call_op_get_map_operands_count_with_arg_operands) {
+  MixedOperandCallOp m(*this);
+  EXPECT_EQ(llzkFunction_CallOpGetMapOperandsCount(m.callOp), 1);
+}
+
+// GetArgOperandsAt must index within the argOperands segment.
+TEST_F(FuncDialectTest, llzk_call_op_get_arg_operands_at_with_map_operands) {
+  MixedOperandCallOp m(*this);
+  EXPECT_EQ(llzkFunction_CallOpGetArgOperandsAt(m.callOp, 0).ptr, m.v[0].ptr);
+  EXPECT_EQ(llzkFunction_CallOpGetArgOperandsAt(m.callOp, 1).ptr, m.v[1].ptr);
+}
+
+// GetMapOperandsAt must skip past the argOperands segment using operandSegmentSizes,
+// not with a hardcoded offset of 1. Old bug: returned `operand[1 + 0] = v[1]`
+// (an arg operand) instead of the actual map operand `v[2]`.
+TEST_F(FuncDialectTest, llzk_call_op_get_map_operands_at_with_arg_operands) {
+  MixedOperandCallOp m(*this);
+  EXPECT_EQ(llzkFunction_CallOpGetMapOperandsAt(m.callOp, 0).ptr, m.v[2].ptr);
+}
+
 // Implementation for `ReturnOp_build_pass` test
 std::unique_ptr<ReturnOpBuildFuncHelper> ReturnOpBuildFuncHelper::get() {
   struct Impl : public ReturnOpBuildFuncHelper {
@@ -445,7 +528,7 @@ std::unique_ptr<ReturnOpBuildFuncHelper> ReturnOpBuildFuncHelper::get() {
         );
         auto func = cppBldr.getFreeFunc(name);
         assert(succeeded(func) && "Failed to retrieve the function just inserted into the module");
-        mlirOpBuilderSetInsertionPointToStart(builder, wrap(&func->getBody().emplaceBlock()));
+        unwrap(builder)->setInsertionPointToStart(&func->getBody().emplaceBlock());
       }
       llvm::SmallVector<MlirValue> vals {};
       return llzkFunction_ReturnOpBuild(


### PR DESCRIPTION
Previously generated code using a fixed offset of 1 for each variadic operand instead of consulting the `operandSegmentSizes` attribute.