### PR TITLE
Shankara/unreduced intervals pass

### DIFF
--- a/changelogs/unreleased/shankara__unreduced-intervals-pass.yaml
+++ b/changelogs/unreleased/shankara__unreduced-intervals-pass.yaml
@@ -1,0 +1,2 @@
+changed:
+  - Extending the interval analysis to track unreduced intervals.

--- a/include/llzk/Analysis/AnalysisPasses.td
+++ b/include/llzk/Analysis/AnalysisPasses.td
@@ -97,6 +97,10 @@ def IntervalAnalysisPrinterPass : LLZKPass<"llzk-print-interval-analysis"> {
               /* default */ "false",
               "Whether to print compute function intervals (default only "
               "prints constrain function intervals).">,
+       Option<"printUnreducedIntervals", "print-unreduced-intervals", "bool",
+              /* default */ "false",
+              "Whether to print tracked unreduced intervals alongside reduced "
+              "interval summaries.">,
   ];
 }
 

--- a/include/llzk/Analysis/AnalysisPasses.td
+++ b/include/llzk/Analysis/AnalysisPasses.td
@@ -101,6 +101,10 @@ def IntervalAnalysisPrinterPass : LLZKPass<"llzk-print-interval-analysis"> {
               /* default */ "false",
               "Whether to print tracked unreduced intervals alongside reduced "
               "interval summaries.">,
+       Option<"printSSAIntervals", "print-ssa-intervals", "bool",
+              /* default */ "false",
+              "Whether to print per-SSA intervals for function arguments and "
+              "scalar op results.">,
   ];
 }
 

--- a/include/llzk/Analysis/IntervalAnalysis.h
+++ b/include/llzk/Analysis/IntervalAnalysis.h
@@ -36,6 +36,7 @@
 
 #include <array>
 #include <mutex>
+#include <optional>
 
 namespace llzk {
 
@@ -46,22 +47,35 @@ namespace llzk {
 class ExpressionValue {
 public:
   /* Must be default initializable to be a ScalarLatticeValue. */
-  ExpressionValue() : i(), expr(nullptr) {}
+  ExpressionValue() : i(), expr(nullptr), unreduced(std::nullopt) {}
 
-  explicit ExpressionValue(const Field &f) : i(Interval::Entire(f)), expr(nullptr) {}
+  explicit ExpressionValue(const Field &f)
+      : i(Interval::Entire(f)), expr(nullptr), unreduced(std::nullopt) {}
 
   ExpressionValue(const Field &f, llvm::SMTExprRef exprRef)
-      : i(Interval::Entire(f)), expr(exprRef) {}
+      : i(Interval::Entire(f)), expr(exprRef), unreduced(std::nullopt) {}
 
   ExpressionValue(const Field &f, llvm::SMTExprRef exprRef, const llvm::DynamicAPInt &singleVal)
-      : i(Interval::Degenerate(f, singleVal)), expr(exprRef) {}
+      : i(Interval::Degenerate(f, singleVal)), expr(exprRef), unreduced(std::nullopt) {}
 
-  ExpressionValue(llvm::SMTExprRef exprRef, const Interval &interval)
-      : i(interval), expr(exprRef) {}
+  ExpressionValue(
+      llvm::SMTExprRef exprRef, const Interval &interval,
+      std::optional<UnreducedInterval> unreducedInterval = std::nullopt
+  )
+      : i(interval), expr(exprRef), unreduced(std::move(unreducedInterval)) {}
 
   llvm::SMTExprRef getExpr() const { return expr; }
 
   const Interval &getInterval() const { return i; }
+
+  bool hasUnreducedInterval() const { return unreduced.has_value(); }
+
+  const std::optional<UnreducedInterval> &getOptionalUnreducedInterval() const { return unreduced; }
+
+  const UnreducedInterval &getUnreducedInterval() const {
+    ensure(unreduced.has_value(), "unreduced interval not set");
+    return *unreduced;
+  }
 
   const Field &getField() const { return i.getField(); }
 
@@ -69,18 +83,30 @@ public:
   /// @param newInterval
   /// @return
   ExpressionValue withInterval(const Interval &newInterval) const {
-    return ExpressionValue(expr, newInterval);
+    return ExpressionValue(expr, newInterval, unreduced);
   }
 
   /// @brief Return the current expression with a new SMT expression.
   ExpressionValue withExpression(const llvm::SMTExprRef &newExpr) const {
-    return ExpressionValue(newExpr, i);
+    return ExpressionValue(newExpr, i, unreduced);
   }
+
+  ExpressionValue withUnreducedInterval(const UnreducedInterval &newUnreducedInterval) const {
+    return ExpressionValue(expr, i, newUnreducedInterval);
+  }
+
+  ExpressionValue
+  withOptionalUnreducedInterval(std::optional<UnreducedInterval> newUnreducedInterval) const {
+    return ExpressionValue(expr, i, std::move(newUnreducedInterval));
+  }
+
+  ExpressionValue dropUnreducedInterval() const { return ExpressionValue(expr, i, std::nullopt); }
 
   /* Required to be a ScalarLatticeValue. */
   /// @brief Fold two expressions together when overapproximating array elements.
   ExpressionValue &join(const ExpressionValue & /*rhs*/) {
     i = Interval::Entire(getField());
+    unreduced = std::nullopt;
     return *this;
   }
 
@@ -188,13 +214,16 @@ public:
 
   struct Hash {
     unsigned operator()(const ExpressionValue &e) const {
-      return Interval::Hash {}(e.i) ^ llvm::hash_value(e.expr);
+      return Interval::Hash {}(e.i) ^ llvm::hash_value(e.expr) ^
+             std::hash<bool> {}(e.unreduced.has_value()) ^
+             (e.unreduced.has_value() ? UnreducedInterval::Hash {}(*e.unreduced) : 0U);
     }
   };
 
 private:
   Interval i;
   llvm::SMTExprRef expr;
+  std::optional<UnreducedInterval> unreduced;
 };
 
 /* IntervalAnalysisLatticeValue */
@@ -267,10 +296,11 @@ class IntervalDataFlowAnalysis
 public:
   explicit IntervalDataFlowAnalysis(
       mlir::DataFlowSolver &dataflowSolver, llvm::SMTSolverRef smt, const Field &f,
-      bool propInputConstraints
+      bool propInputConstraints, bool trackUnreducedIntervals
   )
       : Base::SparseForwardDataFlowAnalysis(dataflowSolver), _dataflowSolver(dataflowSolver),
-        smtSolver(std::move(smt)), field(f), propagateInputConstraints(propInputConstraints) {}
+        smtSolver(std::move(smt)), field(f), propagateInputConstraints(propInputConstraints),
+        trackUnreducedIntervals(trackUnreducedIntervals) {}
 
   mlir::LogicalResult visitOperation(
       mlir::Operation *op, mlir::ArrayRef<const Lattice *> operands,
@@ -295,6 +325,7 @@ private:
   SymbolMap refSymbols;
   std::reference_wrapper<const Field> field;
   bool propagateInputConstraints;
+  bool trackUnreducedIntervals;
   mlir::SymbolTableCollection tables;
 
   // Track SourceRef-indexed reads so writes to rooted storage can update existing readers.
@@ -318,6 +349,10 @@ private:
     return isBooleanType(ty) ? Interval::Boolean(field.get()) : Interval::Entire(field.get());
   }
 
+  std::optional<UnreducedInterval> getDefaultUnreducedIntervalForType(mlir::Type ty) const;
+
+  std::optional<UnreducedInterval> getRefUnreducedInterval(const SourceRef &ref);
+
   llvm::SMTExprRef createSymbol(mlir::Type ty, const char *name) const;
 
   llvm::SMTExprRef createSymbol(const SourceRef &r) const;
@@ -325,7 +360,10 @@ private:
   llvm::SMTExprRef createSymbol(mlir::Value val) const;
 
   ExpressionValue createUnknownValue(mlir::Value val) const {
-    return ExpressionValue(createSymbol(val), getDefaultIntervalForType(val.getType()));
+    return ExpressionValue(
+        createSymbol(val), getDefaultIntervalForType(val.getType()),
+        getDefaultUnreducedIntervalForType(val.getType())
+    );
   }
 
   inline bool isConstOp(mlir::Operation *op) const {
@@ -427,7 +465,8 @@ struct IntervalAnalysisContext {
   IntervalDataFlowAnalysis *intervalDFA;
   llvm::SMTSolverRef smtSolver;
   std::optional<std::reference_wrapper<const Field>> field;
-  bool propagateInputConstraints;
+  bool propagateInputConstraints = false;
+  bool trackUnreducedIntervals = false;
 
   llvm::SMTExprRef getSymbol(const SourceRef &r) const { return intervalDFA->getOrCreateSymbol(r); }
   bool hasField() const { return field.has_value(); }
@@ -436,6 +475,7 @@ struct IntervalAnalysisContext {
     return field->get();
   }
   bool doInputConstraintPropagation() const { return propagateInputConstraints; }
+  bool doTrackUnreducedIntervals() const { return trackUnreducedIntervals; }
 
   friend bool
   operator==(const IntervalAnalysisContext &a, const IntervalAnalysisContext &b) = default;
@@ -449,7 +489,8 @@ template <> struct std::hash<llzk::IntervalAnalysisContext> {
         std::hash<const llzk::IntervalDataFlowAnalysis *> {}(c.intervalDFA),
         std::hash<const llvm::SMTSolver *> {}(c.smtSolver.get()),
         std::hash<const llzk::Field *> {}(&c.getField()),
-        std::hash<bool> {}(c.propagateInputConstraints)
+        std::hash<bool> {}(c.propagateInputConstraints),
+        std::hash<bool> {}(c.trackUnreducedIntervals)
     );
   }
 };
@@ -483,10 +524,17 @@ public:
   mlir::LogicalResult
   computeIntervals(mlir::DataFlowSolver &solver, const IntervalAnalysisContext &ctx);
 
-  void print(mlir::raw_ostream &os, bool withConstraints = false, bool printCompute = false) const;
+  void print(
+      mlir::raw_ostream &os, bool withConstraints = false, bool printCompute = false,
+      bool printUnreduced = false
+  ) const;
 
   const llvm::MapVector<SourceRef, Interval> &getConstrainIntervals() const {
     return constrainMemberRanges;
+  }
+
+  const llvm::MapVector<SourceRef, UnreducedInterval> &getConstrainUnreducedIntervals() const {
+    return constrainMemberUnreducedRanges;
   }
 
   const llvm::SetVector<ExpressionValue> getConstrainSolverConstraints() const {
@@ -495,6 +543,10 @@ public:
 
   const llvm::MapVector<SourceRef, Interval> &getComputeIntervals() const {
     return computeMemberRanges;
+  }
+
+  const llvm::MapVector<SourceRef, UnreducedInterval> &getComputeUnreducedIntervals() const {
+    return computeMemberUnreducedRanges;
   }
 
   const llvm::SetVector<ExpressionValue> getComputeSolverConstraints() const {
@@ -512,6 +564,8 @@ private:
   llvm::SMTSolverRef smtSolver;
   // llvm::MapVector keeps insertion order for consistent iteration
   llvm::MapVector<SourceRef, Interval> constrainMemberRanges, computeMemberRanges;
+  llvm::MapVector<SourceRef, UnreducedInterval> constrainMemberUnreducedRanges,
+      computeMemberUnreducedRanges;
   // llvm::SetVector for the same reasons as above
   llvm::SetVector<ExpressionValue> constrainSolverConstraints, computeSolverConstraints;
 
@@ -554,6 +608,7 @@ public:
 
   void setField(const Field &f) { ctx.field = f; }
   void setPropagateInputConstraints(bool prop) { ctx.propagateInputConstraints = prop; }
+  void setTrackUnreducedIntervals(bool track) { ctx.trackUnreducedIntervals = track; }
 
 protected:
   void initializeSolver() override {
@@ -561,10 +616,12 @@ protected:
     (void)solver.load<SourceRefAnalysis>();
     auto smtSolverRef = ctx.smtSolver;
     bool prop = ctx.propagateInputConstraints;
+    bool track = ctx.trackUnreducedIntervals;
     ctx.intervalDFA =
-        solver.load<IntervalDataFlowAnalysis, llvm::SMTSolverRef, const Field &, bool>(
+        solver.load<IntervalDataFlowAnalysis, llvm::SMTSolverRef, const Field &, bool, bool>(
             std::move(smtSolverRef), ctx.getField(),
-            std::move(prop) // NOLINT(performance-move-const-arg)
+            std::move(prop), // NOLINT(performance-move-const-arg)
+            std::move(track) // NOLINT(performance-move-const-arg)
         );
   }
 

--- a/include/llzk/Analysis/IntervalAnalysis.h
+++ b/include/llzk/Analysis/IntervalAnalysis.h
@@ -296,11 +296,11 @@ class IntervalDataFlowAnalysis
 public:
   explicit IntervalDataFlowAnalysis(
       mlir::DataFlowSolver &dataflowSolver, llvm::SMTSolverRef smt, const Field &f,
-      bool propInputConstraints, bool trackUnreducedIntervals
+      bool propInputConstraints, bool shouldTrackUnreducedIntervals
   )
       : Base::SparseForwardDataFlowAnalysis(dataflowSolver), _dataflowSolver(dataflowSolver),
         smtSolver(std::move(smt)), field(f), propagateInputConstraints(propInputConstraints),
-        trackUnreducedIntervals(trackUnreducedIntervals) {}
+        trackUnreducedIntervals(shouldTrackUnreducedIntervals) {}
 
   mlir::LogicalResult visitOperation(
       mlir::Operation *op, mlir::ArrayRef<const Lattice *> operands,

--- a/include/llzk/Analysis/Intervals.h
+++ b/include/llzk/Analysis/Intervals.h
@@ -102,7 +102,13 @@ public:
     return std::is_eq(lhs <=> rhs);
   };
 
-  /* Utility */
+  /* Utility for hashing unreduced intervals */
+  struct Hash {
+    unsigned operator()(const UnreducedInterval &ui) const {
+      return llvm::hash_value(ui.a) ^ llvm::hash_value(ui.b);
+    }
+  };
+
   llvm::DynamicAPInt getLHS() const { return a; }
   llvm::DynamicAPInt getRHS() const { return b; }
 

--- a/lib/Analysis/IntervalAnalysis.cpp
+++ b/lib/Analysis/IntervalAnalysis.cpp
@@ -19,6 +19,8 @@
 
 #include <llvm/ADT/TypeSwitch.h>
 
+#include <functional>
+
 using namespace mlir;
 
 namespace llzk {
@@ -30,6 +32,41 @@ using namespace component;
 using namespace constrain;
 using namespace felt;
 using namespace function;
+
+namespace {
+
+std::optional<UnreducedInterval> mergeUnreducedIntervals(
+    const std::optional<UnreducedInterval> &lhs, const std::optional<UnreducedInterval> &rhs
+) {
+  if (!lhs.has_value() || !rhs.has_value()) {
+    return std::nullopt;
+  }
+  return lhs->doUnion(*rhs);
+}
+
+template <typename Fn>
+std::optional<UnreducedInterval>
+combineUnreducedIntervals(const ExpressionValue &lhs, const ExpressionValue &rhs, Fn &&fn) {
+  if (!lhs.hasUnreducedInterval() || !rhs.hasUnreducedInterval()) {
+    return std::nullopt;
+  }
+  return fn(lhs.getUnreducedInterval(), rhs.getUnreducedInterval());
+}
+
+ExpressionValue refineReducedInterval(const ExpressionValue &expr, const Interval &newInterval) {
+  ExpressionValue refined = expr.withInterval(newInterval);
+  if (expr.getInterval() != newInterval) {
+    refined = refined.dropUnreducedInterval();
+  }
+  return refined;
+}
+
+std::optional<UnreducedInterval> getBooleanUnreducedInterval(const Interval &interval) {
+  return interval.isBoolean() ? std::optional<UnreducedInterval>(interval.firstUnreduced())
+                              : std::nullopt;
+}
+
+} // namespace
 
 /* ExpressionValue */
 
@@ -63,12 +100,12 @@ llvm::SMTExprRef createFieldInverseExpr(
 
 bool ExpressionValue::operator==(const ExpressionValue &rhs) const {
   if (expr == nullptr && rhs.expr == nullptr) {
-    return i == rhs.i;
+    return i == rhs.i && unreduced == rhs.unreduced;
   }
   if (expr == nullptr || rhs.expr == nullptr) {
     return false;
   }
-  return i == rhs.i && *expr == *rhs.expr;
+  return i == rhs.i && unreduced == rhs.unreduced && *expr == *rhs.expr;
 }
 
 ExpressionValue
@@ -97,7 +134,19 @@ ExpressionValue selectValue(
   }
   llvm::SMTExprRef resultExpr =
       solver->mkIte(cond.getExpr(), trueVal.getExpr(), falseVal.getExpr());
-  return ExpressionValue(resultExpr, resultInterval);
+  std::optional<UnreducedInterval> resultUnreduced;
+  if (condInterval.isEmpty()) {
+    resultUnreduced = resultInterval.firstUnreduced();
+  } else if (condInterval.isDegenerate() && condInterval.rhs() == f.one()) {
+    resultUnreduced = trueVal.getOptionalUnreducedInterval();
+  } else if (condInterval.isDegenerate() && condInterval.rhs() == f.zero()) {
+    resultUnreduced = falseVal.getOptionalUnreducedInterval();
+  } else {
+    resultUnreduced = mergeUnreducedIntervals(
+        trueVal.getOptionalUnreducedInterval(), falseVal.getOptionalUnreducedInterval()
+    );
+  }
+  return ExpressionValue(resultExpr, resultInterval, std::move(resultUnreduced));
 }
 
 ExpressionValue intersection(
@@ -113,6 +162,7 @@ add(const llvm::SMTSolverRef &solver, const ExpressionValue &lhs, const Expressi
   ExpressionValue res;
   res.i = lhs.i + rhs.i;
   res.expr = solver->mkBVAdd(lhs.expr, rhs.expr);
+  res = res.withOptionalUnreducedInterval(combineUnreducedIntervals(lhs, rhs, std::plus {}));
   return res;
 }
 
@@ -121,6 +171,7 @@ sub(const llvm::SMTSolverRef &solver, const ExpressionValue &lhs, const Expressi
   ExpressionValue res;
   res.i = lhs.i - rhs.i;
   res.expr = solver->mkBVSub(lhs.expr, rhs.expr);
+  res = res.withOptionalUnreducedInterval(combineUnreducedIntervals(lhs, rhs, std::minus {}));
   return res;
 }
 
@@ -129,6 +180,7 @@ mul(const llvm::SMTSolverRef &solver, const ExpressionValue &lhs, const Expressi
   ExpressionValue res;
   res.i = lhs.i * rhs.i;
   res.expr = solver->mkBVMul(lhs.expr, rhs.expr);
+  res = res.withOptionalUnreducedInterval(combineUnreducedIntervals(lhs, rhs, std::multiplies {}));
   return res;
 }
 
@@ -327,6 +379,7 @@ cmp(const llvm::SMTSolverRef &solver, CmpOp op, const ExpressionValue &lhs,
     }
     break;
   }
+  res = res.withOptionalUnreducedInterval(getBooleanUnreducedInterval(res.i));
   return res;
 }
 
@@ -335,6 +388,7 @@ boolAnd(const llvm::SMTSolverRef &solver, const ExpressionValue &lhs, const Expr
   ExpressionValue res;
   res.i = boolAnd(lhs.i, rhs.i);
   res.expr = solver->mkAnd(lhs.expr, rhs.expr);
+  res = res.withOptionalUnreducedInterval(getBooleanUnreducedInterval(res.i));
   return res;
 }
 
@@ -343,6 +397,7 @@ boolOr(const llvm::SMTSolverRef &solver, const ExpressionValue &lhs, const Expre
   ExpressionValue res;
   res.i = boolOr(lhs.i, rhs.i);
   res.expr = solver->mkOr(lhs.expr, rhs.expr);
+  res = res.withOptionalUnreducedInterval(getBooleanUnreducedInterval(res.i));
   return res;
 }
 
@@ -354,6 +409,7 @@ boolXor(const llvm::SMTSolverRef &solver, const ExpressionValue &lhs, const Expr
   res.expr = solver->mkAnd(
       solver->mkOr(lhs.expr, rhs.expr), solver->mkNot(solver->mkAnd(lhs.expr, rhs.expr))
   );
+  res = res.withOptionalUnreducedInterval(getBooleanUnreducedInterval(res.i));
   return res;
 }
 
@@ -361,6 +417,9 @@ ExpressionValue neg(const llvm::SMTSolverRef &solver, const ExpressionValue &val
   ExpressionValue res;
   res.i = -val.i;
   res.expr = solver->mkBVNeg(val.expr);
+  if (val.hasUnreducedInterval()) {
+    res = res.withUnreducedInterval(-val.getUnreducedInterval());
+  }
   return res;
 }
 
@@ -375,6 +434,7 @@ ExpressionValue boolNot(const llvm::SMTSolverRef &solver, const ExpressionValue 
   ExpressionValue res;
   res.i = boolNot(val.i);
   res.expr = solver->mkNot(val.expr);
+  res = res.withOptionalUnreducedInterval(getBooleanUnreducedInterval(res.i));
   return res;
 }
 
@@ -404,6 +464,9 @@ void ExpressionValue::print(mlir::raw_ostream &os) const {
   }
 
   os << " ( interval: " << i << " )";
+  if (unreduced.has_value()) {
+    os << " ( unreduced: " << *unreduced << " )";
+  }
 }
 
 /* IntervalAnalysisLattice */
@@ -515,11 +578,54 @@ Interval IntervalDataFlowAnalysis::getRefInterval(const SourceRef &ref) {
   return getDefaultIntervalForType(ref.getType());
 }
 
+std::optional<UnreducedInterval>
+IntervalDataFlowAnalysis::getDefaultUnreducedIntervalForType(mlir::Type ty) const {
+  if (!trackUnreducedIntervals) {
+    return std::nullopt;
+  }
+  if (isBooleanType(ty)) {
+    return UnreducedInterval(0, 1);
+  }
+  return UnreducedInterval(field.get().zero(), field.get().maxVal());
+}
+
+std::optional<UnreducedInterval>
+IntervalDataFlowAnalysis::getRefUnreducedInterval(const SourceRef &ref) {
+  if (!trackUnreducedIntervals) {
+    return std::nullopt;
+  }
+
+  if (auto it = writeResults.find(ref); it != writeResults.end()) {
+    return it->second.getOptionalUnreducedInterval();
+  }
+
+  if (ref.isConstantInt()) {
+    auto constVal = ref.getConstantValue();
+    if (succeeded(constVal)) {
+      return UnreducedInterval(*constVal, *constVal);
+    }
+  }
+
+  if (ref.isRooted() && ref.getPath().empty()) {
+    auto rootVal = ref.getRoot();
+    if (succeeded(rootVal) && !llvm::isa<ArrayType, StructType>(rootVal->getType())) {
+      const ExpressionValue &rootExpr = getLatticeElement(*rootVal)->getValue().getScalarValue();
+      if (rootExpr.hasUnreducedInterval()) {
+        return rootExpr.getUnreducedInterval();
+      }
+    }
+  }
+
+  return getRefInterval(ref).firstUnreduced();
+}
+
 ExpressionValue IntervalDataFlowAnalysis::getRefValue(const SourceRef &ref, Value val) {
   if (auto it = writeResults.find(ref); it != writeResults.end()) {
     return it->second;
   }
-  return createUnknownValue(val).withInterval(getRefInterval(ref));
+  return createUnknownValue(val)
+      .withInterval(getRefInterval(ref))
+      .withOptionalUnreducedInterval(getRefUnreducedInterval(ref));
 }
 
 void IntervalDataFlowAnalysis::recordRefWrite(
@@ -530,12 +636,16 @@ void IntervalDataFlowAnalysis::recordRefWrite(
   if (auto it = writeResults.find(writtenRef); it != writeResults.end()) {
     const ExpressionValue &old = it->second;
     Interval combinedWrite = old.getInterval().join(written.getInterval());
+    auto combinedUnreduced = mergeUnreducedIntervals(
+        old.getOptionalUnreducedInterval(), written.getOptionalUnreducedInterval()
+    );
     if (old.getExpr() != nullptr && written.getExpr() != nullptr &&
         *old.getExpr() == *written.getExpr()) {
-      writeResults[writtenRef] = old.withInterval(combinedWrite);
+      writeResults[writtenRef] =
+          old.withInterval(combinedWrite).withOptionalUnreducedInterval(combinedUnreduced);
     } else {
       llvm::SMTExprRef expr = getOrCreateSymbol(writtenRef);
-      writeResults[writtenRef] = ExpressionValue(expr, combinedWrite);
+      writeResults[writtenRef] = ExpressionValue(expr, combinedWrite, std::move(combinedUnreduced));
     }
   } else {
     writeResults[writtenRef] = written;
@@ -544,7 +654,7 @@ void IntervalDataFlowAnalysis::recordRefWrite(
   for (Lattice *readerLattice : readResults[writtenRef]) {
     ExpressionValue prior = readerLattice->getValue().getScalarValue();
     Interval intersection = prior.getInterval().intersect(written.getInterval());
-    ExpressionValue newVal = prior.withInterval(intersection);
+    ExpressionValue newVal = refineReducedInterval(prior, intersection);
     propagateIfChanged(readerLattice, readerLattice->setValue(newVal));
   }
 }
@@ -647,6 +757,9 @@ mlir::LogicalResult IntervalDataFlowAnalysis::visitOperation(
     }
 
     ExpressionValue latticeVal(field.get(), expr, constVal);
+    if (trackUnreducedIntervals) {
+      latticeVal = latticeVal.withUnreducedInterval(UnreducedInterval(constVal, constVal));
+    }
     propagateIfChanged(results[0], results[0]->setValue(latticeVal));
   } else if (isArithmeticOp(op)) {
     ExpressionValue result;
@@ -659,7 +772,7 @@ mlir::LogicalResult IntervalDataFlowAnalysis::visitOperation(
     // Also intersect with prior interval, if it's initialized
     const ExpressionValue &prior = results[0]->getValue().getScalarValue();
     if (prior.getExpr()) {
-      result = result.withInterval(result.getInterval().intersect(prior.getInterval()));
+      result = refineReducedInterval(result, result.getInterval().intersect(prior.getInterval()));
     }
     propagateIfChanged(results[0], results[0]->setValue(result));
   } else if (auto selectOp = llvm::dyn_cast<arith::SelectOp>(op)) {
@@ -669,7 +782,7 @@ mlir::LogicalResult IntervalDataFlowAnalysis::visitOperation(
     );
     const ExpressionValue &prior = results[0]->getValue().getScalarValue();
     if (prior.getExpr()) {
-      result = result.withInterval(result.getInterval().intersect(prior.getInterval()));
+      result = refineReducedInterval(result, result.getInterval().intersect(prior.getInterval()));
     }
     propagateIfChanged(results[0], results[0]->setValue(result));
   } else if (EmitEqualityOp emitEq = llvm::dyn_cast<EmitEqualityOp>(op)) {
@@ -823,9 +936,16 @@ mlir::LogicalResult IntervalDataFlowAnalysis::visitOperation(
         newResVal = ExpressionValue(createSymbol(parentRes), Interval::Entire(field.get()));
       }
       if (exprVal.getExpr() != nullptr) {
-        newResVal = exprVal.withInterval(exprVal.getInterval().join(newResVal.getInterval()));
+        newResVal =
+            exprVal.withInterval(exprVal.getInterval().join(newResVal.getInterval()))
+                .withOptionalUnreducedInterval(mergeUnreducedIntervals(
+                    exprVal.getOptionalUnreducedInterval(), newResVal.getOptionalUnreducedInterval()
+                ));
       } else {
-        newResVal = ExpressionValue(createSymbol(parentRes), newResVal.getInterval());
+        newResVal = ExpressionValue(
+            createSymbol(parentRes), newResVal.getInterval(),
+            newResVal.getOptionalUnreducedInterval()
+        );
       }
       propagateIfChanged(resLattice, resLattice->setValue(newResVal));
     }
@@ -975,7 +1095,7 @@ void IntervalDataFlowAnalysis::applyInterval(Operation *valUser, Value val, Inte
   ExpressionValue oldLatticeVal = valLattice->getValue().getScalarValue();
   // Intersect with the current value to accumulate restrictions across constraints.
   Interval intersection = oldLatticeVal.getInterval().intersect(newInterval);
-  ExpressionValue newLatticeVal = oldLatticeVal.withInterval(intersection);
+  ExpressionValue newLatticeVal = refineReducedInterval(oldLatticeVal, intersection);
   ChangeResult changed = valLattice->setValue(newLatticeVal);
 
   if (auto blockArg = llvm::dyn_cast<BlockArgument>(val)) {
@@ -990,7 +1110,11 @@ void IntervalDataFlowAnalysis::applyInterval(Operation *valUser, Value val, Inte
       Lattice *computeEntryLattice = getLatticeElement(computeArg);
 
       SourceRef ref(computeArg);
-      ExpressionValue newArgVal(getOrCreateSymbol(ref), newInterval);
+      ExpressionValue newArgVal(
+          getOrCreateSymbol(ref), newInterval,
+          trackUnreducedIntervals ? std::optional<UnreducedInterval>(newInterval.firstUnreduced())
+                                  : std::nullopt
+      );
       propagateIfChanged(computeEntryLattice, computeEntryLattice->setValue(newArgVal));
     }
   }
@@ -1386,8 +1510,14 @@ LogicalResult StructIntervals::computeIntervals(
 
   auto computeIntervalsImpl = [&solver, &ctx, this](
                                   FuncDefOp fn, llvm::MapVector<SourceRef, Interval> &memberRanges,
+                                  llvm::MapVector<SourceRef, UnreducedInterval> &memberUnreducedRanges,
                                   llvm::SetVector<ExpressionValue> & /*solverConstraints*/
                               ) {
+    auto setUnreducedRange =
+        [&memberUnreducedRanges](const SourceRef &ref, const UnreducedInterval &interval) {
+          memberUnreducedRanges.erase(ref);
+          memberUnreducedRanges.insert({ref, interval});
+        };
     // Since every lattice value does not contain every value, we will traverse
     // the function backwards (from most up-to-date to least-up-to-date lattices)
     // searching for the source refs. Once a source ref is found, we remove it
@@ -1411,8 +1541,14 @@ LogicalResult StructIntervals::computeIntervals(
         ExpressionValue expr = lattice->getValue().getScalarValue();
         if (!expr.getExpr()) {
           expr = expr.withInterval(Interval::Entire(ctx.getField()));
+          if (ctx.doTrackUnreducedIntervals()) {
+            expr = expr.withUnreducedInterval(expr.getInterval().firstUnreduced());
+          }
         }
         memberRanges[ref] = expr.getInterval();
+        if (expr.hasUnreducedInterval()) {
+          setUnreducedRange(ref, expr.getUnreducedInterval());
+        }
         assert(memberRanges[ref].getField() == ctx.getField() && "bad interval defaults");
       }
     }
@@ -1423,10 +1559,23 @@ LogicalResult StructIntervals::computeIntervals(
     for (const auto &[ref, lattices] : ctx.intervalDFA->getReadResults()) {
       if (!lattices.empty() && searchSet.erase(ref)) {
         Interval joinedInterval = Interval::Empty(ctx.getField());
+        std::optional<UnreducedInterval> joinedUnreduced = std::nullopt;
+        bool sawFirst = false;
         for (const IntervalAnalysisLattice *lattice : lattices) {
-          joinedInterval = joinedInterval.join(lattice->getValue().getScalarValue().getInterval());
+          const ExpressionValue &expr = lattice->getValue().getScalarValue();
+          joinedInterval = joinedInterval.join(expr.getInterval());
+          if (!sawFirst) {
+            joinedUnreduced = expr.getOptionalUnreducedInterval();
+            sawFirst = true;
+          } else {
+            joinedUnreduced =
+                mergeUnreducedIntervals(joinedUnreduced, expr.getOptionalUnreducedInterval());
+          }
         }
         memberRanges[ref] = joinedInterval;
+        if (joinedUnreduced.has_value()) {
+          setUnreducedRange(ref, *joinedUnreduced);
+        }
         assert(memberRanges[ref].getField() == ctx.getField() && "bad interval defaults");
       }
     }
@@ -1434,6 +1583,9 @@ LogicalResult StructIntervals::computeIntervals(
     for (const auto &[ref, val] : ctx.intervalDFA->getWriteResults()) {
       if (searchSet.erase(ref)) {
         memberRanges[ref] = val.getInterval();
+        if (val.hasUnreducedInterval()) {
+          setUnreducedRange(ref, val.getUnreducedInterval());
+        }
         assert(memberRanges[ref].getField() == ctx.getField() && "bad interval defaults");
       }
     }
@@ -1441,6 +1593,9 @@ LogicalResult StructIntervals::computeIntervals(
     // For all unfound refs, default to the entire range.
     for (const auto &ref : searchSet) {
       memberRanges[ref] = Interval::Entire(ctx.getField());
+      if (ctx.doTrackUnreducedIntervals()) {
+        setUnreducedRange(ref, memberRanges[ref].firstUnreduced());
+      }
     }
 
     // Sort the outputs since we assembled things out of order.
@@ -1454,24 +1609,43 @@ LogicalResult StructIntervals::computeIntervals(
       sortedRanges.emplace_back(ref, interval);
     }
     llvm::sort(sortedRanges, [](const auto &a, const auto &b) { return a.first < b.first; });
+    llvm::SmallVector<std::pair<SourceRef, UnreducedInterval>> sortedUnreducedRanges;
+    sortedUnreducedRanges.reserve(memberUnreducedRanges.size());
+    for (const auto &[ref, interval] : memberUnreducedRanges) {
+      sortedUnreducedRanges.emplace_back(ref, interval);
+    }
+    llvm::sort(
+        sortedUnreducedRanges, [](const auto &a, const auto &b) { return a.first < b.first; }
+    );
     memberRanges.clear();
+    memberUnreducedRanges.clear();
     for (auto &[ref, interval] : sortedRanges) {
       memberRanges[ref] = interval;
     }
+    for (auto &[ref, interval] : sortedUnreducedRanges) {
+      memberUnreducedRanges.insert({ref, interval});
+    }
   };
 
-  computeIntervalsImpl(structDef.getComputeFuncOp(), computeMemberRanges, computeSolverConstraints);
   computeIntervalsImpl(
-      structDef.getConstrainFuncOp(), constrainMemberRanges, constrainSolverConstraints
+      structDef.getComputeFuncOp(), computeMemberRanges, computeMemberUnreducedRanges,
+      computeSolverConstraints
+  );
+  computeIntervalsImpl(
+      structDef.getConstrainFuncOp(), constrainMemberRanges, constrainMemberUnreducedRanges,
+      constrainSolverConstraints
   );
 
   return success();
 }
 
-void StructIntervals::print(mlir::raw_ostream &os, bool withConstraints, bool printCompute) const {
+void StructIntervals::print(
+    mlir::raw_ostream &os, bool withConstraints, bool printCompute, bool printUnreduced
+) const {
   auto writeIntervals =
-      [&os, &withConstraints](
+      [&os, &withConstraints, &printUnreduced](
           const char *fnName, const llvm::MapVector<SourceRef, Interval> &memberRanges,
+          const llvm::MapVector<SourceRef, UnreducedInterval> &memberUnreducedRanges,
           const llvm::SetVector<ExpressionValue> &solverConstraints, bool printName
       ) {
     int indent = 4;
@@ -1489,6 +1663,11 @@ void StructIntervals::print(mlir::raw_ostream &os, bool withConstraints, bool pr
     for (const auto &[ref, interval] : memberRanges) {
       os << '\n';
       os.indent(indent) << ref << " in " << interval;
+      if (printUnreduced) {
+        if (auto it = memberUnreducedRanges.find(ref); it != memberUnreducedRanges.end()) {
+          os << " ( unreduced: " << it->second << " )";
+        }
+      }
     }
 
     if (withConstraints) {
@@ -1520,10 +1699,14 @@ void StructIntervals::print(mlir::raw_ostream &os, bool withConstraints, bool pr
   }
 
   if (printCompute) {
-    writeIntervals(FUNC_NAME_COMPUTE, computeMemberRanges, computeSolverConstraints, printCompute);
+    writeIntervals(
+        FUNC_NAME_COMPUTE, computeMemberRanges, computeMemberUnreducedRanges,
+        computeSolverConstraints, printCompute
+    );
   }
   writeIntervals(
-      FUNC_NAME_CONSTRAIN, constrainMemberRanges, constrainSolverConstraints, printCompute
+      FUNC_NAME_CONSTRAIN, constrainMemberRanges, constrainMemberUnreducedRanges,
+      constrainSolverConstraints, printCompute
   );
 
   os << "\n}\n";

--- a/lib/Analysis/IntervalAnalysis.cpp
+++ b/lib/Analysis/IntervalAnalysis.cpp
@@ -641,9 +641,13 @@ void IntervalDataFlowAnalysis::recordRefWrite(
   if (auto it = writeResults.find(writtenRef); it != writeResults.end()) {
     const ExpressionValue &old = it->second;
     Interval combinedWrite = old.getInterval().join(writeVal.getInterval());
+    auto combinedUnreduced = mergeUnreducedIntervals(
+        old.getOptionalUnreducedInterval(), writeVal.getOptionalUnreducedInterval()
+    );
     if (old.getExpr() != nullptr && writeVal.getExpr() != nullptr &&
         *old.getExpr() == *writeVal.getExpr()) {
-      writeResults[writtenRef] = old.withInterval(combinedWrite);
+      writeResults[writtenRef] =
+          old.withInterval(combinedWrite).withOptionalUnreducedInterval(combinedUnreduced);
     } else {
       llvm::SMTExprRef expr = getOrCreateSymbol(writtenRef);
       writeResults[writtenRef] = ExpressionValue(expr, combinedWrite, std::move(combinedUnreduced));

--- a/lib/Analysis/IntervalAnalysis.cpp
+++ b/lib/Analysis/IntervalAnalysis.cpp
@@ -418,7 +418,7 @@ ExpressionValue neg(const llvm::SMTSolverRef &solver, const ExpressionValue &val
   res.i = -val.i;
   res.expr = solver->mkBVNeg(val.expr);
   if (val.hasUnreducedInterval()) {
-    res = res.withUnreducedInterval(-val.getUnreducedInterval());
+    res = res.withOptionalUnreducedInterval(-val.getUnreducedInterval());
   }
   return res;
 }
@@ -454,7 +454,10 @@ fallbackUnaryOp(const llvm::SMTSolverRef &solver, Operation *op, const Expressio
   });
 
   if (llvm::isa<InvFeltOp>(op)) {
-    res = res.withUnreducedInterval(UnreducedInterval(field.zero(), field.maxVal()));
+    // We have the inverse's unreduced range to be [0, p-1] because for any integer z we can always
+    // choose a conical element x \in [0, p-1] such that 1) (z * x) %p = 0 if z = 0, 2) (z * x) % p
+    // = 1
+    res = res.withOptionalUnreducedInterval(UnreducedInterval(field.zero(), field.maxVal()));
   }
 
   return res;
@@ -1702,7 +1705,7 @@ void StructIntervals::print(
       os.indent(indent) << ref << " in " << interval;
       if (printUnreduced) {
         if (auto it = memberUnreducedRanges.find(ref); it != memberUnreducedRanges.end()) {
-          os << " ( unreduced: " << it->second << " )";
+          os << " ( " << it->second << " )";
         }
       }
     }

--- a/lib/Analysis/IntervalAnalysis.cpp
+++ b/lib/Analysis/IntervalAnalysis.cpp
@@ -453,6 +453,10 @@ fallbackUnaryOp(const llvm::SMTSolverRef &solver, Operation *op, const Expressio
     return nullptr;
   });
 
+  if (llvm::isa<InvFeltOp>(op)) {
+    res = res.withUnreducedInterval(UnreducedInterval(field.zero(), field.maxVal()));
+  }
+
   return res;
 }
 
@@ -676,6 +680,45 @@ mlir::LogicalResult IntervalDataFlowAnalysis::visitOperation(
   // Get the values or defaults from the operand lattices
   llvm::SmallVector<LatticeValue> operandVals;
   llvm::SmallVector<std::optional<SourceRef>> operandRefs;
+  auto resolveRefStateValue =
+      [&](Value value, const SourceRefLatticeValue &refSet) -> std::optional<LatticeValue> {
+    ensure(refSet.isScalar(), "should have ruled out array values already");
+
+    if (refSet.getScalarValue().empty()) {
+      // If we can't compute the reference, then there must be some unsupported
+      // op the reference analysis cannot handle. We emit a warning and return
+      // early, since there's no meaningful computation we can do for this op.
+      op->emitWarning()
+          .append(
+              "state of ", value,
+              " is empty; defining operation is unsupported by SourceRef analysis"
+          )
+          .report();
+      return std::nullopt;
+    }
+
+    if (!refSet.isSingleValue()) {
+      Interval joinedInterval = Interval::Empty(field.get());
+      std::optional<UnreducedInterval> joinedUnreduced = std::nullopt;
+      bool sawFirst = false;
+      for (const SourceRef &ref : refSet.getScalarValue()) {
+        joinedInterval = joinedInterval.join(getRefInterval(ref));
+        auto refUnreduced = getRefUnreducedInterval(ref);
+        if (!sawFirst) {
+          joinedUnreduced = refUnreduced;
+          sawFirst = true;
+        } else {
+          joinedUnreduced = mergeUnreducedIntervals(joinedUnreduced, refUnreduced);
+        }
+      }
+      ExpressionValue anyVal = createUnknownValue(value)
+                                   .withInterval(joinedInterval)
+                                   .withOptionalUnreducedInterval(joinedUnreduced);
+      return LatticeValue(anyVal);
+    }
+
+    return LatticeValue(getRefValue(refSet.getSingleValue(), value));
+  };
   for (unsigned opNum = 0; opNum < op->getNumOperands(); ++opNum) {
     Value val = op->getOperand(opNum);
     SourceRefLatticeValue refSet = getSourceRefState(val);
@@ -713,37 +756,30 @@ mlir::LogicalResult IntervalDataFlowAnalysis::visitOperation(
       continue;
     }
 
-    ensure(refSet.isScalar(), "should have ruled out array values already");
-
-    if (refSet.getScalarValue().empty()) {
-      // If we can't compute the reference, then there must be some unsupported
-      // op the reference analysis cannot handle. We emit a warning and return
-      // early, since there's no meaningful computation we can do for this op.
-      op->emitWarning()
-          .append(
-              "state of ", val, " is empty; defining operation is unsupported by SourceRef analysis"
-          )
-          .report();
+    auto resolvedValue = resolveRefStateValue(val, refSet);
+    if (!resolvedValue.has_value()) {
       // We still return success so we can return overapproximated and partial
       // results to the user.
       return success();
-    } else if (!refSet.isSingleValue()) {
-      Interval joinedInterval = Interval::Empty(field.get());
-      for (const SourceRef &ref : refSet.getScalarValue()) {
-        joinedInterval = joinedInterval.join(getRefInterval(ref));
-      }
-      ExpressionValue anyVal = createUnknownValue(val).withInterval(joinedInterval);
-      operandVals.emplace_back(anyVal);
-    } else {
-      const SourceRef &ref = refSet.getSingleValue();
-      operandVals.emplace_back(getRefValue(ref, val));
     }
+    operandVals.push_back(*resolvedValue);
 
     // Since we initialized a value that was not found in the before lattice,
     // update that value in the lattice so we can find it later, but we don't
     // need to propagate the changes, since we already have what we need.
     Lattice *operandLattice = getLatticeElement(val);
     (void)operandLattice->setValue(operandVals[opNum]);
+  }
+
+  if (isReadOp(op) && op->getNumResults() == 1) {
+    Value resultVal = op->getResult(0);
+    if (!llvm::isa<ArrayType, StructType>(resultVal.getType())) {
+      auto resolvedValue = resolveRefStateValue(resultVal, getSourceRefState(resultVal));
+      if (resolvedValue.has_value()) {
+        propagateIfChanged(results[0], results[0]->setValue(*resolvedValue));
+      }
+    }
+    return success();
   }
 
   // Now, the way we update is dependent on the type of the operation.
@@ -1508,16 +1544,17 @@ LogicalResult StructIntervals::computeIntervals(
     mlir::DataFlowSolver &solver, const IntervalAnalysisContext &ctx
 ) {
 
-  auto computeIntervalsImpl = [&solver, &ctx, this](
-                                  FuncDefOp fn, llvm::MapVector<SourceRef, Interval> &memberRanges,
-                                  llvm::MapVector<SourceRef, UnreducedInterval> &memberUnreducedRanges,
-                                  llvm::SetVector<ExpressionValue> & /*solverConstraints*/
-                              ) {
+  auto computeIntervalsImpl =
+      [&solver, &ctx, this](
+          FuncDefOp fn, llvm::MapVector<SourceRef, Interval> &memberRanges,
+          llvm::MapVector<SourceRef, UnreducedInterval> &memberUnreducedRanges,
+          llvm::SetVector<ExpressionValue> & /*solverConstraints*/
+      ) {
     auto setUnreducedRange =
         [&memberUnreducedRanges](const SourceRef &ref, const UnreducedInterval &interval) {
-          memberUnreducedRanges.erase(ref);
-          memberUnreducedRanges.insert({ref, interval});
-        };
+      memberUnreducedRanges.erase(ref);
+      memberUnreducedRanges.insert({ref, interval});
+    };
     // Since every lattice value does not contain every value, we will traverse
     // the function backwards (from most up-to-date to least-up-to-date lattices)
     // searching for the source refs. Once a source ref is found, we remove it
@@ -1614,9 +1651,9 @@ LogicalResult StructIntervals::computeIntervals(
     for (const auto &[ref, interval] : memberUnreducedRanges) {
       sortedUnreducedRanges.emplace_back(ref, interval);
     }
-    llvm::sort(
-        sortedUnreducedRanges, [](const auto &a, const auto &b) { return a.first < b.first; }
-    );
+    llvm::sort(sortedUnreducedRanges, [](const auto &a, const auto &b) {
+      return a.first < b.first;
+    });
     memberRanges.clear();
     memberUnreducedRanges.clear();
     for (auto &[ref, interval] : sortedRanges) {

--- a/lib/Analysis/IntervalAnalysisPass.cpp
+++ b/lib/Analysis/IntervalAnalysisPass.cpp
@@ -90,6 +90,7 @@ protected:
     auto &mia = getAnalysis<ModuleIntervalAnalysis>();
     mia.setField(selectedField);
     mia.setPropagateInputConstraints(propagateInputConstraints);
+    mia.setTrackUnreducedIntervals(printUnreducedIntervals);
     auto am = getAnalysisManager();
     mia.ensureAnalysisRun(am);
 
@@ -101,7 +102,9 @@ protected:
           "could not resolve fully qualified name of struct " + mlir::Twine(structDef.getName())
       );
       os << fullName.value() << ' ';
-      si.get().print(os, printSolverConstraints, printComputeIntervals);
+      si.get().print(
+          os, printSolverConstraints, printComputeIntervals, printUnreducedIntervals
+      );
     }
   }
 };

--- a/lib/Analysis/IntervalAnalysisPass.cpp
+++ b/lib/Analysis/IntervalAnalysisPass.cpp
@@ -15,8 +15,11 @@
 #include "llzk/Analysis/AnalysisPasses.h"
 #include "llzk/Analysis/IntervalAnalysis.h"
 #include "llzk/Dialect/Bool/IR/Ops.h"
+#include "llzk/Dialect/Function/IR/Ops.h"
 #include "llzk/Util/Constants.h"
 #include "llzk/Util/SymbolHelper.h"
+
+#include <mlir/IR/AsmState.h>
 
 #include <llvm/ADT/STLExtras.h>
 #include <llvm/ADT/SmallVector.h>
@@ -32,6 +35,7 @@ namespace llzk {
 #include "llzk/Analysis/AnalysisPasses.h.inc"
 
 using namespace component;
+using namespace function;
 
 class IntervalAnalysisPrinterPass
     : public impl::IntervalAnalysisPrinterPassBase<IntervalAnalysisPrinterPass> {
@@ -93,6 +97,52 @@ protected:
     mia.setTrackUnreducedIntervals(printUnreducedIntervals);
     auto am = getAnalysisManager();
     mia.ensureAnalysisRun(am);
+    mlir::AsmState asmState(modOp);
+
+    auto printValueInterval = [this, &asmState,
+                               &mia](mlir::raw_ostream &out, int indent, mlir::Value value) {
+      if (llvm::isa<llzk::array::ArrayType, StructType>(value.getType())) {
+        return;
+      }
+      const auto *lattice = mia.getSolver().lookupState<IntervalAnalysisLattice>(value);
+      if (!lattice) {
+        return;
+      }
+      const ExpressionValue &expr = lattice->getValue().getScalarValue();
+      out << '\n';
+      out.indent(indent);
+      value.printAsOperand(out, asmState);
+      if (auto opResult = llvm::dyn_cast<mlir::OpResult>(value)) {
+        out << " [" << opResult.getOwner()->getName().getStringRef() << "]";
+      }
+      out << " in " << expr.getInterval();
+      if (printUnreducedIntervals && expr.hasUnreducedInterval()) {
+        out << " ( unreduced: " << expr.getUnreducedInterval() << " )";
+      }
+    };
+
+    auto printFunctionSSAIntervals =
+        [&printValueInterval](mlir::raw_ostream &out, FuncDefOp fn, llvm::StringRef fnName) {
+      if (!fn) {
+        return;
+      }
+
+      out << '\n';
+      out.indent(4) << fnName << " {";
+      for (mlir::BlockArgument arg : fn.getArguments()) {
+        printValueInterval(out, 8, arg);
+      }
+      fn.walk([&](mlir::Operation *op) {
+        if (op == fn.getOperation()) {
+          return;
+        }
+        for (mlir::Value result : op->getResults()) {
+          printValueInterval(out, 8, result);
+        }
+      });
+      out << '\n';
+      out.indent(4) << '}';
+    };
 
     for (const auto &[s, si] : mia.getCurrentResults()) {
       auto &structDef = const_cast<StructDefOp &>(s);
@@ -102,9 +152,19 @@ protected:
           "could not resolve fully qualified name of struct " + mlir::Twine(structDef.getName())
       );
       os << fullName.value() << ' ';
-      si.get().print(
-          os, printSolverConstraints, printComputeIntervals, printUnreducedIntervals
-      );
+      si.get().print(os, printSolverConstraints, printComputeIntervals, printUnreducedIntervals);
+      if (printSSAIntervals) {
+        os << fullName.value() << " SSAIntervals {";
+        if (printComputeIntervals) {
+          printFunctionSSAIntervals(os, structDef.getComputeFuncOp(), FUNC_NAME_COMPUTE);
+        }
+        printFunctionSSAIntervals(os, structDef.getConstrainFuncOp(), FUNC_NAME_CONSTRAIN);
+        if (auto productFn = structDef.getProductFuncOp();
+            productFn && (!structDef.getConstrainFuncOp() || printComputeIntervals)) {
+          printFunctionSSAIntervals(os, productFn, FUNC_NAME_PRODUCT);
+        }
+        os << "\n}\n";
+      }
     }
   }
 };

--- a/test/Analysis/interval_analysis/interval_analysis_pass_unreduced.llzk
+++ b/test/Analysis/interval_analysis/interval_analysis_pass_unreduced.llzk
@@ -1,4 +1,4 @@
-// RUN: llzk-opt -split-input-file -llzk-print-interval-analysis="field=babybear print-compute-intervals print-unreduced-intervals propagate-input-constraints" %s 2>&1 | FileCheck %s
+// RUN: llzk-opt -split-input-file -llzk-print-interval-analysis="field=babybear print-compute-intervals print-unreduced-intervals print-ssa-intervals propagate-input-constraints" %s 2>&1 | FileCheck %s
 
 module attributes {llzk.lang} {
   struct.def @TrackUnreducedArithmetic {
@@ -98,4 +98,99 @@ module attributes {llzk.lang} {
 // CHECK-LABEL: @TrackUnreducedTypeFPropagation StructIntervals {
 // CHECK: compute {
 // CHECK-NEXT:    %arg0 in TypeF:[ 2013265920, 0 ] ( unreduced: Unreduced:[ -1, 0 ] )
+// CHECK-NEXT:  }
+
+// -----
+
+module attributes {llzk.lang} {
+  struct.def @TrackUnreducedSignalReadDefault {
+    struct.member @sig : !felt.type {signal}
+
+    function.def @compute() -> !struct.type<@TrackUnreducedSignalReadDefault>
+        attributes {function.allow_witness} {
+      %self = struct.new : !struct.type<@TrackUnreducedSignalReadDefault>
+      function.return %self : !struct.type<@TrackUnreducedSignalReadDefault>
+    }
+
+    function.def @constrain(%self: !struct.type<@TrackUnreducedSignalReadDefault>)
+        attributes {function.allow_constraint} {
+      %sig = struct.readm %self[@sig] : !struct.type<@TrackUnreducedSignalReadDefault>, !felt.type
+      function.return
+    }
+  }
+}
+
+// CHECK-LABEL: @TrackUnreducedSignalReadDefault StructIntervals {
+// CHECK: constrain {
+// CHECK-NEXT:    %arg0[@sig] in Entire ( unreduced: Unreduced:[ 0, 2013265920 ] )
+// CHECK-NEXT:  }
+
+// -----
+
+module @Comparators attributes {llzk.lang = "llzk"} {
+  // Adapted from test/Conversions/circom_isZero.llzk.
+  struct.def @IsZero {
+    struct.member @out : !felt.type {llzk.pub}
+    struct.member @inv : !felt.type
+
+    function.def @compute(%in: !felt.type) -> !struct.type<@IsZero>
+        attributes {function.allow_non_native_field_ops} {
+      %self = struct.new : !struct.type<@IsZero>
+      %const_1 = felt.const 1
+      %inv = felt.inv %in
+      struct.writem %self[@inv] = %inv : !struct.type<@IsZero>, !felt.type
+      %neg_in = felt.neg %in
+      %mul = felt.mul %neg_in, %inv
+      %out = felt.add %mul, %const_1
+      struct.writem %self[@out] = %out : !struct.type<@IsZero>, !felt.type
+      function.return %self : !struct.type<@IsZero>
+    }
+
+    function.def @constrain(%self: !struct.type<@IsZero>, %in: !felt.type) {
+      %const_0 = felt.const 0
+      %const_1 = felt.const 1
+      %out = struct.readm %self[@out] : !struct.type<@IsZero>, !felt.type
+      %inv = struct.readm %self[@inv] : !struct.type<@IsZero>, !felt.type
+      %neg_in = felt.neg %in
+      %mul = felt.mul %neg_in, %inv
+      %sum = felt.add %mul, %const_1
+      constrain.eq %out, %sum : !felt.type
+      %zero_prod = felt.mul %in, %out
+      constrain.eq %zero_prod, %const_0 : !felt.type
+      function.return
+    }
+  }
+}
+
+// CHECK-LABEL: @Comparators::@IsZero StructIntervals {
+// CHECK: compute {
+// CHECK-NEXT:    %arg0 in Entire ( unreduced: Unreduced:[ 0, 2013265920 ] )
+// CHECK-NEXT:    %self[@out] in Entire ( unreduced: Unreduced:[ -4053239664633446399, 1 ] )
+// CHECK-NEXT:    %self[@inv] in Entire ( unreduced: Unreduced:[ 0, 2013265920 ] )
+// CHECK-NEXT:  }
+// CHECK-NEXT:  constrain {
+// CHECK-NEXT:    %arg0[@out] in Entire ( unreduced: Unreduced:[ 0, 2013265920 ] )
+// CHECK-NEXT:    %arg0[@inv] in Entire ( unreduced: Unreduced:[ 0, 2013265920 ] )
+// CHECK-NEXT:    %arg1 in Entire ( unreduced: Unreduced:[ 0, 2013265920 ] )
+// CHECK-NEXT:  }
+
+// CHECK-LABEL: @Comparators::@IsZero SSAIntervals {
+// CHECK: compute {
+// CHECK-NEXT:    %arg0 in Entire ( unreduced: Unreduced:[ 0, 2013265920 ] )
+// CHECK-NEXT:    %{{[^ ]+}} [felt.const] in Degenerate(1) ( unreduced: Unreduced:[ 1, 1 ] )
+// CHECK-NEXT:    %{{[^ ]+}} [felt.inv] in Entire ( unreduced: Unreduced:[ 0, 2013265920 ] )
+// CHECK-NEXT:    %{{[^ ]+}} [felt.neg] in Entire ( unreduced: Unreduced:[ -2013265920, 0 ] )
+// CHECK-NEXT:    %{{[^ ]+}} [felt.mul] in Entire ( unreduced: Unreduced:[ -4053239664633446400, 0 ] )
+// CHECK-NEXT:    %{{[^ ]+}} [felt.add] in Entire ( unreduced: Unreduced:[ -4053239664633446399, 1 ] )
+// CHECK-NEXT:  }
+// CHECK-NEXT:  constrain {
+// CHECK-NEXT:    %arg1 in Entire ( unreduced: Unreduced:[ 0, 2013265920 ] )
+// CHECK-NEXT:    %{{[^ ]+}} [felt.const] in Degenerate(0) ( unreduced: Unreduced:[ 0, 0 ] )
+// CHECK-NEXT:    %{{[^ ]+}} [felt.const] in Degenerate(1) ( unreduced: Unreduced:[ 1, 1 ] )
+// CHECK-NEXT:    %{{[^ ]+}} [struct.readm] in Entire ( unreduced: Unreduced:[ 0, 2013265920 ] )
+// CHECK-NEXT:    %{{[^ ]+}} [struct.readm] in Entire ( unreduced: Unreduced:[ 0, 2013265920 ] )
+// CHECK-NEXT:    %{{[^ ]+}} [felt.neg] in Entire ( unreduced: Unreduced:[ -2013265920, 0 ] )
+// CHECK-NEXT:    %{{[^ ]+}} [felt.mul] in Entire ( unreduced: Unreduced:[ -4053239664633446400, 0 ] )
+// CHECK-NEXT:    %{{[^ ]+}} [felt.add] in Entire ( unreduced: Unreduced:[ -4053239664633446399, 1 ] )
+// CHECK-NEXT:    %{{[^ ]+}} [felt.mul] in Degenerate(0)
 // CHECK-NEXT:  }

--- a/test/Analysis/interval_analysis/interval_analysis_pass_unreduced.llzk
+++ b/test/Analysis/interval_analysis/interval_analysis_pass_unreduced.llzk
@@ -23,8 +23,8 @@ module attributes {llzk.lang} {
 
 // CHECK-LABEL: @TrackUnreducedArithmetic StructIntervals {
 // CHECK: compute {
-// CHECK-NEXT:    %arg0 in Entire ( unreduced: Unreduced:[ 0, 2013265920 ] )
-// CHECK-NEXT:    %self[@out] in Entire ( unreduced: Unreduced:[ -2013265925, -5 ] )
+// CHECK-NEXT:    %arg0 in Entire ( Unreduced:[ 0, 2013265920 ] )
+// CHECK-NEXT:    %self[@out] in Entire ( Unreduced:[ -2013265925, -5 ] )
 // CHECK-NEXT:  }
 
 // -----
@@ -66,12 +66,12 @@ module attributes {llzk.lang} {
 
 // CHECK-LABEL: @TrackUnreducedBoolSelect StructIntervals {
 // CHECK: compute {
-// CHECK-NEXT:    %arg0 in TypeA:[ 0, 1 ] ( unreduced: Unreduced:[ 0, 1 ] )
-// CHECK-NEXT:    %self[@xor] in Degenerate(1) ( unreduced: Unreduced:[ 1, 1 ] )
-// CHECK-NEXT:    %self[@not] in TypeA:[ 0, 1 ] ( unreduced: Unreduced:[ 0, 1 ] )
-// CHECK-NEXT:    %self[@sel_true] in Degenerate(3) ( unreduced: Unreduced:[ 3, 3 ] )
-// CHECK-NEXT:    %self[@sel_false] in Degenerate(9) ( unreduced: Unreduced:[ 9, 9 ] )
-// CHECK-NEXT:    %self[@sel_flag] in TypeA:[ 3, 9 ] ( unreduced: Unreduced:[ 3, 9 ] )
+// CHECK-NEXT:    %arg0 in TypeA:[ 0, 1 ] ( Unreduced:[ 0, 1 ] )
+// CHECK-NEXT:    %self[@xor] in Degenerate(1) ( Unreduced:[ 1, 1 ] )
+// CHECK-NEXT:    %self[@not] in TypeA:[ 0, 1 ] ( Unreduced:[ 0, 1 ] )
+// CHECK-NEXT:    %self[@sel_true] in Degenerate(3) ( Unreduced:[ 3, 3 ] )
+// CHECK-NEXT:    %self[@sel_false] in Degenerate(9) ( Unreduced:[ 9, 9 ] )
+// CHECK-NEXT:    %self[@sel_flag] in TypeA:[ 3, 9 ] ( Unreduced:[ 3, 9 ] )
 // CHECK-NEXT:  }
 
 // -----
@@ -97,7 +97,7 @@ module attributes {llzk.lang} {
 
 // CHECK-LABEL: @TrackUnreducedTypeFPropagation StructIntervals {
 // CHECK: compute {
-// CHECK-NEXT:    %arg0 in TypeF:[ 2013265920, 0 ] ( unreduced: Unreduced:[ -1, 0 ] )
+// CHECK-NEXT:    %arg0 in TypeF:[ 2013265920, 0 ] ( Unreduced:[ -1, 0 ] )
 // CHECK-NEXT:  }
 
 // -----
@@ -121,8 +121,11 @@ module attributes {llzk.lang} {
 }
 
 // CHECK-LABEL: @TrackUnreducedSignalReadDefault StructIntervals {
+// CHECK: compute {
+// CHECK-NEXT:    %self[@sig] in Entire ( Unreduced:[ 0, 2013265920 ] )
+// CHECK-NEXT:  }
 // CHECK: constrain {
-// CHECK-NEXT:    %arg0[@sig] in Entire ( unreduced: Unreduced:[ 0, 2013265920 ] )
+// CHECK-NEXT:    %arg0[@sig] in Entire ( Unreduced:[ 0, 2013265920 ] )
 // CHECK-NEXT:  }
 
 // -----
@@ -164,14 +167,14 @@ module @Comparators attributes {llzk.lang = "llzk"} {
 
 // CHECK-LABEL: @Comparators::@IsZero StructIntervals {
 // CHECK: compute {
-// CHECK-NEXT:    %arg0 in Entire ( unreduced: Unreduced:[ 0, 2013265920 ] )
-// CHECK-NEXT:    %self[@out] in Entire ( unreduced: Unreduced:[ -4053239664633446399, 1 ] )
-// CHECK-NEXT:    %self[@inv] in Entire ( unreduced: Unreduced:[ 0, 2013265920 ] )
+// CHECK-NEXT:    %arg0 in Entire ( Unreduced:[ 0, 2013265920 ] )
+// CHECK-NEXT:    %self[@out] in Entire ( Unreduced:[ -4053239664633446399, 1 ] )
+// CHECK-NEXT:    %self[@inv] in Entire ( Unreduced:[ 0, 2013265920 ] )
 // CHECK-NEXT:  }
 // CHECK-NEXT:  constrain {
-// CHECK-NEXT:    %arg0[@out] in Entire ( unreduced: Unreduced:[ 0, 2013265920 ] )
-// CHECK-NEXT:    %arg0[@inv] in Entire ( unreduced: Unreduced:[ 0, 2013265920 ] )
-// CHECK-NEXT:    %arg1 in Entire ( unreduced: Unreduced:[ 0, 2013265920 ] )
+// CHECK-NEXT:    %arg0[@out] in Entire ( Unreduced:[ 0, 2013265920 ] )
+// CHECK-NEXT:    %arg0[@inv] in Entire ( Unreduced:[ 0, 2013265920 ] )
+// CHECK-NEXT:    %arg1 in Entire ( Unreduced:[ 0, 2013265920 ] )
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: @Comparators::@IsZero SSAIntervals {

--- a/test/Analysis/interval_analysis/interval_analysis_pass_unreduced.llzk
+++ b/test/Analysis/interval_analysis/interval_analysis_pass_unreduced.llzk
@@ -1,0 +1,101 @@
+// RUN: llzk-opt -split-input-file -llzk-print-interval-analysis="field=babybear print-compute-intervals print-unreduced-intervals propagate-input-constraints" %s 2>&1 | FileCheck %s
+
+module attributes {llzk.lang} {
+  struct.def @TrackUnreducedArithmetic {
+    struct.member @out : !felt.type
+
+    function.def @compute(%a: !felt.type) -> !struct.type<@TrackUnreducedArithmetic>
+        attributes {function.allow_witness, function.allow_non_native_field_ops} {
+      %self = struct.new : !struct.type<@TrackUnreducedArithmetic>
+      %five = felt.const 5
+      %sum = felt.add %a, %five : !felt.type, !felt.type
+      %neg = felt.neg %sum : !felt.type
+      struct.writem %self[@out] = %neg : !struct.type<@TrackUnreducedArithmetic>, !felt.type
+      function.return %self : !struct.type<@TrackUnreducedArithmetic>
+    }
+
+    function.def @constrain(%self: !struct.type<@TrackUnreducedArithmetic>, %a: !felt.type)
+        attributes {function.allow_constraint} {
+      function.return
+    }
+  }
+}
+
+// CHECK-LABEL: @TrackUnreducedArithmetic StructIntervals {
+// CHECK: compute {
+// CHECK-NEXT:    %arg0 in Entire ( unreduced: Unreduced:[ 0, 2013265920 ] )
+// CHECK-NEXT:    %self[@out] in Entire ( unreduced: Unreduced:[ -2013265925, -5 ] )
+// CHECK-NEXT:  }
+
+// -----
+
+module attributes {llzk.lang} {
+  struct.def @TrackUnreducedBoolSelect {
+    struct.member @xor : i1
+    struct.member @not : i1
+    struct.member @sel_true : !felt.type
+    struct.member @sel_false : !felt.type
+    struct.member @sel_flag : !felt.type
+
+    function.def @compute(%flag: i1) -> !struct.type<@TrackUnreducedBoolSelect>
+        attributes {function.allow_witness, function.allow_non_native_field_ops} {
+      %self = struct.new : !struct.type<@TrackUnreducedBoolSelect>
+      %true = arith.constant true
+      %false = arith.constant false
+      %three = felt.const 3
+      %nine = felt.const 9
+      %xor = bool.xor %true, %false
+      %not = bool.not %flag
+      %sel_true = arith.select %true, %three, %nine : !felt.type
+      %sel_false = arith.select %false, %three, %nine : !felt.type
+      %sel_flag = arith.select %flag, %three, %nine : !felt.type
+      struct.writem %self[@xor] = %xor : !struct.type<@TrackUnreducedBoolSelect>, i1
+      struct.writem %self[@not] = %not : !struct.type<@TrackUnreducedBoolSelect>, i1
+      struct.writem %self[@sel_true] = %sel_true : !struct.type<@TrackUnreducedBoolSelect>, !felt.type
+      struct.writem %self[@sel_false] = %sel_false : !struct.type<@TrackUnreducedBoolSelect>, !felt.type
+      struct.writem %self[@sel_flag] = %sel_flag : !struct.type<@TrackUnreducedBoolSelect>, !felt.type
+      function.return %self : !struct.type<@TrackUnreducedBoolSelect>
+    }
+
+    function.def @constrain(%self: !struct.type<@TrackUnreducedBoolSelect>, %flag: i1)
+        attributes {function.allow_constraint} {
+      function.return
+    }
+  }
+}
+
+// CHECK-LABEL: @TrackUnreducedBoolSelect StructIntervals {
+// CHECK: compute {
+// CHECK-NEXT:    %arg0 in TypeA:[ 0, 1 ] ( unreduced: Unreduced:[ 0, 1 ] )
+// CHECK-NEXT:    %self[@xor] in Degenerate(1) ( unreduced: Unreduced:[ 1, 1 ] )
+// CHECK-NEXT:    %self[@not] in TypeA:[ 0, 1 ] ( unreduced: Unreduced:[ 0, 1 ] )
+// CHECK-NEXT:    %self[@sel_true] in Degenerate(3) ( unreduced: Unreduced:[ 3, 3 ] )
+// CHECK-NEXT:    %self[@sel_false] in Degenerate(9) ( unreduced: Unreduced:[ 9, 9 ] )
+// CHECK-NEXT:    %self[@sel_flag] in TypeA:[ 3, 9 ] ( unreduced: Unreduced:[ 3, 9 ] )
+// CHECK-NEXT:  }
+
+// -----
+
+module attributes {llzk.lang} {
+  struct.def @TrackUnreducedTypeFPropagation {
+    function.def @compute(%a: !felt.type) -> !struct.type<@TrackUnreducedTypeFPropagation>
+        attributes {function.allow_witness, function.allow_non_native_field_ops} {
+      %self = struct.new : !struct.type<@TrackUnreducedTypeFPropagation>
+      function.return %self : !struct.type<@TrackUnreducedTypeFPropagation>
+    }
+
+    function.def @constrain(%self: !struct.type<@TrackUnreducedTypeFPropagation>, %a: !felt.type)
+        attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+      %one = felt.const 1
+      %sum = felt.add %a, %one : !felt.type, !felt.type
+      %cmp = bool.cmp le(%sum, %one) : !felt.type, !felt.type
+      bool.assert %cmp
+      function.return
+    }
+  }
+}
+
+// CHECK-LABEL: @TrackUnreducedTypeFPropagation StructIntervals {
+// CHECK: compute {
+// CHECK-NEXT:    %arg0 in TypeF:[ 2013265920, 0 ] ( unreduced: Unreduced:[ -1, 0 ] )
+// CHECK-NEXT:  }

--- a/unittests/Analysis/IntervalTests.cpp
+++ b/unittests/Analysis/IntervalTests.cpp
@@ -12,11 +12,14 @@
 
 #include "llzk/Analysis/IntervalAnalysis.h"
 #include "llzk/Analysis/Intervals.h"
+#include "llzk/Dialect/Bool/IR/Ops.h"
+#include "llzk/Dialect/Felt/IR/Ops.h"
 #include "llzk/Dialect/Function/IR/Ops.h"
 #include "llzk/Dialect/Struct/IR/Ops.h"
 #include "llzk/Util/Debug.h"
 #include "llzk/Util/StreamHelper.h"
 
+#include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Parser/Parser.h>
 
 #include <gtest/gtest.h>
@@ -293,6 +296,11 @@ TEST_F(IntervalTests, Mod) {
 
 class IntervalAnalysisAPITests : public LLZKTest {
 protected:
+  inline static void
+  AssertUnreducedIntervalEq(const UnreducedInterval &expected, const UnreducedInterval &actual) {
+    ASSERT_TRUE(checkCond(expected, actual, expected == actual));
+  }
+
   static constexpr auto kArrayIntervalModule = R"mlir(
 module attributes {llzk.lang} {
   struct.def @ArrayIntervals {
@@ -351,10 +359,180 @@ module attributes {llzk.lang} {
 }
 )mlir";
 
+  static constexpr auto kUnreducedIntervalPropagationModule = R"mlir(
+module attributes {llzk.lang} {
+  struct.def @TrackUnreduced {
+    struct.member @out : !felt.type {llzk.pub, signal}
+
+    function.def @compute(%a: !felt.type) -> !struct.type<@TrackUnreduced>
+        attributes {function.allow_witness, function.allow_non_native_field_ops} {
+      %self = struct.new : <@TrackUnreduced>
+      %felt_const_5 = felt.const 5
+      %sum = felt.add %a, %felt_const_5 : !felt.type, !felt.type
+      %neg = felt.neg %sum : !felt.type
+      %div = felt.uintdiv %sum, %felt_const_5
+      struct.writem %self[@out] = %neg : <@TrackUnreduced>, !felt.type
+      function.return %self : !struct.type<@TrackUnreduced>
+    }
+
+    function.def @constrain(%self: !struct.type<@TrackUnreduced>, %a: !felt.type)
+        attributes {function.allow_constraint} {
+      function.return
+    }
+  }
+}
+)mlir";
+
+  static constexpr auto kUnreducedBoolAndSelectModule = R"mlir(
+module attributes {llzk.lang} {
+  struct.def @TrackUnreducedBoolAndSelect {
+    struct.member @out : !felt.type {llzk.pub, signal}
+
+    function.def @compute(%flag: i1) -> !struct.type<@TrackUnreducedBoolAndSelect>
+        attributes {function.allow_witness, function.allow_non_native_field_ops} {
+      %self = struct.new : <@TrackUnreducedBoolAndSelect>
+      %true = arith.constant true
+      %false = arith.constant false
+      %felt_const_3 = felt.const 3
+      %felt_const_9 = felt.const 9
+      %xor = bool.xor %true, %false
+      %not = bool.not %flag
+      %sel_true = arith.select %true, %felt_const_3, %felt_const_9 : !felt.type
+      %sel_false = arith.select %false, %felt_const_3, %felt_const_9 : !felt.type
+      %sel_flag = arith.select %flag, %felt_const_3, %felt_const_9 : !felt.type
+      struct.writem %self[@out] = %sel_flag : <@TrackUnreducedBoolAndSelect>, !felt.type
+      function.return %self : !struct.type<@TrackUnreducedBoolAndSelect>
+    }
+
+    function.def @constrain(%self: !struct.type<@TrackUnreducedBoolAndSelect>, %flag: i1)
+        attributes {function.allow_constraint} {
+      function.return
+    }
+  }
+}
+)mlir";
+
+  static constexpr auto kUnreducedTypeFLiftModule = R"mlir(
+module attributes {llzk.lang} {
+  struct.def @TrackUnreducedTypeF {
+    struct.member @out : !felt.type {llzk.pub, signal}
+
+    function.def @compute(%a: !felt.type) -> !struct.type<@TrackUnreducedTypeF>
+        attributes {function.allow_witness, function.allow_non_native_field_ops} {
+      %self = struct.new : <@TrackUnreducedTypeF>
+      %felt_const_1 = felt.const 1
+      %cmp = bool.cmp le(%a, %felt_const_1) : !felt.type, !felt.type
+      bool.assert %cmp
+      %neg = felt.neg %a : !felt.type
+      struct.writem %self[@out] = %neg : <@TrackUnreducedTypeF>, !felt.type
+      function.return %self : !struct.type<@TrackUnreducedTypeF>
+    }
+
+    function.def @constrain(%self: !struct.type<@TrackUnreducedTypeF>, %a: !felt.type)
+        attributes {function.allow_constraint} {
+      %read = struct.readm %self[@out] : <@TrackUnreducedTypeF>, !felt.type
+      %felt_const_0 = felt.const 0
+      %sum = felt.add %read, %felt_const_0 : !felt.type, !felt.type
+      function.return
+    }
+  }
+}
+)mlir";
+
+  static constexpr auto kUnreducedTypeFPropagationModule = R"mlir(
+module attributes {llzk.lang} {
+  struct.def @TrackUnreducedTypeFPropagation {
+    function.def @compute(%a: !felt.type) -> !struct.type<@TrackUnreducedTypeFPropagation>
+        attributes {function.allow_witness, function.allow_non_native_field_ops} {
+      %self = struct.new : <@TrackUnreducedTypeFPropagation>
+      function.return %self : !struct.type<@TrackUnreducedTypeFPropagation>
+    }
+
+    function.def @constrain(%self: !struct.type<@TrackUnreducedTypeFPropagation>, %a: !felt.type)
+        attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+      %felt_const_1 = felt.const 1
+      %sum = felt.add %a, %felt_const_1 : !felt.type, !felt.type
+      %cmp = bool.cmp le(%sum, %felt_const_1) : !felt.type, !felt.type
+      bool.assert %cmp
+      function.return
+    }
+  }
+}
+)mlir";
+
+  static constexpr auto kProductFunctionIntervalModule = R"mlir(
+module attributes {llzk.lang} {
+  struct.def @ProductIntervals {
+    struct.member @out : !felt.type {llzk.pub, signal}
+
+    function.def @product(%a: !felt.type) -> !struct.type<@ProductIntervals>
+        attributes {function.allow_constraint, function.allow_non_native_field_ops, function.allow_witness, llzk.derived} {
+      %self = struct.new : <@ProductIntervals>
+      %five = felt.const 5
+      %six = felt.const 6
+      %cmp0 = bool.cmp ge(%a, %five) : !felt.type, !felt.type
+      bool.assert %cmp0
+      %cmp1 = bool.cmp le(%a, %six) : !felt.type, !felt.type
+      bool.assert %cmp1
+      %sum = felt.add %a, %five : !felt.type, !felt.type
+      struct.writem %self[@out] = %sum : <@ProductIntervals>, !felt.type
+      %read = struct.readm %self[@out] : <@ProductIntervals>, !felt.type
+      constrain.eq %read, %sum : !felt.type, !felt.type
+      function.return %self : !struct.type<@ProductIntervals>
+    }
+
+    function.def @compute(%a: !felt.type) -> !struct.type<@ProductIntervals>
+        attributes {function.allow_witness} {
+      %self = struct.new : <@ProductIntervals>
+      function.return %self : !struct.type<@ProductIntervals>
+    }
+
+    function.def @constrain(%self: !struct.type<@ProductIntervals>, %a: !felt.type)
+        attributes {function.allow_constraint} {
+      function.return
+    }
+  }
+}
+)mlir";
+
+  static constexpr auto kProductFunctionUnreducedModule = R"mlir(
+module attributes {llzk.lang} {
+  struct.def @ProductUnreducedIntervals {
+    struct.member @out : !felt.type {llzk.pub, signal}
+
+    function.def @product(%a: !felt.type) -> !struct.type<@ProductUnreducedIntervals>
+        attributes {function.allow_constraint, function.allow_non_native_field_ops, function.allow_witness, llzk.derived} {
+      %self = struct.new : <@ProductUnreducedIntervals>
+      %five = felt.const 5
+      %sum = felt.add %a, %five : !felt.type, !felt.type
+      struct.writem %self[@out] = %sum : <@ProductUnreducedIntervals>, !felt.type
+      %read = struct.readm %self[@out] : <@ProductUnreducedIntervals>, !felt.type
+      constrain.eq %read, %sum : !felt.type, !felt.type
+      function.return %self : !struct.type<@ProductUnreducedIntervals>
+    }
+
+    function.def @compute(%a: !felt.type) -> !struct.type<@ProductUnreducedIntervals>
+        attributes {function.allow_witness} {
+      %self = struct.new : <@ProductUnreducedIntervals>
+      function.return %self : !struct.type<@ProductUnreducedIntervals>
+    }
+
+    function.def @constrain(%self: !struct.type<@ProductUnreducedIntervals>, %a: !felt.type)
+        attributes {function.allow_constraint} {
+      function.return
+    }
+  }
+}
+)mlir";
+
   OwningOpRef<ModuleOp> parseModule(llvm::StringRef source) {
     auto mod = parseSourceString<ModuleOp>(source, ParserConfig(&ctx));
     EXPECT_TRUE(mod);
     return mod;
+  }
+
+  const IntervalAnalysisLattice *lookupLattice(ModuleIntervalAnalysis &analysis, Value value) {
+    return analysis.getSolver().lookupState<IntervalAnalysisLattice>(value);
   }
 };
 
@@ -451,4 +629,391 @@ TEST_F(IntervalAnalysisAPITests, ComputeIntervalsTrackArrayNewStoredIntoMember) 
   auto expected = Interval::TypeA(field, field.felt(5), field.felt(6));
   ASSERT_TRUE(checkCond(expected, out1It->second, expected == out1It->second))
       << buildStringViaPrint(*out1Ref) << " -> " << buildStringViaPrint(out1It->second);
+}
+
+TEST_F(IntervalAnalysisAPITests, UnreducedIntervalsDisabledByDefault) {
+  auto mod = parseModule(kUnreducedIntervalPropagationModule);
+  auto structDef = *mod->getOps<StructDefOp>().begin();
+  auto computeFn = structDef.getComputeFuncOp();
+  ASSERT_TRUE(computeFn != nullptr);
+
+  felt::FeltConstantOp constFive;
+  felt::AddFeltOp sumOp;
+  felt::NegFeltOp negOp;
+  felt::UnsignedIntDivFeltOp divOp;
+  computeFn.walk([&](Operation *op) {
+    if (auto c = dyn_cast<felt::FeltConstantOp>(op)) {
+      constFive = c;
+    } else if (auto add = dyn_cast<felt::AddFeltOp>(op)) {
+      sumOp = add;
+    } else if (auto neg = dyn_cast<felt::NegFeltOp>(op)) {
+      negOp = neg;
+    } else if (auto div = dyn_cast<felt::UnsignedIntDivFeltOp>(op)) {
+      divOp = div;
+    }
+  });
+  ASSERT_TRUE(constFive != nullptr);
+  ASSERT_TRUE(sumOp != nullptr);
+  ASSERT_TRUE(negOp != nullptr);
+  ASSERT_TRUE(divOp != nullptr);
+
+  ModuleAnalysisManager mam(*mod, nullptr);
+  AnalysisManager am = mam;
+  ModuleIntervalAnalysis analysis(mod->getOperation());
+  const Field &field = Field::getField("babybear");
+  analysis.setField(field);
+  analysis.runAnalysis(am);
+
+  SmallVector<Value> values = {
+      computeFn.getArgument(0), constFive.getResult(), sumOp.getResult(), negOp.getResult(),
+      divOp.getResult()
+  };
+  for (Value value : values) {
+    const IntervalAnalysisLattice *lattice = lookupLattice(analysis, value);
+    ASSERT_NE(lattice, nullptr);
+    EXPECT_FALSE(lattice->getValue().getScalarValue().hasUnreducedInterval())
+        << buildStringViaPrint(value);
+  }
+}
+
+TEST_F(IntervalAnalysisAPITests, UnreducedIntervalsPropagateThroughSupportedArithmetic) {
+  auto mod = parseModule(kUnreducedIntervalPropagationModule);
+  auto structDef = *mod->getOps<StructDefOp>().begin();
+  auto computeFn = structDef.getComputeFuncOp();
+  ASSERT_TRUE(computeFn != nullptr);
+
+  felt::FeltConstantOp constFive;
+  felt::AddFeltOp sumOp;
+  felt::NegFeltOp negOp;
+  felt::UnsignedIntDivFeltOp divOp;
+  computeFn.walk([&](Operation *op) {
+    if (auto c = dyn_cast<felt::FeltConstantOp>(op)) {
+      constFive = c;
+    } else if (auto add = dyn_cast<felt::AddFeltOp>(op)) {
+      sumOp = add;
+    } else if (auto neg = dyn_cast<felt::NegFeltOp>(op)) {
+      negOp = neg;
+    } else if (auto div = dyn_cast<felt::UnsignedIntDivFeltOp>(op)) {
+      divOp = div;
+    }
+  });
+  ASSERT_TRUE(constFive != nullptr);
+  ASSERT_TRUE(sumOp != nullptr);
+  ASSERT_TRUE(negOp != nullptr);
+  ASSERT_TRUE(divOp != nullptr);
+
+  ModuleAnalysisManager mam(*mod, nullptr);
+  AnalysisManager am = mam;
+  ModuleIntervalAnalysis analysis(mod->getOperation());
+  const Field &field = Field::getField("babybear");
+  analysis.setField(field);
+  analysis.setTrackUnreducedIntervals(true);
+  analysis.runAnalysis(am);
+
+  const IntervalAnalysisLattice *argLattice = lookupLattice(analysis, computeFn.getArgument(0));
+  ASSERT_NE(argLattice, nullptr);
+  const ExpressionValue &argExpr = argLattice->getValue().getScalarValue();
+  ASSERT_TRUE(argExpr.hasUnreducedInterval());
+  AssertUnreducedIntervalEq(
+      UnreducedInterval(field.zero(), field.maxVal()), argExpr.getUnreducedInterval()
+  );
+
+  const IntervalAnalysisLattice *constLattice = lookupLattice(analysis, constFive.getResult());
+  ASSERT_NE(constLattice, nullptr);
+  const ExpressionValue &constExpr = constLattice->getValue().getScalarValue();
+  ASSERT_TRUE(constExpr.hasUnreducedInterval());
+  AssertUnreducedIntervalEq(
+      UnreducedInterval(field.felt(5), field.felt(5)), constExpr.getUnreducedInterval()
+  );
+
+  const IntervalAnalysisLattice *sumLattice = lookupLattice(analysis, sumOp.getResult());
+  ASSERT_NE(sumLattice, nullptr);
+  const ExpressionValue &sumExpr = sumLattice->getValue().getScalarValue();
+  ASSERT_TRUE(sumExpr.hasUnreducedInterval());
+  AssertUnreducedIntervalEq(
+      UnreducedInterval(field.felt(5), field.maxVal() + field.felt(5)),
+      sumExpr.getUnreducedInterval()
+  );
+
+  const IntervalAnalysisLattice *negLattice = lookupLattice(analysis, negOp.getResult());
+  ASSERT_NE(negLattice, nullptr);
+  const ExpressionValue &negExpr = negLattice->getValue().getScalarValue();
+  ASSERT_TRUE(negExpr.hasUnreducedInterval());
+  AssertUnreducedIntervalEq(
+      UnreducedInterval(-(field.maxVal() + field.felt(5)), -field.felt(5)),
+      negExpr.getUnreducedInterval()
+  );
+
+  const IntervalAnalysisLattice *divLattice = lookupLattice(analysis, divOp.getResult());
+  ASSERT_NE(divLattice, nullptr);
+  EXPECT_FALSE(divLattice->getValue().getScalarValue().hasUnreducedInterval());
+}
+
+TEST_F(IntervalAnalysisAPITests, UnreducedIntervalsTrackBooleanAndSelectResults) {
+  auto mod = parseModule(kUnreducedBoolAndSelectModule);
+  auto structDef = *mod->getOps<StructDefOp>().begin();
+  auto computeFn = structDef.getComputeFuncOp();
+  ASSERT_TRUE(computeFn != nullptr);
+
+  arith::ConstantOp trueConst;
+  arith::ConstantOp falseConst;
+  boolean::XorBoolOp xorOp;
+  boolean::NotBoolOp notOp;
+  SmallVector<arith::SelectOp> selectOps;
+  computeFn.walk([&](Operation *op) {
+    if (auto cst = dyn_cast<arith::ConstantOp>(op)) {
+      if (auto boolAttr = dyn_cast<BoolAttr>(cst.getValue())) {
+        if (boolAttr.getValue()) {
+          trueConst = cst;
+        } else {
+          falseConst = cst;
+        }
+      }
+    } else if (auto xorBool = dyn_cast<boolean::XorBoolOp>(op)) {
+      xorOp = xorBool;
+    } else if (auto notBool = dyn_cast<boolean::NotBoolOp>(op)) {
+      notOp = notBool;
+    } else if (auto select = dyn_cast<arith::SelectOp>(op)) {
+      selectOps.push_back(select);
+    }
+  });
+  ASSERT_TRUE(trueConst != nullptr);
+  ASSERT_TRUE(falseConst != nullptr);
+  ASSERT_TRUE(xorOp != nullptr);
+  ASSERT_TRUE(notOp != nullptr);
+  ASSERT_EQ(selectOps.size(), 3U);
+
+  ModuleAnalysisManager mam(*mod, nullptr);
+  AnalysisManager am = mam;
+  ModuleIntervalAnalysis analysis(mod->getOperation());
+  const Field &field = Field::getField("babybear");
+  analysis.setField(field);
+  analysis.setTrackUnreducedIntervals(true);
+  analysis.runAnalysis(am);
+
+  const IntervalAnalysisLattice *flagLattice = lookupLattice(analysis, computeFn.getArgument(0));
+  ASSERT_NE(flagLattice, nullptr);
+  const ExpressionValue &flagExpr = flagLattice->getValue().getScalarValue();
+  ASSERT_TRUE(flagExpr.hasUnreducedInterval());
+  AssertUnreducedIntervalEq(UnreducedInterval(0, 1), flagExpr.getUnreducedInterval());
+
+  const IntervalAnalysisLattice *trueLattice = lookupLattice(analysis, trueConst.getResult());
+  ASSERT_NE(trueLattice, nullptr);
+  ASSERT_TRUE(trueLattice->getValue().getScalarValue().hasUnreducedInterval());
+  AssertUnreducedIntervalEq(
+      UnreducedInterval(1, 1), trueLattice->getValue().getScalarValue().getUnreducedInterval()
+  );
+
+  const IntervalAnalysisLattice *falseLattice = lookupLattice(analysis, falseConst.getResult());
+  ASSERT_NE(falseLattice, nullptr);
+  ASSERT_TRUE(falseLattice->getValue().getScalarValue().hasUnreducedInterval());
+  AssertUnreducedIntervalEq(
+      UnreducedInterval(0, 0), falseLattice->getValue().getScalarValue().getUnreducedInterval()
+  );
+
+  const IntervalAnalysisLattice *xorLattice = lookupLattice(analysis, xorOp.getResult());
+  ASSERT_NE(xorLattice, nullptr);
+  ASSERT_TRUE(xorLattice->getValue().getScalarValue().hasUnreducedInterval());
+  AssertUnreducedIntervalEq(
+      UnreducedInterval(1, 1), xorLattice->getValue().getScalarValue().getUnreducedInterval()
+  );
+
+  const IntervalAnalysisLattice *notLattice = lookupLattice(analysis, notOp.getResult());
+  ASSERT_NE(notLattice, nullptr);
+  ASSERT_TRUE(notLattice->getValue().getScalarValue().hasUnreducedInterval());
+  AssertUnreducedIntervalEq(
+      UnreducedInterval(0, 1), notLattice->getValue().getScalarValue().getUnreducedInterval()
+  );
+
+  const IntervalAnalysisLattice *selectTrueLattice =
+      lookupLattice(analysis, selectOps[0].getResult());
+  ASSERT_NE(selectTrueLattice, nullptr);
+  ASSERT_TRUE(selectTrueLattice->getValue().getScalarValue().hasUnreducedInterval());
+  AssertUnreducedIntervalEq(
+      UnreducedInterval(field.felt(3), field.felt(3)),
+      selectTrueLattice->getValue().getScalarValue().getUnreducedInterval()
+  );
+
+  const IntervalAnalysisLattice *selectFalseLattice =
+      lookupLattice(analysis, selectOps[1].getResult());
+  ASSERT_NE(selectFalseLattice, nullptr);
+  ASSERT_TRUE(selectFalseLattice->getValue().getScalarValue().hasUnreducedInterval());
+  AssertUnreducedIntervalEq(
+      UnreducedInterval(field.felt(9), field.felt(9)),
+      selectFalseLattice->getValue().getScalarValue().getUnreducedInterval()
+  );
+
+  const IntervalAnalysisLattice *selectFlagLattice =
+      lookupLattice(analysis, selectOps[2].getResult());
+  ASSERT_NE(selectFlagLattice, nullptr);
+  ASSERT_TRUE(selectFlagLattice->getValue().getScalarValue().hasUnreducedInterval());
+  AssertUnreducedIntervalEq(
+      UnreducedInterval(field.felt(3), field.felt(9)),
+      selectFlagLattice->getValue().getScalarValue().getUnreducedInterval()
+  );
+}
+
+TEST_F(IntervalAnalysisAPITests, RefinedReducedIntervalsDropUnreducedIntervals) {
+  auto mod = parseModule(kUnreducedTypeFLiftModule);
+  auto structDef = *mod->getOps<StructDefOp>().begin();
+  auto computeFn = structDef.getComputeFuncOp();
+  ASSERT_TRUE(computeFn != nullptr);
+
+  felt::NegFeltOp negOp;
+  computeFn.walk([&](felt::NegFeltOp op) { negOp = op; });
+  ASSERT_TRUE(negOp != nullptr);
+
+  ModuleAnalysisManager mam(*mod, nullptr);
+  AnalysisManager am = mam;
+  ModuleIntervalAnalysis analysis(mod->getOperation());
+  const Field &field = Field::getField("babybear");
+  analysis.setField(field);
+  analysis.setTrackUnreducedIntervals(true);
+  analysis.runAnalysis(am);
+
+  const IntervalAnalysisLattice *argLattice = lookupLattice(analysis, computeFn.getArgument(0));
+  ASSERT_NE(argLattice, nullptr);
+  EXPECT_FALSE(argLattice->getValue().getScalarValue().hasUnreducedInterval());
+
+  const IntervalAnalysisLattice *negLattice = lookupLattice(analysis, negOp.getResult());
+  ASSERT_NE(negLattice, nullptr);
+  EXPECT_FALSE(negLattice->getValue().getScalarValue().hasUnreducedInterval());
+}
+
+TEST_F(IntervalAnalysisAPITests, TypeFConstraintPropagationUsesFirstUnreducedInterval) {
+  auto mod = parseModule(kUnreducedTypeFPropagationModule);
+  auto structDef = *mod->getOps<StructDefOp>().begin();
+  auto computeFn = structDef.getComputeFuncOp();
+  ASSERT_TRUE(computeFn != nullptr);
+
+  ModuleAnalysisManager mam(*mod, nullptr);
+  AnalysisManager am = mam;
+  ModuleIntervalAnalysis analysis(mod->getOperation());
+  const Field &field = Field::getField("babybear");
+  analysis.setField(field);
+  analysis.setPropagateInputConstraints(true);
+  analysis.setTrackUnreducedIntervals(true);
+  analysis.runAnalysis(am);
+
+  const IntervalAnalysisLattice *argLattice = lookupLattice(analysis, computeFn.getArgument(0));
+  ASSERT_NE(argLattice, nullptr);
+  const ExpressionValue &argExpr = argLattice->getValue().getScalarValue();
+  ASSERT_TRUE(argExpr.getInterval().isTypeF());
+  ASSERT_TRUE(argExpr.hasUnreducedInterval());
+  AssertUnreducedIntervalEq(UnreducedInterval(-1, 0), argExpr.getUnreducedInterval());
+}
+
+TEST_F(IntervalAnalysisAPITests, ProductFunctionsTrackReducedIntervals) {
+  auto mod = parseModule(kProductFunctionIntervalModule);
+  auto structDef = *mod->getOps<StructDefOp>().begin();
+  auto productFn = structDef.getProductFuncOp();
+  ASSERT_TRUE(productFn != nullptr);
+
+  felt::AddFeltOp sumOp;
+  component::MemberReadOp readOp;
+  productFn.walk([&](Operation *op) {
+    if (auto add = dyn_cast<felt::AddFeltOp>(op)) {
+      sumOp = add;
+    } else if (auto read = dyn_cast<component::MemberReadOp>(op)) {
+      readOp = read;
+    }
+  });
+  ASSERT_TRUE(sumOp != nullptr);
+  ASSERT_TRUE(readOp != nullptr);
+
+  ModuleAnalysisManager mam(*mod, nullptr);
+  AnalysisManager am = mam;
+  ModuleIntervalAnalysis analysis(mod->getOperation());
+  const Field &field = Field::getField("babybear");
+  analysis.setField(field);
+  analysis.runAnalysis(am);
+
+  const IntervalAnalysisLattice *argLattice = lookupLattice(analysis, productFn.getArgument(0));
+  ASSERT_NE(argLattice, nullptr);
+  const ExpressionValue &argExpr = argLattice->getValue().getScalarValue();
+  ASSERT_TRUE(checkCond(
+      Interval::TypeA(field, field.felt(5), field.felt(6)), argExpr.getInterval(),
+      argExpr.getInterval() == Interval::TypeA(field, field.felt(5), field.felt(6))
+  ));
+
+  const IntervalAnalysisLattice *sumLattice = lookupLattice(analysis, sumOp.getResult());
+  ASSERT_NE(sumLattice, nullptr);
+  const ExpressionValue &sumExpr = sumLattice->getValue().getScalarValue();
+  ASSERT_TRUE(checkCond(
+      Interval::TypeA(field, field.felt(10), field.felt(11)), sumExpr.getInterval(),
+      sumExpr.getInterval() == Interval::TypeA(field, field.felt(10), field.felt(11))
+  ));
+
+  const IntervalAnalysisLattice *readLattice = lookupLattice(analysis, readOp.getResult());
+  ASSERT_NE(readLattice, nullptr);
+  const ExpressionValue &readExpr = readLattice->getValue().getScalarValue();
+  ASSERT_TRUE(checkCond(
+      Interval::TypeA(field, field.felt(10), field.felt(11)), readExpr.getInterval(),
+      readExpr.getInterval() == Interval::TypeA(field, field.felt(10), field.felt(11))
+  ));
+}
+
+TEST_F(IntervalAnalysisAPITests, ProductFunctionsTrackUnreducedIntervals) {
+  auto mod = parseModule(kProductFunctionUnreducedModule);
+  auto structDef = *mod->getOps<StructDefOp>().begin();
+  auto productFn = structDef.getProductFuncOp();
+  ASSERT_TRUE(productFn != nullptr);
+
+  felt::FeltConstantOp constFive;
+  felt::AddFeltOp sumOp;
+  component::MemberReadOp readOp;
+  productFn.walk([&](Operation *op) {
+    if (auto cst = dyn_cast<felt::FeltConstantOp>(op)) {
+      constFive = cst;
+    } else if (auto add = dyn_cast<felt::AddFeltOp>(op)) {
+      sumOp = add;
+    } else if (auto read = dyn_cast<component::MemberReadOp>(op)) {
+      readOp = read;
+    }
+  });
+  ASSERT_TRUE(constFive != nullptr);
+  ASSERT_TRUE(sumOp != nullptr);
+  ASSERT_TRUE(readOp != nullptr);
+
+  ModuleAnalysisManager mam(*mod, nullptr);
+  AnalysisManager am = mam;
+  ModuleIntervalAnalysis analysis(mod->getOperation());
+  const Field &field = Field::getField("babybear");
+  analysis.setField(field);
+  analysis.setTrackUnreducedIntervals(true);
+  analysis.runAnalysis(am);
+
+  const IntervalAnalysisLattice *argLattice = lookupLattice(analysis, productFn.getArgument(0));
+  ASSERT_NE(argLattice, nullptr);
+  const ExpressionValue &argExpr = argLattice->getValue().getScalarValue();
+  ASSERT_TRUE(argExpr.hasUnreducedInterval());
+  AssertUnreducedIntervalEq(
+      UnreducedInterval(field.zero(), field.maxVal()), argExpr.getUnreducedInterval()
+  );
+
+  const IntervalAnalysisLattice *constLattice = lookupLattice(analysis, constFive.getResult());
+  ASSERT_NE(constLattice, nullptr);
+  const ExpressionValue &constExpr = constLattice->getValue().getScalarValue();
+  ASSERT_TRUE(constExpr.hasUnreducedInterval());
+  AssertUnreducedIntervalEq(
+      UnreducedInterval(field.felt(5), field.felt(5)), constExpr.getUnreducedInterval()
+  );
+
+  const IntervalAnalysisLattice *sumLattice = lookupLattice(analysis, sumOp.getResult());
+  ASSERT_NE(sumLattice, nullptr);
+  const ExpressionValue &sumExpr = sumLattice->getValue().getScalarValue();
+  ASSERT_TRUE(sumExpr.hasUnreducedInterval());
+  AssertUnreducedIntervalEq(
+      UnreducedInterval(field.felt(5), field.maxVal() + field.felt(5)),
+      sumExpr.getUnreducedInterval()
+  );
+
+  const IntervalAnalysisLattice *readLattice = lookupLattice(analysis, readOp.getResult());
+  ASSERT_NE(readLattice, nullptr);
+  const ExpressionValue &readExpr = readLattice->getValue().getScalarValue();
+  ASSERT_TRUE(readExpr.hasUnreducedInterval());
+  AssertUnreducedIntervalEq(
+      UnreducedInterval(field.felt(5), field.maxVal() + field.felt(5)),
+      readExpr.getUnreducedInterval()
+  );
 }

--- a/unittests/Analysis/IntervalTests.cpp
+++ b/unittests/Analysis/IntervalTests.cpp
@@ -460,6 +460,63 @@ module attributes {llzk.lang} {
 }
 )mlir";
 
+  static constexpr auto kUnreducedSignalReadDefaultModule = R"mlir(
+module attributes {llzk.lang} {
+  struct.def @TrackUnreducedSignalReadDefault {
+    struct.member @sig : !felt.type {signal}
+
+    function.def @compute() -> !struct.type<@TrackUnreducedSignalReadDefault>
+        attributes {function.allow_witness} {
+      %self = struct.new : <@TrackUnreducedSignalReadDefault>
+      function.return %self : !struct.type<@TrackUnreducedSignalReadDefault>
+    }
+
+    function.def @constrain(%self: !struct.type<@TrackUnreducedSignalReadDefault>)
+        attributes {function.allow_constraint} {
+      %sig = struct.readm %self[@sig] : <@TrackUnreducedSignalReadDefault>, !felt.type
+      function.return
+    }
+  }
+}
+)mlir";
+
+  static constexpr auto kUnreducedIsZeroModule = R"mlir(
+module attributes {llzk.lang} {
+  struct.def @IsZero {
+    struct.member @out : !felt.type {llzk.pub}
+    struct.member @inv : !felt.type
+
+    function.def @compute(%in: !felt.type) -> !struct.type<@IsZero>
+        attributes {function.allow_non_native_field_ops, function.allow_witness} {
+      %self = struct.new : <@IsZero>
+      %const_1 = felt.const 1
+      %inv = felt.inv %in
+      struct.writem %self[@inv] = %inv : <@IsZero>, !felt.type
+      %neg_in = felt.neg %in : !felt.type
+      %mul = felt.mul %neg_in, %inv : !felt.type, !felt.type
+      %out = felt.add %mul, %const_1 : !felt.type, !felt.type
+      struct.writem %self[@out] = %out : <@IsZero>, !felt.type
+      function.return %self : !struct.type<@IsZero>
+    }
+
+    function.def @constrain(%self: !struct.type<@IsZero>, %in: !felt.type)
+        attributes {function.allow_constraint} {
+      %const_0 = felt.const 0
+      %const_1 = felt.const 1
+      %out = struct.readm %self[@out] : <@IsZero>, !felt.type
+      %inv = struct.readm %self[@inv] : <@IsZero>, !felt.type
+      %neg_in = felt.neg %in : !felt.type
+      %mul = felt.mul %neg_in, %inv : !felt.type, !felt.type
+      %sum = felt.add %mul, %const_1 : !felt.type, !felt.type
+      constrain.eq %out, %sum : !felt.type, !felt.type
+      %zero_prod = felt.mul %in, %out : !felt.type, !felt.type
+      constrain.eq %zero_prod, %const_0 : !felt.type, !felt.type
+      function.return
+    }
+  }
+}
+)mlir";
+
   static constexpr auto kProductFunctionIntervalModule = R"mlir(
 module attributes {llzk.lang} {
   struct.def @ProductIntervals {
@@ -901,6 +958,121 @@ TEST_F(IntervalAnalysisAPITests, TypeFConstraintPropagationUsesFirstUnreducedInt
   ASSERT_TRUE(argExpr.getInterval().isTypeF());
   ASSERT_TRUE(argExpr.hasUnreducedInterval());
   AssertUnreducedIntervalEq(UnreducedInterval(-1, 0), argExpr.getUnreducedInterval());
+}
+
+TEST_F(IntervalAnalysisAPITests, UnconstrainedSignalReadsDefaultToCanonicalUnreducedInterval) {
+  auto mod = parseModule(kUnreducedSignalReadDefaultModule);
+  auto structDef = *mod->getOps<StructDefOp>().begin();
+  auto constrainFn = structDef.getConstrainFuncOp();
+  ASSERT_TRUE(constrainFn != nullptr);
+
+  component::MemberReadOp readOp;
+  constrainFn.walk([&](component::MemberReadOp op) { readOp = op; });
+  ASSERT_TRUE(readOp != nullptr);
+
+  ModuleAnalysisManager mam(*mod, nullptr);
+  AnalysisManager am = mam;
+  ModuleIntervalAnalysis analysis(mod->getOperation());
+  const Field &field = Field::getField("babybear");
+  analysis.setField(field);
+  analysis.setTrackUnreducedIntervals(true);
+  analysis.runAnalysis(am);
+
+  const IntervalAnalysisLattice *readLattice = lookupLattice(analysis, readOp.getResult());
+  ASSERT_NE(readLattice, nullptr);
+  const ExpressionValue &readExpr = readLattice->getValue().getScalarValue();
+  ASSERT_TRUE(readExpr.hasUnreducedInterval());
+  AssertUnreducedIntervalEq(
+      UnreducedInterval(field.zero(), field.maxVal()), readExpr.getUnreducedInterval()
+  );
+}
+
+TEST_F(IntervalAnalysisAPITests, IsZeroTracksWideUnreducedMulAndSumIntervals) {
+  auto mod = parseModule(kUnreducedIsZeroModule);
+  auto structDef = *mod->getOps<StructDefOp>().begin();
+  auto computeFn = structDef.getComputeFuncOp();
+  auto constrainFn = structDef.getConstrainFuncOp();
+  ASSERT_TRUE(computeFn != nullptr);
+  ASSERT_TRUE(constrainFn != nullptr);
+
+  llvm::SmallVector<felt::InvFeltOp> computeInvOps;
+  llvm::SmallVector<felt::NegFeltOp> computeNegOps;
+  llvm::SmallVector<felt::MulFeltOp> computeMulOps;
+  llvm::SmallVector<felt::AddFeltOp> computeAddOps;
+  computeFn.walk([&](Operation *op) {
+    if (auto inv = dyn_cast<felt::InvFeltOp>(op)) {
+      computeInvOps.push_back(inv);
+    } else if (auto neg = dyn_cast<felt::NegFeltOp>(op)) {
+      computeNegOps.push_back(neg);
+    } else if (auto mul = dyn_cast<felt::MulFeltOp>(op)) {
+      computeMulOps.push_back(mul);
+    } else if (auto add = dyn_cast<felt::AddFeltOp>(op)) {
+      computeAddOps.push_back(add);
+    }
+  });
+  ASSERT_EQ(computeInvOps.size(), 1U);
+  ASSERT_EQ(computeNegOps.size(), 1U);
+  ASSERT_EQ(computeMulOps.size(), 1U);
+  ASSERT_EQ(computeAddOps.size(), 1U);
+
+  llvm::SmallVector<felt::NegFeltOp> constrainNegOps;
+  llvm::SmallVector<felt::MulFeltOp> constrainMulOps;
+  llvm::SmallVector<felt::AddFeltOp> constrainAddOps;
+  constrainFn.walk([&](Operation *op) {
+    if (auto neg = dyn_cast<felt::NegFeltOp>(op)) {
+      constrainNegOps.push_back(neg);
+    } else if (auto mul = dyn_cast<felt::MulFeltOp>(op)) {
+      constrainMulOps.push_back(mul);
+    } else if (auto add = dyn_cast<felt::AddFeltOp>(op)) {
+      constrainAddOps.push_back(add);
+    }
+  });
+  ASSERT_EQ(constrainNegOps.size(), 1U);
+  ASSERT_EQ(constrainMulOps.size(), 2U);
+  ASSERT_EQ(constrainAddOps.size(), 1U);
+
+  ModuleAnalysisManager mam(*mod, nullptr);
+  AnalysisManager am = mam;
+  ModuleIntervalAnalysis analysis(mod->getOperation());
+  const Field &field = Field::getField("babybear");
+  analysis.setField(field);
+  analysis.setTrackUnreducedIntervals(true);
+  analysis.runAnalysis(am);
+
+  auto pMinusOne = field.maxVal();
+  auto square = pMinusOne * pMinusOne;
+  auto oneMinusSquare = field.one() - square;
+
+  auto assertValueHasUnreduced = [&](Value value, const UnreducedInterval &expected) {
+    const IntervalAnalysisLattice *lattice = lookupLattice(analysis, value);
+    ASSERT_NE(lattice, nullptr);
+    const ExpressionValue &expr = lattice->getValue().getScalarValue();
+    ASSERT_TRUE(expr.hasUnreducedInterval());
+    AssertUnreducedIntervalEq(expected, expr.getUnreducedInterval());
+  };
+
+  assertValueHasUnreduced(
+      computeInvOps.front().getResult(), UnreducedInterval(field.zero(), field.maxVal())
+  );
+  assertValueHasUnreduced(
+      computeNegOps.front().getResult(), UnreducedInterval(-pMinusOne, field.zero())
+  );
+  assertValueHasUnreduced(
+      computeMulOps.front().getResult(), UnreducedInterval(-square, field.zero())
+  );
+  assertValueHasUnreduced(
+      computeAddOps.front().getResult(), UnreducedInterval(oneMinusSquare, field.one())
+  );
+
+  assertValueHasUnreduced(
+      constrainNegOps.front().getResult(), UnreducedInterval(-pMinusOne, field.zero())
+  );
+  assertValueHasUnreduced(
+      constrainMulOps.front().getResult(), UnreducedInterval(-square, field.zero())
+  );
+  assertValueHasUnreduced(
+      constrainAddOps.front().getResult(), UnreducedInterval(oneMinusSquare, field.one())
+  );
 }
 
 TEST_F(IntervalAnalysisAPITests, ProductFunctionsTrackReducedIntervals) {


### PR DESCRIPTION
The optimized SMT lowering requires tracking the unreduced intervals for SSA values. The interval analysis already computes unreduced intervals, so this PR extends it to track unreduced intervals. 