### PR TITLE
Fix `llzk-tblgen` handling for VariadicOfVariadic

### DIFF
--- a/changelogs/unreleased/copilot__review-llzk-tblgen-tool-3.yaml
+++ b/changelogs/unreleased/copilot__review-llzk-tblgen-tool-3.yaml
@@ -1,2 +1,2 @@
 fixed:
-  - bug in `llzk-tblgen` where generated setter did not handle VariadicOfVariadic operand groups correctly and simplify Variadic group handling
+  - bug in `llzk-tblgen` where generated setter did not handle VariadicOfVariadic operand groups correctly

--- a/changelogs/unreleased/copilot__review-llzk-tblgen-tool-3.yaml
+++ b/changelogs/unreleased/copilot__review-llzk-tblgen-tool-3.yaml
@@ -1,0 +1,2 @@
+fixed:
+  - bug in `llzk-tblgen` where generated setter did not handle VariadicOfVariadic operand groups correctly and simplify Variadic group handling

--- a/lib/CAPI/Dialect/Struct.cpp
+++ b/lib/CAPI/Dialect/Struct.cpp
@@ -19,6 +19,7 @@
 #include "llzk/Util/SymbolLookup.h"
 #include "llzk/Util/TypeHelper.h"
 
+#include <mlir-c/BuiltinAttributes.h>
 #include <mlir-c/Support.h>
 
 #include <mlir/CAPI/AffineMap.h>

--- a/tools/llzk-tblgen/CommonAttrOrTypeCAPIGen.h
+++ b/tools/llzk-tblgen/CommonAttrOrTypeCAPIGen.h
@@ -174,7 +174,7 @@ struct AttrOrTypeImplementationGenerator : public ImplementationGenerator {
     this->paramNameCapitalized = toPascalCase(name);
   }
 
-  virtual void genPrologue() const {
+  void genPrologue() const override {
     os << R"(
 #include <mlir/CAPI/IR.h>
 #include <mlir/CAPI/Support.h>

--- a/tools/llzk-tblgen/CommonCAPIGen.h
+++ b/tools/llzk-tblgen/CommonCAPIGen.h
@@ -452,6 +452,8 @@ struct ImplementationGenerator : public Generator {
   using Generator::Generator;
   ~ImplementationGenerator() override = default;
 
+  virtual void genPrologue() const {}
+
   virtual void genIsAImpl() const {
     static constexpr char fmt[] = R"(
 bool {0}{1}IsA_{2}_{3}(Mlir{1} inp) {{

--- a/tools/llzk-tblgen/OpCAPIGen.cpp
+++ b/tools/llzk-tblgen/OpCAPIGen.cpp
@@ -551,15 +551,17 @@ void {0}{1}_{2}Set{3}(MlirOperation op, intptr_t groupCount, MlirValueRange cons
     return;
 
   ::llvm::SmallVector<::mlir::Value> vals;
-  for (intptr_t g = 0; g < groupCount; ++g)
-    for (intptr_t i = 0; i < groups[g].size; ++i)
+  for (intptr_t g = 0; g < groupCount; ++g) {{
+    assert(groups[g].size >= 0 && "group size must be non-negative");
+    for (intptr_t i = 0; i < groups[g].size; ++i) {{
       vals.push_back(unwrap(groups[g].values[i]));
+    }
+  }
   ::llvm::cast<{2}>(unwrap(op)).get{3}Mutable().join().assign(vals);
 
   ::llvm::SmallVector<int32_t> newGroupSizes;
   newGroupSizes.reserve(static_cast<size_t>(groupCount));
   for (intptr_t g = 0; g < groupCount; ++g) {{
-    assert(groups[g].size >= 0 && "group size must be non-negative");
     assert(
         groups[g].size <= static_cast<intptr_t>(std::numeric_limits<int32_t>::max()) &&
         "group size exceeds int32_t range"

--- a/tools/llzk-tblgen/OpCAPIGen.cpp
+++ b/tools/llzk-tblgen/OpCAPIGen.cpp
@@ -443,6 +443,10 @@ MlirOperation {0}{1}_{2}Build(MlirOpBuilder builder, MlirLocation location{3}) {
 MlirValue {0}{1}_{2}Get{3}(MlirOperation op) {{
   auto range = llvm::cast<{2}>(unwrap(op)).getODSOperandIndexAndLength({4});
   assert(range.second == 1 && "expected fixed operand segment size");
+  assert(
+      static_cast<uintptr_t>(range.first) <= static_cast<uintptr_t>(std::numeric_limits<intptr_t>::max()) &&
+      "operand index exceeds intptr_t range"
+  );
   return mlirOperationGetOperand(op, static_cast<intptr_t>(range.first));
 }
 )";
@@ -463,6 +467,10 @@ MlirValue {0}{1}_{2}Get{3}(MlirOperation op) {{
 void {0}{1}_{2}Set{3}(MlirOperation op, MlirValue value) {{
   auto range = llvm::cast<{2}>(unwrap(op)).getODSOperandIndexAndLength({4});
   assert(range.second == 1 && "expected fixed operand segment size");
+  assert(
+      static_cast<uintptr_t>(range.first) <= static_cast<uintptr_t>(std::numeric_limits<intptr_t>::max()) &&
+      "operand index exceeds intptr_t range"
+  );
   mlirOperationSetOperand(op, static_cast<intptr_t>(range.first), value);
 }
 )";
@@ -488,6 +496,10 @@ intptr_t {0}{1}_{2}Get{3}Count(MlirOperation op) {{
 MlirValue {0}{1}_{2}Get{3}At(MlirOperation op, intptr_t index) {{
   auto range = llvm::cast<{2}>(unwrap(op)).getODSOperandIndexAndLength({4});
   assert(index >= 0 && index < range.second && "variadic operand index out of range");
+  assert(
+      static_cast<uintptr_t>(range.first) <= static_cast<uintptr_t>(std::numeric_limits<intptr_t>::max()) &&
+      "operand index exceeds intptr_t range"
+  );
   return mlirOperationGetOperand(op, static_cast<intptr_t>(range.first) + index);
 }
 )";
@@ -555,6 +567,10 @@ void {0}{1}_{2}Set{3}(MlirOperation op, intptr_t groupCount, MlirValueRange cons
     newGroupSizes.push_back(static_cast<int32_t>(groups[g].size));
   }
   MlirContext ctx = mlirOperationGetContext(op);
+  assert(
+      newGroupSizes.size() <= static_cast<size_t>(std::numeric_limits<intptr_t>::max()) &&
+      "group count exceeds intptr_t range"
+  );
   mlirOperationSetAttributeByName(
       op, mlirStringRefCreateFromCString("{4}"),
       mlirDenseI32ArrayGet(ctx, static_cast<intptr_t>(newGroupSizes.size()), newGroupSizes.data())

--- a/tools/llzk-tblgen/OpCAPIGen.cpp
+++ b/tools/llzk-tblgen/OpCAPIGen.cpp
@@ -143,6 +143,25 @@ MLIR_CAPI_EXPORTED void {0}{1}_{2}Set{3}(MlirOperation op, intptr_t count, MlirV
     );
   }
 
+  void genVariadicOfVariadicOperandSetterDecl() const {
+    static constexpr char fmt[] = R"(
+/// Set {3} operand groups of {4}::{2} Operation.
+/// Each element of `groups` represents one group; its `size` field drives the per-group
+/// segment-size attribute and `values` supplies the operands for that group.
+MLIR_CAPI_EXPORTED void {0}{1}_{2}Set{3}(MlirOperation op, intptr_t groupCount, MlirValueRange const *groups);
+)";
+    assert(!className.empty() && "className must be set");
+    assert(!operandNameCapitalized.empty() && "operandName must be set");
+    os << llvm::formatv(
+        fmt,
+        FunctionPrefix,         // {0}
+        dialectNameCapitalized, // {1}
+        className,              // {2}
+        operandNameCapitalized, // {3}
+        dialectNamespace        // {4}
+    );
+  }
+
   void genAttributeGetterDecl() const {
     static constexpr char fmt[] = R"(
 /// Get {3} attribute from {4}::{2} Operation.
@@ -325,7 +344,11 @@ static bool emitOpCAPIHeader(const llvm::RecordKeeper &records, raw_ostream &os)
           generator.genVariadicOperandGetterDecl();
         }
         if (GenOpOperandSetters) {
-          generator.genVariadicOperandSetterDecl();
+          if (operand.isVariadicOfVariadic()) {
+            generator.genVariadicOfVariadicOperandSetterDecl();
+          } else {
+            generator.genVariadicOperandSetterDecl();
+          }
         }
       } else {
         if (GenOpOperandGetters) {
@@ -480,79 +503,73 @@ MlirValue {0}{1}_{2}Get{3}At(MlirOperation op, intptr_t index) {{
     );
   }
 
-  void genVariadicOperandSetterImpl(int index, bool updateOperandSegmentSizes) const {
+  // Delegate to the ODS-generated mutable accessor. assign() keeps operandSegmentSizes in sync
+  // automatically via MutableOperandRange::updateLength.
+  void genVariadicOperandSetterImpl() const {
     static constexpr char fmt[] = R"(
 void {0}{1}_{2}Set{3}(MlirOperation op, intptr_t count, MlirValue const *values) {{
-  auto range = llvm::cast<{2}>(unwrap(op)).getODSOperandIndexAndLength({4});
-  intptr_t numOperands = mlirOperationGetNumOperands(op);
-  intptr_t startIdx = static_cast<intptr_t>(range.first);
-  intptr_t oldCount = static_cast<intptr_t>(range.second);
-
-  // Validate bounds
-  if (startIdx < 0 || startIdx > numOperands) {{
+  if (count < 0)
     return;
-  }
-  if (count < 0 || count > (std::numeric_limits<intptr_t>::max() - startIdx)) {{
-    return;
-  }
-
-  intptr_t newNumOperands = numOperands - oldCount + count;
-
-  std::vector<MlirValue> newOperands(newNumOperands);
-
-  // Copy operands before this variadic group
-  for (intptr_t i = 0; i < startIdx; ++i) {{
-    newOperands[i] = mlirOperationGetOperand(op, i);
-  }
-
-  // Copy new variadic operands
-  for (intptr_t i = 0; i < count; ++i) {{
-    newOperands[startIdx + i] = values[i];
-  }
-
-  // Copy operands after this variadic group
-  for (intptr_t i = startIdx + oldCount; i < numOperands; ++i) {{
-    newOperands[i - oldCount + count] = mlirOperationGetOperand(op, i);
-  }
-
-  mlirOperationSetOperands(op, newNumOperands, newOperands.data());{5}
+  ::llvm::SmallVector<::mlir::Value> vals;
+  vals.reserve(static_cast<size_t>(count));
+  for (intptr_t i = 0; i < count; ++i)
+    vals.push_back(unwrap(values[i]));
+  ::llvm::cast<{2}>(unwrap(op)).get{3}Mutable().assign(vals);
 }
 )";
     assert(!className.empty() && "className must be set");
     assert(!operandNameCapitalized.empty() && "operandName must be set");
-    std::string updateSegmentSizes;
-    if (updateOperandSegmentSizes) {
-      llvm::raw_string_ostream updateOs(updateSegmentSizes);
-      updateOs << llvm::formatv(
-          R"(
+    os << llvm::formatv(
+        fmt,
+        FunctionPrefix,         // {0}
+        dialectNameCapitalized, // {1}
+        className,              // {2}
+        operandNameCapitalized  // {3}
+    );
+  }
 
-  // Update operandSegmentSizes to reflect the new count for this segment.
-  MlirAttribute segSizes = mlirOperationGetAttributeByName(op, mlirStringRefCreateFromCString("operandSegmentSizes"));
-  assert(!mlirAttributeIsNull(segSizes) && "expected operandSegmentSizes attribute");
-  assert(mlirAttributeIsADenseI32Array(segSizes) &&
-         "expected operandSegmentSizes to be a DenseI32ArrayAttr");
-  intptr_t numSegments = mlirDenseArrayGetNumElements(segSizes);
-  assert(numSegments > {0} && "operandSegmentSizes has fewer segments than expected");
-  std::vector<int32_t> newSegSizes(numSegments);
-  for (intptr_t i = 0; i < numSegments; ++i)
-    newSegSizes[i] = mlirDenseI32ArrayGetElement(segSizes, i);
-  assert(count <= static_cast<intptr_t>(std::numeric_limits<int32_t>::max()) && "count exceeds int32_t range");
-  newSegSizes[{0}] = static_cast<int32_t>(count);
+  // For VariadicOfVariadic operands the caller passes one MlirValueRange per group. The flat
+  // operand list is rebuilt from all groups, operandSegmentSizes is updated automatically by
+  // join().assign(), and the per-group segment-size attribute (whose name is read from the
+  // TableGen constraint via getVariadicOfVariadicSegmentSizeAttr()) is updated explicitly.
+  void genVariadicOfVariadicOperandSetterImpl(mlir::StringRef segSizeAttrName) const {
+    static constexpr char fmt[] = R"(
+void {0}{1}_{2}Set{3}(MlirOperation op, intptr_t groupCount, MlirValueRange const *groups) {{
+  if (groupCount < 0)
+    return;
+
+  ::llvm::SmallVector<::mlir::Value> vals;
+  for (intptr_t g = 0; g < groupCount; ++g)
+    for (intptr_t i = 0; i < groups[g].size; ++i)
+      vals.push_back(unwrap(groups[g].values[i]));
+  ::llvm::cast<{2}>(unwrap(op)).get{3}Mutable().join().assign(vals);
+
+  ::llvm::SmallVector<int32_t> newGroupSizes;
+  newGroupSizes.reserve(static_cast<size_t>(groupCount));
+  for (intptr_t g = 0; g < groupCount; ++g) {{
+    assert(groups[g].size >= 0 && "group size must be non-negative");
+    assert(
+        groups[g].size <= static_cast<intptr_t>(std::numeric_limits<int32_t>::max()) &&
+        "group size exceeds int32_t range"
+    );
+    newGroupSizes.push_back(static_cast<int32_t>(groups[g].size));
+  }
   MlirContext ctx = mlirOperationGetContext(op);
-  MlirAttribute newSegSizesAttr = mlirDenseI32ArrayGet(ctx, numSegments, newSegSizes.data());
-  mlirOperationSetAttributeByName(op, mlirStringRefCreateFromCString("operandSegmentSizes"), newSegSizesAttr);
-)",
-          index
-      );
-    }
+  mlirOperationSetAttributeByName(
+      op, mlirStringRefCreateFromCString("{4}"),
+      mlirDenseI32ArrayGet(ctx, static_cast<intptr_t>(newGroupSizes.size()), newGroupSizes.data())
+  );
+}
+)";
+    assert(!className.empty() && "className must be set");
+    assert(!operandNameCapitalized.empty() && "operandName must be set");
     os << llvm::formatv(
         fmt,
         FunctionPrefix,         // {0}
         dialectNameCapitalized, // {1}
         className,              // {2}
         operandNameCapitalized, // {3}
-        index,                  // {4}
-        updateSegmentSizes      // {5}
+        segSizeAttrName         // {4}
     );
   }
 
@@ -782,11 +799,6 @@ static bool emitOpCAPIImpl(const llvm::RecordKeeper &records, raw_ostream &os) {
       generator.genIsAImpl();
     }
 
-    // If the op has AttrSizedOperandSegments, variadic setters must keep the generated segment
-    // size metadata in sync after replacing the operand range.
-    bool hasAttrSizedOperandSegments =
-        op.getTrait("::mlir::OpTrait::AttrSizedOperandSegments") != nullptr;
-
     // Generate operand getters and setters
     for (int i = 0, e = op.getNumOperands(); i < e; ++i) {
       const auto &operand = op.getOperand(i);
@@ -796,7 +808,13 @@ static bool emitOpCAPIImpl(const llvm::RecordKeeper &records, raw_ostream &os) {
           generator.genVariadicOperandGetterImpl(i);
         }
         if (GenOpOperandSetters) {
-          generator.genVariadicOperandSetterImpl(i, hasAttrSizedOperandSegments);
+          if (operand.isVariadicOfVariadic()) {
+            generator.genVariadicOfVariadicOperandSetterImpl(
+                operand.constraint.getVariadicOfVariadicSegmentSizeAttr()
+            );
+          } else {
+            generator.genVariadicOperandSetterImpl();
+          }
         }
       } else {
         if (GenOpOperandGetters) {

--- a/tools/llzk-tblgen/OpCAPIGen.cpp
+++ b/tools/llzk-tblgen/OpCAPIGen.cpp
@@ -412,6 +412,15 @@ struct OpImplementationGenerator : public ImplementationGenerator, OpGeneratorDa
   using ImplementationGenerator::ImplementationGenerator;
   ~OpImplementationGenerator() override = default;
 
+  void genPrologue() const override {
+    os << R"(
+#include <limits>
+
+using namespace mlir;
+using namespace llvm;
+)";
+  }
+
   /// @brief Generate operation "Build" function implementation
   /// @param operationName The full operation name (e.g., "dialect.opname")
   /// @param params The parameter list for the "Build" function
@@ -794,6 +803,7 @@ static bool emitOpCAPIImpl(const llvm::RecordKeeper &records, raw_ostream &os) {
   emitSourceFileHeader("Op C API Definitions", os, records);
 
   OpImplementationGenerator generator("Operation", os);
+  generator.genPrologue();
 
   for (const auto *def : records.getAllDerivedDefinitions("Op")) {
     const Operator op(def);

--- a/tools/llzk-tblgen/OpCAPITestGen.cpp
+++ b/tools/llzk-tblgen/OpCAPITestGen.cpp
@@ -180,6 +180,22 @@ TEST_F({1}OperationLinkTests, {0}_{2}_Set{3}_Variadic) {{
   mlirOperationDestroy(testOp);
 }
 )";
+
+    static constexpr char VariadicOfVariadicOperandSetterTest[] = R"(
+TEST_F({1}OperationLinkTests, {0}_{2}_Set{3}_VariadicOfVariadic) {{
+  auto testOp = createIndexOperation();
+
+  if ({0}OperationIsA_{1}_{2}(testOp)) {{
+    auto dummyValue = mlirOperationGetResult(testOp, 0);
+    MlirValueRange groups[1];
+    groups[0].values = &dummyValue;
+    groups[0].size = 1;
+    {0}{1}_{2}Set{3}(testOp, 1, groups);
+  }
+
+  mlirOperationDestroy(testOp);
+}
+)";
     assert(!className.empty() && "className must be set");
 
     for (int i = 0, e = op.getNumOperands(); i < e; ++i) {
@@ -197,7 +213,8 @@ TEST_F({1}OperationLinkTests, {0}_{2}_Set{3}_Variadic) {{
         }
         if (GenOpOperandSetters) {
           os << llvm::formatv(
-              VariadicOperandSetterTest,
+              operand.isVariadicOfVariadic() ? VariadicOfVariadicOperandSetterTest
+                                             : VariadicOperandSetterTest,
               FunctionPrefix,         // {0}
               dialectNameCapitalized, // {1}
               className,              // {2}

--- a/unittests/CAPI/Dialect/Array.cpp
+++ b/unittests/CAPI/Dialect/Array.cpp
@@ -476,3 +476,105 @@ std::unique_ptr<ExtractArrayOpBuildFuncHelper> ExtractArrayOpBuildFuncHelper::ge
   };
   return std::make_unique<Impl>();
 }
+
+/// Test that SetMapOperands (a VariadicOfVariadic operand setter) correctly updates both
+/// `operandSegmentSizes` (via `MutableOperandRange::assign()` after `join()`) and
+/// `mapOpGroupSizes` (via the explicit post-update in the generated code).
+///
+/// CreateArrayOp.mapOperands is declared as VariadicOfVariadic, so the generated setter
+/// accepts one `MlirValueRange` per group. Internally it calls
+/// `getMapOperandsMutable().join().assign(flatVals)`. The `join()` produces a flat
+/// `MutableOperandRange` whose `operandSegments` carries `operandSegmentSizes[1]`, so
+/// `assign()` keeps that slot in sync automatically via `updateLength`. The generator then
+/// explicitly updates the per-group segment-size attribute (here `mapOpGroupSizes`) using
+/// the name obtained from `TypeConstraint::getVariadicOfVariadicSegmentSizeAttr()`.
+/// LLZK-specific attributes such as `numDimsPerMap` are the caller's responsibility and
+/// are not touched by the generated setter.
+TEST_F(ArrayDialectTests, create_array_op_set_map_operands_updates_attributes) {
+  auto location = mlirLocationUnknownGet(context);
+  auto elt_type = createIndexType();
+
+  // Create four constant ops: e0 (element), m0 and m1 (initial map operands), m_new.
+  auto auxOps = create_n_ops(4, elt_type);
+  MlirValue e0 = mlirOperationGetResult(auxOps[0], 0);
+  MlirValue m0 = mlirOperationGetResult(auxOps[1], 0);
+  MlirValue m1 = mlirOperationGetResult(auxOps[2], 0);
+  MlirValue m_new = mlirOperationGetResult(auxOps[3], 0);
+
+  // Manually build an `array.new` op with:
+  //   operands:            [e0, m0, m1]
+  //   operandSegmentSizes: [1, 2]  (elements=1, mapOperands=2)
+  //   mapOpGroupSizes:     [2]     (one group of 2 map operands)
+  //   numDimsPerMap:       [1]     (1 dim per map for the one group)
+  //   result:              !array.type<1 x index>
+  int64_t dims[1] = {1};
+  auto arr_type = test_array(elt_type, llvm::ArrayRef(dims, 1));
+
+  auto op_state = mlirOperationStateGet(mlirStringRefCreateFromCString("array.new"), location);
+  MlirValue operands[3] = {e0, m0, m1};
+  mlirOperationStateAddOperands(&op_state, 3, operands);
+  mlirOperationStateAddResults(&op_state, 1, &arr_type);
+
+  int32_t segSizes[2] = {1, 2};
+  int32_t groupSizes[1] = {2};
+  int32_t numDims[1] = {1};
+  MlirNamedAttribute attrs[3] = {
+      mlirNamedAttributeGet(
+          mlirIdentifierGet(context, mlirStringRefCreateFromCString("operandSegmentSizes")),
+          mlirDenseI32ArrayGet(context, 2, segSizes)
+      ),
+      mlirNamedAttributeGet(
+          mlirIdentifierGet(context, mlirStringRefCreateFromCString("mapOpGroupSizes")),
+          mlirDenseI32ArrayGet(context, 1, groupSizes)
+      ),
+      mlirNamedAttributeGet(
+          mlirIdentifierGet(context, mlirStringRefCreateFromCString("numDimsPerMap")),
+          mlirDenseI32ArrayGet(context, 1, numDims)
+      ),
+  };
+  mlirOperationStateAddAttributes(&op_state, 3, attrs);
+
+  auto op = mlirOperationCreate(&op_state);
+  ASSERT_NE(op.ptr, nullptr);
+
+  // Verify the initial operand layout is as expected.
+  EXPECT_EQ(mlirOperationGetNumOperands(op), 3);
+  EXPECT_EQ(llzkArray_CreateArrayOpGetElementsCount(op), 1);
+  EXPECT_EQ(llzkArray_CreateArrayOpGetMapOperandsCount(op), 2);
+  EXPECT_EQ(llzkArray_CreateArrayOpGetMapOperandsAt(op, 0).ptr, m0.ptr);
+  EXPECT_EQ(llzkArray_CreateArrayOpGetMapOperandsAt(op, 1).ptr, m1.ptr);
+
+  // Replace the two map operands with a single new one, expressed as one group of size 1.
+  MlirValueRange newGroups[1] = {{&m_new, 1}};
+  llzkArray_CreateArrayOpSetMapOperands(op, 1, newGroups);
+
+  // Physical operand count must reflect the removal.
+  EXPECT_EQ(mlirOperationGetNumOperands(op), 2);
+
+  // mapOperands should now report count=1 and return m_new.
+  EXPECT_EQ(llzkArray_CreateArrayOpGetMapOperandsCount(op), 1);
+  EXPECT_EQ(llzkArray_CreateArrayOpGetMapOperandsAt(op, 0).ptr, m_new.ptr);
+
+  // operandSegmentSizes[0] must be intact so the elements operand is still reachable.
+  // This verifies that join().assign() updated only slot 1, not slot 0.
+  EXPECT_EQ(llzkArray_CreateArrayOpGetElementsCount(op), 1);
+  EXPECT_EQ(llzkArray_CreateArrayOpGetElementsAt(op, 0).ptr, e0.ptr);
+
+  // mapOpGroupSizes must have been updated to [1] (one group of 1 operand).
+  MlirAttribute mapGroupSizesAttr = llzkArray_CreateArrayOpGetMapOpGroupSizes(op);
+  ASSERT_FALSE(mlirAttributeIsNull(mapGroupSizesAttr));
+  EXPECT_EQ(mlirDenseArrayGetNumElements(mapGroupSizesAttr), 1);
+  EXPECT_EQ(mlirDenseI32ArrayGetElement(mapGroupSizesAttr, 0), 1);
+
+  // numDimsPerMap is NOT updated by the generated setter (it is LLZK-specific and the
+  // caller's responsibility), so it must remain unchanged at [1].
+  MlirAttribute numDimsAttr = llzkArray_CreateArrayOpGetNumDimsPerMap(op);
+  ASSERT_FALSE(mlirAttributeIsNull(numDimsAttr));
+  EXPECT_EQ(mlirDenseArrayGetNumElements(numDimsAttr), 1);
+  EXPECT_EQ(mlirDenseI32ArrayGetElement(numDimsAttr, 0), 1);
+
+  mlirOperationDestroy(op);
+  for (auto auxOp : auxOps) {
+    mlirOperationDestroy(auxOp);
+  }
+}

--- a/unittests/CAPI/Dialect/Array.cpp
+++ b/unittests/CAPI/Dialect/Array.cpp
@@ -544,27 +544,33 @@ TEST_F(ArrayDialectTests, create_array_op_set_map_operands_updates_attributes) {
   EXPECT_EQ(llzkArray_CreateArrayOpGetMapOperandsAt(op, 0).ptr, m0.ptr);
   EXPECT_EQ(llzkArray_CreateArrayOpGetMapOperandsAt(op, 1).ptr, m1.ptr);
 
-  // Replace the two map operands with a single new one, expressed as one group of size 1.
-  MlirValueRange newGroups[1] = {{&m_new, 1}};
-  llzkArray_CreateArrayOpSetMapOperands(op, 1, newGroups);
+  // Replace the two map operands with multiple groups so the VariadicOfVariadic
+  // setter must preserve group boundaries, not just flatten operands.
+  MlirValue secondGroupVals[2] = {m0, m1};
+  MlirValueRange newGroups[2] = {{&m_new, 1}, {secondGroupVals, 2}};
+  llzkArray_CreateArrayOpSetMapOperands(op, 2, newGroups);
 
-  // Physical operand count must reflect the removal.
-  EXPECT_EQ(mlirOperationGetNumOperands(op), 2);
+  // Physical operand count must reflect the replacement: one element plus three
+  // flattened map operands across two groups.
+  EXPECT_EQ(mlirOperationGetNumOperands(op), 4);
 
-  // mapOperands should now report count=1 and return m_new.
-  EXPECT_EQ(llzkArray_CreateArrayOpGetMapOperandsCount(op), 1);
+  // mapOperands should flatten to [m_new, m0, m1].
+  EXPECT_EQ(llzkArray_CreateArrayOpGetMapOperandsCount(op), 3);
   EXPECT_EQ(llzkArray_CreateArrayOpGetMapOperandsAt(op, 0).ptr, m_new.ptr);
+  EXPECT_EQ(llzkArray_CreateArrayOpGetMapOperandsAt(op, 1).ptr, m0.ptr);
+  EXPECT_EQ(llzkArray_CreateArrayOpGetMapOperandsAt(op, 2).ptr, m1.ptr);
 
   // operandSegmentSizes[0] must be intact so the elements operand is still reachable.
   // This verifies that join().assign() updated only slot 1, not slot 0.
   EXPECT_EQ(llzkArray_CreateArrayOpGetElementsCount(op), 1);
   EXPECT_EQ(llzkArray_CreateArrayOpGetElementsAt(op, 0).ptr, e0.ptr);
 
-  // mapOpGroupSizes must have been updated to [1] (one group of 1 operand).
+  // mapOpGroupSizes must have been updated to [1, 2], preserving both groups.
   MlirAttribute mapGroupSizesAttr = llzkArray_CreateArrayOpGetMapOpGroupSizes(op);
   ASSERT_FALSE(mlirAttributeIsNull(mapGroupSizesAttr));
-  EXPECT_EQ(mlirDenseArrayGetNumElements(mapGroupSizesAttr), 1);
+  EXPECT_EQ(mlirDenseArrayGetNumElements(mapGroupSizesAttr), 2);
   EXPECT_EQ(mlirDenseI32ArrayGetElement(mapGroupSizesAttr, 0), 1);
+  EXPECT_EQ(mlirDenseI32ArrayGetElement(mapGroupSizesAttr, 1), 2);
 
   // numDimsPerMap is NOT updated by the generated setter (it is LLZK-specific and the
   // caller's responsibility), so it must remain unchanged at [1].


### PR DESCRIPTION
Another issue pointed out by copilot review of `llzk-tblgen`: the segment size attribute (e.g. `mapOpGroupSizes` in several LLZK IR ops) was not updated properly. The function signature did not convey enough information to update that attribute so this PR introduces fully separate handling for `VariadicOfVariadic` operands that accepts a `MlirValueRange*` parameter instead of just `MlirValue*` which the `Variadic` uses. 

Additionally, I realized the manual update of `operandSegmentSizes` was not necessary because `mlir-tblgen` generates `get*Mutable()` on the C++ side and the CAPI wrapper can just call into that to set the values and the segment sizes attribute.