### PR TITLE
Fix DynamicAPInt shifts over 64 bits

### DIFF
--- a/changelogs/unreleased/fix-dynamic-apint-large-shifts.yaml
+++ b/changelogs/unreleased/fix-dynamic-apint-large-shifts.yaml
@@ -1,0 +1,2 @@
+fixed:
+  - Fixed `DynamicAPInt` shift operations with shift amounts larger than 64 bits

--- a/lib/Util/DynamicAPIntHelper.cpp
+++ b/lib/Util/DynamicAPIntHelper.cpp
@@ -21,11 +21,12 @@ using namespace llvm;
 using namespace std;
 
 static DynamicAPInt po2(const DynamicAPInt &e) {
-  // Ensure parameter is not negative and that it can be safely cast to unsigned.
+  // Ensure parameter is not negative and that shiftAmt + 1 fits in unsigned.
   assert(e >= 0);
-  assert(e <= std::numeric_limits<unsigned>::max() /* upcast from unsigned -> int64_t */);
+  assert(e < std::numeric_limits<unsigned>::max() /* upcast from unsigned -> int64_t */);
   unsigned shiftAmt = llzk::toAPSInt(e).getZExtValue();
-  APSInt p = APSInt::get(1) << shiftAmt;
+  APSInt p(shiftAmt + 1, /* isUnsigned */ true);
+  p.setBit(shiftAmt);
   return llzk::toDynamicAPInt(p);
 }
 

--- a/lib/Util/DynamicAPIntHelper.cpp
+++ b/lib/Util/DynamicAPIntHelper.cpp
@@ -21,9 +21,10 @@ using namespace llvm;
 using namespace std;
 
 static DynamicAPInt po2(const DynamicAPInt &e) {
-  // Ensure parameter is not negative and that shiftAmt + 1 fits in unsigned.
+  // APInt/APSInt bitwidth is limited to max unsigned bits, so must be strictly
+  // less than the max to accommodate for the sign bit
   assert(e >= 0);
-  assert(e < std::numeric_limits<unsigned>::max() /* upcast from unsigned -> int64_t */);
+  assert(e < std::numeric_limits<unsigned>::max());
   unsigned shiftAmt = llzk::toAPSInt(e).getZExtValue();
   APSInt p(shiftAmt + 1, /* isUnsigned */ true);
   p.setBit(shiftAmt);

--- a/unittests/Analysis/DynamicAPIntTests.cpp
+++ b/unittests/Analysis/DynamicAPIntTests.cpp
@@ -151,7 +151,9 @@ struct DynamicAPIntShiftTest : public testing::TestWithParam<std::pair<DynamicAP
         {DynamicAPInt(-1), 0},
         {bn254, 0},
         {bn254, 32},
+        {bn254, 100},
         {DynamicAPInt(100), 32},
+        {DynamicAPInt(100), 100},
     };
     return vals;
   }
@@ -169,7 +171,10 @@ TEST_P(DynamicAPIntShiftTest, ShiftLeft) {
 TEST_P(DynamicAPIntShiftTest, ShiftRight) {
   auto [a, b] = GetParam();
   // Equivalent to APSInt operator
-  ASSERT_EQ(a >> toDynamicAPInt(APSInt::get(b)), toDynamicAPInt(toAPSInt(a) >> b));
+  APSInt base = toAPSInt(a);
+  base = base.extend(max(base.getBitWidth(), b));
+
+  ASSERT_EQ(a >> toDynamicAPInt(APSInt::get(b)), toDynamicAPInt(base >> b));
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/unittests/Analysis/DynamicAPIntTests.cpp
+++ b/unittests/Analysis/DynamicAPIntTests.cpp
@@ -148,11 +148,7 @@ INSTANTIATE_TEST_SUITE_P(
 struct DynamicAPIntShiftTest : public testing::TestWithParam<std::pair<DynamicAPInt, unsigned>> {
   static const std::vector<std::pair<DynamicAPInt, unsigned>> &TestingValues() {
     static std::vector<std::pair<DynamicAPInt, unsigned>> vals = {
-        {DynamicAPInt(-1), 0},
-        {bn254, 0},
-        {bn254, 32},
-        {bn254, 100},
-        {DynamicAPInt(100), 32},
+        {DynamicAPInt(-1), 0},    {bn254, 0}, {bn254, 32}, {bn254, 100}, {DynamicAPInt(100), 32},
         {DynamicAPInt(100), 100},
     };
     return vals;

--- a/unittests/IR/FeltFoldTests.cpp
+++ b/unittests/IR/FeltFoldTests.cpp
@@ -325,6 +325,10 @@ TEST_F(BabyBearFoldTest, Shl33) {
   expectValue(foldBinary<ShlFeltOp>(babyBearConst(1), babyBearConst(33)), 536870908ULL);
 }
 
+TEST_F(BabyBearFoldTest, Shl100) {
+  expectValue(foldBinary<ShlFeltOp>(babyBearConst(1), babyBearConst(100)), 1060618158ULL);
+}
+
 TEST_F(BabyBearFoldTest, Shr) {
   // 16 >> 2 = 4
   expectValue(foldBinary<ShrFeltOp>(babyBearConst(16), babyBearConst(2)), 4);


### PR DESCRIPTION
## Summary

Fixes #392.

`po2` previously computed powers of two with `APSInt::get(1) << shiftAmt`, but `APSInt::get(1)` uses a fixed default width, so shift amounts above that width could assert inside LLVM.

This constructs the power-of-two value with `shiftAmt + 1` bits and sets the target bit directly. It also tightens the shift bound so the computed bit width cannot overflow.

## Testing

- `unittests/Analysis/LLZK_Analysis_Tests --gtest_filter="*DynamicAPIntShiftTest*"`
  - 12 tests passed
- `unittests/IR/LLZK_IR_Tests --gtest_filter="BabyBearFoldTest.Shl*:BabyBearFoldTest.Shr*"`
  - 8 tests passed
