### PR TITLE
Fix flattening of parameterized callees

### DIFF
--- a/changelogs/unreleased/fix-flatten-parameterized-callee.yaml
+++ b/changelogs/unreleased/fix-flatten-parameterized-callee.yaml
@@ -1,0 +1,2 @@
+fixed:
+  - Fixed `llzk-flatten` when instantiated struct bodies call through type parameters

--- a/lib/Dialect/Polymorphic/Transforms/FlatteningPass.cpp
+++ b/lib/Dialect/Polymorphic/Transforms/FlatteningPass.cpp
@@ -1284,11 +1284,12 @@ public:
         FuncDefOp newFunc = callTgt.clone();
         convertCalleesInPlace(newFunc, paramNameToConcrete);
 
-        // Insert before body conversion so nested concrete callees verify from a root module.
+        // Insert before body conversion so nested concrete callees verify from the root module. Use
+        // the `SymbolTable::insert()` function so that the name will be made unique if necessary.
         symTables.getSymbolTable(newTemplate).insert(newFunc);
         symTables.getSymbolTable(parentModule).insert(newTemplate, Block::iterator(parentTemplate));
         if (failed(applyBodyConversions(newFunc))) {
-          std::string newFuncName = newFunc.getSymName().str();
+          StringRef newFuncName = newFunc.getSymName();
           LLVM_DEBUG(
               llvm::dbgs() << "[InstantiateFuncAtCallOp]   body conversion failed for "
                            << newFuncName << '\n'

--- a/lib/Dialect/Polymorphic/Transforms/FlatteningPass.cpp
+++ b/lib/Dialect/Polymorphic/Transforms/FlatteningPass.cpp
@@ -1283,8 +1283,12 @@ public:
         // Clone and partially convert the function (concretize only the concrete params).
         FuncDefOp newFunc = callTgt.clone();
         convertCalleesInPlace(newFunc, paramNameToConcrete);
+
+        // Insert before body conversion so nested concrete callees verify from a root module.
+        symTables.getSymbolTable(newTemplate).insert(newFunc);
+        symTables.getSymbolTable(parentModule).insert(newTemplate, Block::iterator(parentTemplate));
         if (failed(applyBodyConversions(newFunc))) {
-          StringRef newFuncName = newFunc.getSymName();
+          std::string newFuncName = newFunc.getSymName().str();
           LLVM_DEBUG(
               llvm::dbgs() << "[InstantiateFuncAtCallOp]   body conversion failed for "
                            << newFuncName << '\n'
@@ -1295,10 +1299,6 @@ public:
           });
         }
 
-        // Insert the function into the new template, then the template into the module. Use the
-        // `SymbolTable::insert()` function so that the name will be made unique if necessary.
-        symTables.getSymbolTable(newTemplate).insert(newFunc);
-        symTables.getSymbolTable(parentModule).insert(newTemplate, Block::iterator(parentTemplate));
         LLVM_DEBUG(
             llvm::dbgs() << "[InstantiateFuncAtCallOp]  created partial instantiation template: "
                          << newTemplate.getSymName() << '\n'

--- a/lib/Dialect/Polymorphic/Transforms/FlatteningPass.cpp
+++ b/lib/Dialect/Polymorphic/Transforms/FlatteningPass.cpp
@@ -367,6 +367,47 @@ template <bool AllowStructParams = true> bool isConcreteAttr(Attribute a) {
   return false;
 }
 
+static SymbolRefAttr
+convertCalleeSymRefs(SymbolRefAttr callee, const DenseMap<Attribute, Attribute> &paramNameToValue) {
+  auto it = paramNameToValue.find(FlatSymbolRefAttr::get(callee.getRootReference()));
+  if (it == paramNameToValue.end()) {
+    return callee;
+  }
+
+  auto tyAttr = llvm::dyn_cast<TypeAttr>(it->second);
+  if (!tyAttr) {
+    return callee;
+  }
+
+  auto structTy = llvm::dyn_cast<StructType>(tyAttr.getValue());
+  if (!structTy) {
+    return callee;
+  }
+
+  SmallVector<FlatSymbolRefAttr> newPieces = getPieces(structTy.getNameRef());
+  llvm::append_range(newPieces, callee.getNestedReferences());
+  return asSymbolRefAttr(newPieces);
+}
+
+static void
+convertCalleesInPlace(Operation *op, const DenseMap<Attribute, Attribute> &paramNameToValue) {
+  op->walk([&paramNameToValue](CallOp callOp) {
+    callOp.setCalleeAttr(convertCalleeSymRefs(callOp.getCalleeAttr(), paramNameToValue));
+  });
+}
+
+static bool calleeReferencesTemplateParam(CallOp op) {
+  SymbolRefAttr callee = op.getCalleeAttr();
+  if (!callee || callee.getNestedReferences().size() != 1) {
+    return false;
+  }
+  TemplateOp parentTemplate = getParentOfType<TemplateOp>(op);
+  if (!parentTemplate) {
+    return false;
+  }
+  return parentTemplate.hasConstNamed<TemplateParamOp>(callee.getRootReference());
+}
+
 /// Attempt to evaluate the concrete result of a single `TemplateExprOp` expression given
 /// the currently-known concrete param values in `paramNameToConcrete`. Returns the result
 /// attribute if all referenced params are concrete and all operations in the body can be
@@ -663,6 +704,7 @@ class StructCloner {
 
     // Clone the original struct.
     StructDefOp newStruct = origStruct.clone();
+    convertCalleesInPlace(newStruct, paramNameToConcrete);
     if (remainingNames.empty()) { // FULL INSTANTIATION CASE
       // Set name of the new struct by prepending its name with instantiated template name.
       newStruct.setSymName(
@@ -990,6 +1032,10 @@ public:
   LogicalResult matchAndRewrite(CallOp op, PatternRewriter &rewriter) const override {
     LLVM_DEBUG(llvm::dbgs() << "[InstantiateFuncAtCallOp] op: " << op << '\n');
 
+    if (calleeReferencesTemplateParam(op)) {
+      return failure();
+    }
+
     // Lookup callee target function
     SymbolTableCollection symTables;
     FailureOr<SymbolLookupResult<FuncDefOp>> callTgtOpt = op.getCalleeTarget(symTables);
@@ -1178,6 +1224,7 @@ public:
       if (!symTables.getSymbolTable(parentModule).lookup(newFuncName)) {
         FuncDefOp newFunc = callTgt.clone();
         newFunc.setSymName(newFuncName);
+        convertCalleesInPlace(newFunc, paramNameToConcrete);
         // Insert before the TemplateOp; symbol table may adjust the name to ensure uniqueness.
         symTables.getSymbolTable(parentModule).insert(newFunc, Block::iterator(parentTemplate));
         actualNewFuncName = newFunc.getSymName();
@@ -1235,6 +1282,7 @@ public:
 
         // Clone and partially convert the function (concretize only the concrete params).
         FuncDefOp newFunc = callTgt.clone();
+        convertCalleesInPlace(newFunc, paramNameToConcrete);
         if (failed(applyBodyConversions(newFunc))) {
           StringRef newFuncName = newFunc.getSymName();
           LLVM_DEBUG(
@@ -1540,6 +1588,9 @@ public:
       auto callArgTypes = op.getArgOperands().getTypes();
       if (callArgTypes.empty()) {
         // no refinement possible if no function arguments
+        return failure();
+      }
+      if (calleeReferencesTemplateParam(op)) {
         return failure();
       }
       SymbolTableCollection tables;
@@ -1956,6 +2007,9 @@ public:
       : OpRewritePattern(ctx, 3), tracker_(tracker) {}
 
   LogicalResult matchAndRewrite(CallOp op, PatternRewriter &rewriter) const override {
+    if (calleeReferencesTemplateParam(op)) {
+      return failure();
+    }
     SymbolTableCollection tables;
     auto lookupRes = lookupTopLevelSymbol<FuncDefOp>(tables, op.getCalleeAttr(), op);
     if (failed(lookupRes)) {

--- a/test/Transforms/Flattening/parameterized_callee_pass.llzk
+++ b/test/Transforms/Flattening/parameterized_callee_pass.llzk
@@ -112,3 +112,42 @@ module attributes {llzk.lang} {
 //
 // CHECK-LABEL: function.def @"TF_!s<@Q>_make"() -> !struct.type<@Q> attributes {function.allow_witness} {
 // CHECK:        function.call @Q::@compute() : () -> !struct.type<@Q>
+
+// -----
+
+module attributes {llzk.lang} {
+  struct.def @P {
+    function.def @compute() -> !struct.type<@P> {
+      %self = struct.new : !struct.type<@P>
+      function.return %self : !struct.type<@P>
+    }
+
+    function.def @constrain(%self: !struct.type<@P>) {
+      function.return
+    }
+  }
+
+  poly.template @TPF {
+    poly.param @S
+    poly.param @T
+
+    function.def @make(%value: !poly.tvar<@T>) -> !poly.tvar<@S> attributes {function.allow_witness} {
+      %s = function.call @S::@compute() : () -> !poly.tvar<@S>
+      function.return %s : !poly.tvar<@S>
+    }
+  }
+
+  poly.template @Outer {
+    poly.param @T
+
+    function.def @use(%value: !poly.tvar<@T>) -> !struct.type<@P> attributes {function.allow_witness} {
+      %p = function.call @TPF::@make(%value) : (!poly.tvar<@T>) -> !struct.type<@P>
+      function.return %p : !struct.type<@P>
+    }
+  }
+}
+// CHECK-LABEL: poly.template @"TPF_!s<@P>_\1A" {
+// CHECK:        function.def @make(%{{[0-9a-zA-Z_\.]+}}: !poly.tvar<@T>) -> !struct.type<@P> attributes {function.allow_witness} {
+// CHECK:          function.call @P::@compute() : () -> !struct.type<@P>
+// CHECK-NOT:      @S::@compute
+// CHECK:          function.return

--- a/test/Transforms/Flattening/parameterized_callee_pass.llzk
+++ b/test/Transforms/Flattening/parameterized_callee_pass.llzk
@@ -59,3 +59,56 @@ module attributes {llzk.lang} {
 // CHECK-LABEL: struct.def @"TU_!s<@Q>_unknown_call_target" {
 // CHECK:        function.call @Q::@compute() : () -> !struct.type<@Q>
 // CHECK-NOT:    @S::@compute
+
+// -----
+
+module attributes {llzk.lang} {
+  struct.def @P {
+    function.def @compute() -> !struct.type<@P> {
+      %self = struct.new : !struct.type<@P>
+      function.return %self : !struct.type<@P>
+    }
+
+    function.def @constrain(%self: !struct.type<@P>) {
+      function.return
+    }
+  }
+
+  struct.def @Q {
+    function.def @compute() -> !struct.type<@Q> {
+      %self = struct.new : !struct.type<@Q>
+      function.return %self : !struct.type<@Q>
+    }
+
+    function.def @constrain(%self: !struct.type<@Q>) {
+      function.return
+    }
+  }
+
+  poly.template @TF {
+    poly.param @S
+
+    function.def @make() -> !poly.tvar<@S> attributes {function.allow_witness} {
+      %s = function.call @S::@compute() : () -> !poly.tvar<@S>
+      function.return %s : !poly.tvar<@S>
+    }
+  }
+
+  struct.def @Main {
+    function.def @compute() -> !struct.type<@Main> {
+      %self = struct.new : !struct.type<@Main>
+      %p = function.call @TF::@make() : () -> !struct.type<@P>
+      %q = function.call @TF::@make() : () -> !struct.type<@Q>
+      function.return %self : !struct.type<@Main>
+    }
+
+    function.def @constrain(%self: !struct.type<@Main>) {
+      function.return
+    }
+  }
+}
+// CHECK-LABEL: function.def @"TF_!s<@P>_make"() -> !struct.type<@P> attributes {function.allow_witness} {
+// CHECK:        function.call @P::@compute() : () -> !struct.type<@P>
+//
+// CHECK-LABEL: function.def @"TF_!s<@Q>_make"() -> !struct.type<@Q> attributes {function.allow_witness} {
+// CHECK:        function.call @Q::@compute() : () -> !struct.type<@Q>

--- a/test/Transforms/Flattening/parameterized_callee_pass.llzk
+++ b/test/Transforms/Flattening/parameterized_callee_pass.llzk
@@ -1,0 +1,61 @@
+// RUN: llzk-opt -split-input-file -llzk-flatten -verify-diagnostics %s | FileCheck --enable-var-scope %s
+
+module attributes {llzk.lang} {
+  struct.def @P {
+    function.def @compute() -> !struct.type<@P> {
+      %self = struct.new : !struct.type<@P>
+      function.return %self : !struct.type<@P>
+    }
+
+    function.def @constrain(%self: !struct.type<@P>) {
+      function.return
+    }
+  }
+
+  struct.def @Q {
+    function.def @compute() -> !struct.type<@Q> {
+      %self = struct.new : !struct.type<@Q>
+      function.return %self : !struct.type<@Q>
+    }
+
+    function.def @constrain(%self: !struct.type<@Q>) {
+      function.return
+    }
+  }
+
+  poly.template @TU {
+    poly.param @S
+
+    struct.def @unknown_call_target {
+      function.def @compute() -> !struct.type<@TU::@unknown_call_target<[@S]>> {
+        %self = struct.new : !struct.type<@TU::@unknown_call_target<[@S]>>
+        %s = function.call @S::@compute() : () -> !poly.tvar<@S>
+        function.return %self : !struct.type<@TU::@unknown_call_target<[@S]>>
+      }
+
+      function.def @constrain(%self: !struct.type<@TU::@unknown_call_target<[@S]>>) {
+        function.return
+      }
+    }
+  }
+
+  struct.def @Main {
+    function.def @compute() -> !struct.type<@Main> {
+      %self = struct.new : !struct.type<@Main>
+      %p = function.call @TU::@unknown_call_target::@compute() : () -> !struct.type<@TU::@unknown_call_target<[!struct.type<@P>]>>
+      %q = function.call @TU::@unknown_call_target::@compute() : () -> !struct.type<@TU::@unknown_call_target<[!struct.type<@Q>]>>
+      function.return %self : !struct.type<@Main>
+    }
+
+    function.def @constrain(%self: !struct.type<@Main>) {
+      function.return
+    }
+  }
+}
+// CHECK-LABEL: struct.def @"TU_!s<@P>_unknown_call_target" {
+// CHECK:        function.call @P::@compute() : () -> !struct.type<@P>
+// CHECK-NOT:    @S::@compute
+//
+// CHECK-LABEL: struct.def @"TU_!s<@Q>_unknown_call_target" {
+// CHECK:        function.call @Q::@compute() : () -> !struct.type<@Q>
+// CHECK-NOT:    @S::@compute


### PR DESCRIPTION
## Summary

Fixes `llzk-flatten` when an instantiated struct body calls through a template parameter, such as `@S::@compute`.

The flattening pass now rewrites parameterized callee roots in cloned instantiated bodies to the concrete struct symbol path. It also avoids lookup-based rewrite patterns while a callee is still symbolic inside the original template.

Fixes #388.

## Testing

- `git diff --check`
- `clang-format --dry-run --Werror lib/Dialect/Polymorphic/Transforms/FlatteningPass.cpp`
