### PR TITLE
Fix another tblgen bug by using reliable offset calculation

### DIFF
--- a/changelogs/unreleased/th__fix_tblgen_bug_2.yaml
+++ b/changelogs/unreleased/th__fix_tblgen_bug_2.yaml
@@ -1,0 +1,2 @@
+fixed:
+  - fix tblgen bug involving non-variadic offsets when there are variadic operands

--- a/tools/llzk-tblgen/OpCAPIGen.cpp
+++ b/tools/llzk-tblgen/OpCAPIGen.cpp
@@ -464,6 +464,7 @@ intptr_t {0}{1}_{2}Get{3}Count(MlirOperation op) {{
 
 MlirValue {0}{1}_{2}Get{3}At(MlirOperation op, intptr_t index) {{
   auto range = llvm::cast<{2}>(unwrap(op)).getODSOperandIndexAndLength({4});
+  assert(index >= 0 && index < range.second && "variadic operand index out of range");
   return mlirOperationGetOperand(op, static_cast<intptr_t>(range.first) + index);
 }
 )";
@@ -531,9 +532,11 @@ void {0}{1}_{2}Set{3}(MlirOperation op, intptr_t count, MlirValue const *values)
   assert(mlirAttributeIsADenseI32Array(segSizes) &&
          "expected operandSegmentSizes to be a DenseI32ArrayAttr");
   intptr_t numSegments = mlirDenseArrayGetNumElements(segSizes);
+  assert(numSegments > {0} && "operandSegmentSizes has fewer segments than expected");
   std::vector<int32_t> newSegSizes(numSegments);
   for (intptr_t i = 0; i < numSegments; ++i)
     newSegSizes[i] = mlirDenseI32ArrayGetElement(segSizes, i);
+  assert(count <= static_cast<intptr_t>(std::numeric_limits<int32_t>::max()) && "count exceeds int32_t range");
   newSegSizes[{0}] = static_cast<int32_t>(count);
   MlirContext ctx = mlirOperationGetContext(op);
   MlirAttribute newSegSizesAttr = mlirDenseI32ArrayGet(ctx, numSegments, newSegSizes.data());

--- a/tools/llzk-tblgen/OpCAPIGen.cpp
+++ b/tools/llzk-tblgen/OpCAPIGen.cpp
@@ -418,7 +418,9 @@ MlirOperation {0}{1}_{2}Build(MlirOpBuilder builder, MlirLocation location{3}) {
   void genOperandGetterImpl(int index) const {
     static constexpr char fmt[] = R"(
 MlirValue {0}{1}_{2}Get{3}(MlirOperation op) {{
-  return mlirOperationGetOperand(op, {4});
+  auto range = llvm::cast<{2}>(unwrap(op)).getODSOperandIndexAndLength({4});
+  assert(range.second == 1 && "expected fixed operand segment size");
+  return mlirOperationGetOperand(op, static_cast<intptr_t>(range.first));
 }
 )";
     assert(!className.empty() && "className must be set");
@@ -436,7 +438,9 @@ MlirValue {0}{1}_{2}Get{3}(MlirOperation op) {{
   void genOperandSetterImpl(int index) const {
     static constexpr char fmt[] = R"(
 void {0}{1}_{2}Set{3}(MlirOperation op, MlirValue value) {{
-  mlirOperationSetOperand(op, {4}, value);
+  auto range = llvm::cast<{2}>(unwrap(op)).getODSOperandIndexAndLength({4});
+  assert(range.second == 1 && "expected fixed operand segment size");
+  mlirOperationSetOperand(op, static_cast<intptr_t>(range.first), value);
 }
 )";
     assert(!className.empty() && "className must be set");
@@ -451,16 +455,16 @@ void {0}{1}_{2}Set{3}(MlirOperation op, MlirValue value) {{
     );
   }
 
-  void genVariadicOperandGetterImpl(int startIdx) const {
+  void genVariadicOperandGetterImpl(int index) const {
     static constexpr char fmt[] = R"(
 intptr_t {0}{1}_{2}Get{3}Count(MlirOperation op) {{
-  intptr_t count = mlirOperationGetNumOperands(op);
-  assert(count >= {4} && "operand count less than start index");
-  return count - {4};
+  auto range = llvm::cast<{2}>(unwrap(op)).getODSOperandIndexAndLength({4});
+  return range.second;
 }
 
 MlirValue {0}{1}_{2}Get{3}At(MlirOperation op, intptr_t index) {{
-  return mlirOperationGetOperand(op, {4} + index);
+  auto range = llvm::cast<{2}>(unwrap(op)).getODSOperandIndexAndLength({4});
+  return mlirOperationGetOperand(op, static_cast<intptr_t>(range.first) + index);
 }
 )";
     assert(!className.empty() && "className must be set");
@@ -471,107 +475,22 @@ MlirValue {0}{1}_{2}Get{3}At(MlirOperation op, intptr_t index) {{
         dialectNameCapitalized, // {1}
         className,              // {2}
         operandNameCapitalized, // {3}
-        startIdx                // {4}
+        index                   // {4}
     );
   }
 
-  void genVariadicOperandSetterImpl(int startIdx) const {
+  void genVariadicOperandSetterImpl(int index, bool updateOperandSegmentSizes) const {
     static constexpr char fmt[] = R"(
 void {0}{1}_{2}Set{3}(MlirOperation op, intptr_t count, MlirValue const *values) {{
+  auto range = llvm::cast<{2}>(unwrap(op)).getODSOperandIndexAndLength({4});
   intptr_t numOperands = mlirOperationGetNumOperands(op);
-  intptr_t startIdx = {4};
+  intptr_t startIdx = static_cast<intptr_t>(range.first);
+  intptr_t oldCount = static_cast<intptr_t>(range.second);
 
   // Validate bounds
   if (startIdx < 0 || startIdx > numOperands) {{
     return;
   }
-  if (count < 0 || count > (std::numeric_limits<intptr_t>::max() - startIdx)) {{
-    return;
-  }
-
-  intptr_t oldCount = numOperands - startIdx;
-  intptr_t newNumOperands = startIdx + count;
-
-  std::vector<MlirValue> newOperands(newNumOperands);
-
-  // Copy operands before this variadic group
-  for (intptr_t i = 0; i < startIdx; ++i) {{
-    newOperands[i] = mlirOperationGetOperand(op, i);
-  }
-
-  // Copy new variadic operands
-  for (intptr_t i = 0; i < count; ++i) {{
-    newOperands[startIdx + i] = values[i];
-  }
-
-  // Copy operands after this variadic group
-  for (intptr_t i = startIdx + oldCount; i < numOperands; ++i) {{
-    newOperands[i - oldCount + count] = mlirOperationGetOperand(op, i);
-  }
-
-  mlirOperationSetOperands(op, newNumOperands, newOperands.data());
-}
-)";
-    assert(!className.empty() && "className must be set");
-    assert(!operandNameCapitalized.empty() && "operandName must be set");
-    os << llvm::formatv(
-        fmt,
-        FunctionPrefix,         // {0}
-        dialectNameCapitalized, // {1}
-        className,              // {2}
-        operandNameCapitalized, // {3}
-        startIdx                // {4}
-    );
-  }
-
-  /// Generate getter for a variadic operand whose start index must be determined at runtime by
-  /// consulting the `operandSegmentSizes` attribute (because another operand is also variadic).
-  void genVariadicOperandGetterImplDynamic(int segmentIdx) const {
-    static constexpr char fmt[] = R"(
-intptr_t {0}{1}_{2}Get{3}Count(MlirOperation op) {{
-  MlirAttribute segSizes = mlirOperationGetAttributeByName(op, mlirStringRefCreateFromCString("operandSegmentSizes"));
-  assert(!mlirAttributeIsNull(segSizes) && "expected operandSegmentSizes attribute");
-  assert(mlirAttributeIsADenseI32Array(segSizes) &&
-         "expected operandSegmentSizes to be a DenseI32ArrayAttr");
-  return mlirDenseI32ArrayGetElement(segSizes, {4});
-}
-
-MlirValue {0}{1}_{2}Get{3}At(MlirOperation op, intptr_t index) {{
-  MlirAttribute segSizes = mlirOperationGetAttributeByName(op, mlirStringRefCreateFromCString("operandSegmentSizes"));
-  assert(!mlirAttributeIsNull(segSizes) && "expected operandSegmentSizes attribute");
-  assert(mlirAttributeIsADenseI32Array(segSizes) &&
-         "expected operandSegmentSizes to be a DenseI32ArrayAttr");
-  intptr_t startIdx = 0;
-  for (int i = 0; i < {4}; ++i)
-    startIdx += mlirDenseI32ArrayGetElement(segSizes, i);
-  return mlirOperationGetOperand(op, startIdx + index);
-}
-)";
-    assert(!className.empty() && "className must be set");
-    assert(!operandNameCapitalized.empty() && "operandName must be set");
-    os << llvm::formatv(
-        fmt,
-        FunctionPrefix,         // {0}
-        dialectNameCapitalized, // {1}
-        className,              // {2}
-        operandNameCapitalized, // {3}
-        segmentIdx              // {4}
-    );
-  }
-
-  /// Generate setter for a variadic operand whose start index must be determined at runtime by
-  /// consulting the `operandSegmentSizes` attribute (because another operand is also variadic).
-  void genVariadicOperandSetterImplDynamic(int segmentIdx) const {
-    static constexpr char fmt[] = R"(
-void {0}{1}_{2}Set{3}(MlirOperation op, intptr_t count, MlirValue const *values) {{
-  MlirAttribute segSizes = mlirOperationGetAttributeByName(op, mlirStringRefCreateFromCString("operandSegmentSizes"));
-  intptr_t startIdx = 0;
-  for (int i = 0; i < {4}; ++i)
-    startIdx += mlirDenseI32ArrayGetElement(segSizes, i);
-  intptr_t numOperands = mlirOperationGetNumOperands(op);
-  intptr_t oldCount = mlirDenseI32ArrayGetElement(segSizes, {4});
-
-  // Validate bounds
   if (count < 0 || count > (std::numeric_limits<intptr_t>::max() - startIdx)) {{
     return;
   }
@@ -595,28 +514,42 @@ void {0}{1}_{2}Set{3}(MlirOperation op, intptr_t count, MlirValue const *values)
     newOperands[i - oldCount + count] = mlirOperationGetOperand(op, i);
   }
 
-  mlirOperationSetOperands(op, newNumOperands, newOperands.data());
-
-  // Update operandSegmentSizes to reflect the new count for this segment
-  intptr_t numSegments = mlirDenseArrayGetNumElements(segSizes);
-  std::vector<int32_t> newSegSizes(numSegments);
-  for (intptr_t i = 0; i < numSegments; ++i)
-    newSegSizes[i] = mlirDenseI32ArrayGetElement(segSizes, i);
-  newSegSizes[{4}] = static_cast<int32_t>(count);
-  MlirContext ctx = mlirOperationGetContext(op);
-  MlirAttribute newSegSizesAttr = mlirDenseI32ArrayGet(ctx, numSegments, newSegSizes.data());
-  mlirOperationSetAttributeByName(op, mlirStringRefCreateFromCString("operandSegmentSizes"), newSegSizesAttr);
+  mlirOperationSetOperands(op, newNumOperands, newOperands.data());{5}
 }
 )";
     assert(!className.empty() && "className must be set");
     assert(!operandNameCapitalized.empty() && "operandName must be set");
+    std::string updateSegmentSizes;
+    if (updateOperandSegmentSizes) {
+      llvm::raw_string_ostream updateOs(updateSegmentSizes);
+      updateOs << llvm::formatv(
+          R"(
+
+  // Update operandSegmentSizes to reflect the new count for this segment.
+  MlirAttribute segSizes = mlirOperationGetAttributeByName(op, mlirStringRefCreateFromCString("operandSegmentSizes"));
+  assert(!mlirAttributeIsNull(segSizes) && "expected operandSegmentSizes attribute");
+  assert(mlirAttributeIsADenseI32Array(segSizes) &&
+         "expected operandSegmentSizes to be a DenseI32ArrayAttr");
+  intptr_t numSegments = mlirDenseArrayGetNumElements(segSizes);
+  std::vector<int32_t> newSegSizes(numSegments);
+  for (intptr_t i = 0; i < numSegments; ++i)
+    newSegSizes[i] = mlirDenseI32ArrayGetElement(segSizes, i);
+  newSegSizes[{0}] = static_cast<int32_t>(count);
+  MlirContext ctx = mlirOperationGetContext(op);
+  MlirAttribute newSegSizesAttr = mlirDenseI32ArrayGet(ctx, numSegments, newSegSizes.data());
+  mlirOperationSetAttributeByName(op, mlirStringRefCreateFromCString("operandSegmentSizes"), newSegSizesAttr);
+)",
+          index
+      );
+    }
     os << llvm::formatv(
         fmt,
         FunctionPrefix,         // {0}
         dialectNameCapitalized, // {1}
         className,              // {2}
         operandNameCapitalized, // {3}
-        segmentIdx              // {4}
+        index,                  // {4}
+        updateSegmentSizes      // {5}
     );
   }
 
@@ -846,8 +779,8 @@ static bool emitOpCAPIImpl(const llvm::RecordKeeper &records, raw_ostream &os) {
       generator.genIsAImpl();
     }
 
-    // If the op has AttrSizedOperandSegments, each segment's count must be read from the
-    // `operandSegmentSizes` attribute at runtime rather than derived from total operand count.
+    // If the op has AttrSizedOperandSegments, variadic setters must keep the generated segment
+    // size metadata in sync after replacing the operand range.
     bool hasAttrSizedOperandSegments =
         op.getTrait("::mlir::OpTrait::AttrSizedOperandSegments") != nullptr;
 
@@ -857,18 +790,10 @@ static bool emitOpCAPIImpl(const llvm::RecordKeeper &records, raw_ostream &os) {
       generator.setOperandName(operand.name);
       if (operand.isVariadic()) {
         if (GenOpOperandGetters) {
-          if (hasAttrSizedOperandSegments) {
-            generator.genVariadicOperandGetterImplDynamic(i);
-          } else {
-            generator.genVariadicOperandGetterImpl(i);
-          }
+          generator.genVariadicOperandGetterImpl(i);
         }
         if (GenOpOperandSetters) {
-          if (hasAttrSizedOperandSegments) {
-            generator.genVariadicOperandSetterImplDynamic(i);
-          } else {
-            generator.genVariadicOperandSetterImpl(i);
-          }
+          generator.genVariadicOperandSetterImpl(i, hasAttrSizedOperandSegments);
         }
       } else {
         if (GenOpOperandGetters) {

--- a/unittests/CAPI/Dialect/Array.cpp
+++ b/unittests/CAPI/Dialect/Array.cpp
@@ -266,6 +266,67 @@ std::unique_ptr<WriteArrayOpBuildFuncHelper> WriteArrayOpBuildFuncHelper::get() 
   return std::make_unique<Impl>();
 }
 
+/// Regression test for ops with a fixed operand after a variadic operand segment.
+///
+/// `array.write` has operands laid out as:
+///   [arr_ref, indices..., rvalue]
+/// The C API accessors must use MLIR's generated ODS segment index/length logic so that `rvalue`
+/// is found after however many `indices` operands are present, not at the static ODS index 2.
+TEST_F(ArrayDialectTests, write_array_op_accessors_handle_fixed_operand_after_variadic_indices) {
+  MlirOpBuilder builder = mlirOpBuilderCreate(context);
+  MlirLocation location = mlirLocationUnknownGet(context);
+  auto eltType = createIndexType();
+
+  int64_t dims[2] = {1, 1};
+  auto arrType = test_array(eltType, llvm::ArrayRef(dims, 2));
+  auto arrState = mlirOperationStateGet(mlirStringRefCreateFromCString("array.new"), location);
+  mlirOperationStateAddResults(&arrState, 1, &arrType);
+  MlirOperation arrOp = mlirOperationCreate(&arrState);
+  ASSERT_NE(arrOp.ptr, nullptr);
+
+  auto auxOps = create_n_ops(5, eltType);
+  MlirValue indices[2] = {
+      mlirOperationGetResult(auxOps[0], 0),
+      mlirOperationGetResult(auxOps[1], 0),
+  };
+  MlirValue rvalue = mlirOperationGetResult(auxOps[2], 0);
+
+  MlirOperation op = llzkArray_WriteArrayOpBuild(
+      builder, location, mlirOperationGetResult(arrOp, 0), 2, indices, rvalue
+  );
+  ASSERT_NE(op.ptr, nullptr);
+
+  EXPECT_EQ(mlirOperationGetNumOperands(op), 4);
+  EXPECT_EQ(llzkArray_WriteArrayOpGetIndicesCount(op), 2);
+  EXPECT_EQ(llzkArray_WriteArrayOpGetIndicesAt(op, 0).ptr, indices[0].ptr);
+  EXPECT_EQ(llzkArray_WriteArrayOpGetIndicesAt(op, 1).ptr, indices[1].ptr);
+  EXPECT_EQ(llzkArray_WriteArrayOpGetRvalue(op).ptr, rvalue.ptr);
+
+  // Updating the fixed trailing operand should touch the physical operand after the variadic
+  // segment, not the static ODS index.
+  MlirValue newRvalue = mlirOperationGetResult(auxOps[4], 0);
+  llzkArray_WriteArrayOpSetRvalue(op, newRvalue);
+  EXPECT_EQ(llzkArray_WriteArrayOpGetIndicesAt(op, 1).ptr, indices[1].ptr);
+  EXPECT_EQ(llzkArray_WriteArrayOpGetRvalue(op).ptr, newRvalue.ptr);
+  EXPECT_EQ(mlirOperationGetOperand(op, 3).ptr, newRvalue.ptr);
+
+  // Resizing the variadic segment should keep the trailing fixed operand accessible at its new
+  // physical position.
+  MlirValue newIndices[1] = {mlirOperationGetResult(auxOps[3], 0)};
+  llzkArray_WriteArrayOpSetIndices(op, 1, newIndices);
+  EXPECT_EQ(mlirOperationGetNumOperands(op), 3);
+  EXPECT_EQ(llzkArray_WriteArrayOpGetIndicesCount(op), 1);
+  EXPECT_EQ(llzkArray_WriteArrayOpGetIndicesAt(op, 0).ptr, newIndices[0].ptr);
+  EXPECT_EQ(llzkArray_WriteArrayOpGetRvalue(op).ptr, newRvalue.ptr);
+
+  mlirOperationDestroy(op);
+  mlirOperationDestroy(arrOp);
+  for (auto auxOp : auxOps) {
+    mlirOperationDestroy(auxOp);
+  }
+  mlirOpBuilderDestroy(builder);
+}
+
 // Implementation for `InsertArrayOp_build_pass` test
 std::unique_ptr<InsertArrayOpBuildFuncHelper> InsertArrayOpBuildFuncHelper::get() {
   struct Impl : public InsertArrayOpBuildFuncHelper {


### PR DESCRIPTION
Followup to https://github.com/project-llzk/llzk-lib/pull/444. There was still a scenario where variadic operands were not accounted for correctly. This PR changes all operand getter/setter impls to use the `getODSOperandIndexAndLength` function generated by `mlir-tblgen` to correctly compute operand offsets.