### PR TITLE
Ensure `llzk.main` attribute is always verified

### DIFF
--- a/backends/smt/lib/Conversions/SMTLoweringPass.cpp
+++ b/backends/smt/lib/Conversions/SMTLoweringPass.cpp
@@ -537,7 +537,7 @@ class SMTLoweringPass : public smt::impl::SMTLoweringPassBase<SMTLoweringPass> {
     auto selectedField = *(fields.begin());
     auto prime = toAPSInt(selectedField.get().prime());
 
-    mod.walk([this, &prime](component::StructDefOp structDef) {
+    auto result = mod.walk([this, &prime](component::StructDefOp structDef) {
       // Start by adding declare-funcs for each signal
       IRRewriter rewriter {&getContext()};
       rewriter.setInsertionPointToStart(&structDef.getProductFuncOp().getFunctionBody().front());
@@ -558,16 +558,17 @@ class SMTLoweringPass : public smt::impl::SMTLoweringPassBase<SMTLoweringPass> {
         signalSymbols[memberDef.getSymName()] = {constraintSym.getResult(), witnessSym.getResult()};
       }
 
-      auto *result = convertFunction(convertBodies(structDef, signalSymbols, prime));
-      if (result == nullptr) {
+      if (convertFunction(convertBodies(structDef, signalSymbols, prime))) {
+        return WalkResult::advance();
+      } else {
         signalPassFailure();
         return WalkResult::interrupt();
       }
-      return WalkResult::advance();
     });
-
-    // Remove `llzk.main` attribute because `convertFunction()` above deleted structs.
-    mod->removeAttr(MAIN_ATTR_NAME);
+    if (!result.wasInterrupted()) {
+      // Remove `llzk.main` attribute because `convertFunction()` above deleted structs.
+      mod->removeAttr(MAIN_ATTR_NAME);
+    }
   }
 };
 

--- a/backends/smt/lib/Conversions/SMTLoweringPass.cpp
+++ b/backends/smt/lib/Conversions/SMTLoweringPass.cpp
@@ -36,6 +36,7 @@
 #include "llzk/Dialect/String/IR/Ops.h"
 #include "llzk/Dialect/Struct/IR/Dialect.h"
 #include "llzk/Dialect/Struct/IR/Ops.h"
+#include "llzk/Util/Constants.h"
 #include "llzk/Util/Field.h"
 #include "llzk/Util/TypeHelper.h"
 
@@ -564,6 +565,9 @@ class SMTLoweringPass : public smt::impl::SMTLoweringPassBase<SMTLoweringPass> {
       }
       return WalkResult::advance();
     });
+
+    // Remove `llzk.main` attribute because `convertFunction()` above deleted structs.
+    mod->removeAttr(MAIN_ATTR_NAME);
   }
 };
 

--- a/changelogs/unreleased/th__add_missing_verif.yaml
+++ b/changelogs/unreleased/th__add_missing_verif.yaml
@@ -1,0 +1,2 @@
+fixed:
+  - "The `llzk.main` attribute was not always verified"

--- a/include/llzk/Dialect/LLZK/IR/Attrs.h
+++ b/include/llzk/Dialect/LLZK/IR/Attrs.h
@@ -9,8 +9,18 @@
 
 #pragma once
 
+#include "llzk/Dialect/Struct/IR/Types.h"
+
 #include <mlir/IR/Attributes.h>
+#include <mlir/IR/BuiltinOps.h>
 
 // Include TableGen'd declarations
 #define GET_ATTRDEF_CLASSES
 #include "llzk/Dialect/LLZK/IR/Attrs.h.inc"
+
+namespace llzk {
+
+mlir::FailureOr<component::StructType>
+getTypeFromLlzkMainAttr(mlir::ModuleOp op, mlir::Attribute attr);
+
+}

--- a/include/llzk/Dialect/LLZK/IR/Dialect.td
+++ b/include/llzk/Dialect/LLZK/IR/Dialect.td
@@ -19,6 +19,7 @@ def LLZKDialect : Dialect {
   let cppNamespace = "::llzk";
 
   let useDefaultAttributePrinterParser = true;
+  let hasOperationAttrVerify = 1;
 }
 
 #endif // LLZK_DIALECT

--- a/lib/Dialect/LLZK/IR/Attrs.cpp
+++ b/lib/Dialect/LLZK/IR/Attrs.cpp
@@ -1,0 +1,42 @@
+//===-- Attrs.cpp -----------------------------------------------*- C++ -*-===//
+//
+// Part of the LLZK Project, under the Apache License v2.0.
+// See LICENSE.txt for license information.
+// Copyright 2026 Project LLZK
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#include "llzk/Dialect/LLZK/IR/Attrs.h"
+
+#include "llzk/Dialect/Struct/IR/Types.h"
+#include "llzk/Util/Constants.h"
+#include "llzk/Util/TypeHelper.h"
+
+#include <mlir/IR/BuiltinAttributes.h>
+
+using namespace mlir;
+
+namespace llzk {
+
+using namespace component;
+
+FailureOr<StructType> getTypeFromLlzkMainAttr(ModuleOp op, Attribute attr) {
+  assert(op);   // pre-condition
+  assert(attr); // pre-condition
+
+  // If the attribute is present, it must be a TypeAttr of concrete StructType.
+  if (TypeAttr ta = llvm::dyn_cast<TypeAttr>(attr)) {
+    if (auto st = llvm::dyn_cast<StructType>(ta.getValue())) {
+      if (isConcreteType(st)) {
+        return success(st);
+      }
+    }
+  }
+  return op->emitError().append(
+      '"', MAIN_ATTR_NAME, "\" on module must be a concrete '", StructType::name,
+      "' attribute. Found: ", attr
+  );
+}
+
+} // namespace llzk

--- a/lib/Dialect/LLZK/IR/Dialect.cpp
+++ b/lib/Dialect/LLZK/IR/Dialect.cpp
@@ -16,6 +16,7 @@
 #include "llzk/Dialect/LLZK/IR/Attrs.h"
 #include "llzk/Dialect/LLZK/IR/Ops.h"
 #include "llzk/Dialect/LLZK/IR/Versioning.h"
+#include "llzk/Dialect/Struct/IR/Types.h"
 
 #include <mlir/Bytecode/BytecodeImplementation.h>
 #include <mlir/IR/DialectImplementation.h>
@@ -30,11 +31,44 @@
 #define GET_ATTRDEF_CLASSES
 #include "llzk/Dialect/LLZK/IR/Attrs.cpp.inc"
 
+using namespace mlir;
+using namespace llzk;
+
 //===------------------------------------------------------------------===//
 // LLZKDialect
 //===------------------------------------------------------------------===//
 
-auto llzk::LLZKDialect::initialize() -> void {
+namespace {
+
+LogicalResult verifyLlzkMainAttr(Operation *op, Attribute attr) {
+  ModuleOp moduleOp = llvm::dyn_cast<ModuleOp>(op);
+  if (!moduleOp) {
+    return op->emitError().append(
+        '"', MAIN_ATTR_NAME, "\" attribute can only be specified on '",
+        ModuleOp::getOperationName(), '\''
+    );
+  }
+
+  FailureOr<component::StructType> mainStructTypeOpt = getTypeFromLlzkMainAttr(moduleOp, attr);
+  if (succeeded(mainStructTypeOpt)) {
+    if (component::StructType st = mainStructTypeOpt.value()) {
+      SymbolTableCollection symbolTables;
+      return st.getDefinition(symbolTables, op);
+    }
+  }
+  return failure();
+}
+
+} // namespace
+
+LogicalResult LLZKDialect::verifyOperationAttribute(Operation *op, NamedAttribute attr) {
+  if (attr.getName() == MAIN_ATTR_NAME) {
+    return verifyLlzkMainAttr(op, attr.getValue());
+  }
+  return success();
+}
+
+auto LLZKDialect::initialize() -> void {
   // clang-format off
   addAttributes<
     #define GET_ATTRDEF_LIST

--- a/lib/Util/SymbolHelper.cpp
+++ b/lib/Util/SymbolHelper.cpp
@@ -328,18 +328,7 @@ FailureOr<StructType> getMainInstanceType(Operation *lookupFrom) {
   }
   ModuleOp root = rootOpt.value();
   if (Attribute a = root->getAttr(MAIN_ATTR_NAME)) {
-    // If the attribute is present, it must be a TypeAttr of concrete StructType.
-    if (TypeAttr ta = llvm::dyn_cast<TypeAttr>(a)) {
-      if (StructType st = llvm::dyn_cast<StructType>(ta.getValue())) {
-        if (isConcreteType(st)) {
-          return success(st);
-        }
-      }
-    }
-    return rootOpt->emitError().append(
-        '"', MAIN_ATTR_NAME, "\" on top-level module must be a concrete '", StructType::name,
-        "' attribute. Found: ", a
-    );
+    return getTypeFromLlzkMainAttr(root, a);
   }
   // The attribute is optional so it's okay if not present.
   return success(nullptr);

--- a/test/Conversions/llzk_to_smt_no_cf_iszero.llzk
+++ b/test/Conversions/llzk_to_smt_no_cf_iszero.llzk
@@ -48,7 +48,7 @@ module attributes {llzk.lang, llzk.main = !struct.type<@TIsZero_0::@IsZero_0>} {
   }
 }
 
-// CHECK-LABEL: module attributes {llzk.lang, llzk.main = !struct.type<@TIsZero_0::@IsZero_0>} {
+// CHECK-LABEL: module attributes {llzk.lang} {
 // CHECK: func.func @smt_IsZero_0(%[[IN:[0-9a-zA-Z_\.]+]]: !smt.int) {
 // CHECK-DAG: %[[OUTC:[0-9a-zA-Z_\.]+]] = smt.declare_fun "out_c" : !smt.int
 // CHECK-DAG: %[[OUTW:[0-9a-zA-Z_\.]+]] = smt.declare_fun "out_w" : !smt.int

--- a/test/Dialect/LLZK_and_Builtin/mainAttrVerif_fail.llzk
+++ b/test/Dialect/LLZK_and_Builtin/mainAttrVerif_fail.llzk
@@ -1,0 +1,21 @@
+// RUN: llzk-opt -split-input-file -verify-diagnostics %s
+
+// expected-error@+2 {{'builtin.module' op references unknown symbol "@MissingMain"}}
+// expected-error@+1 {{could not find 'struct.def' named "@MissingMain"}}
+module attributes {llzk.main = !struct.type<@MissingMain>, llzk.lang} {
+  struct.def @Main {
+    function.def @compute() -> !struct.type<@Main> {
+      %self = struct.new : !struct.type<@Main>
+      function.return %self : !struct.type<@Main>
+    }
+    function.def @constrain(%self: !struct.type<@Main>) {
+      function.return
+    }
+  }
+}
+// -----
+
+module attributes {llzk.lang} {
+  // expected-error@+1 {{"llzk.main" attribute can only be specified on 'builtin.module'}}
+  global.def @b : i1 = false {llzk.main = !struct.type<@NonModuleMainAttr>}
+}

--- a/test/Dialect/Struct/structs_fail.llzk
+++ b/test/Dialect/Struct/structs_fail.llzk
@@ -414,7 +414,7 @@ module attributes {llzk.main = !struct.type<@MyMain>, llzk.lang} {
   }
 }
 // -----
-// expected-error@+1 {{"llzk.main" on top-level module must be a concrete 'struct.type' attribute. Found: 12}}
+// expected-error@+1 {{"llzk.main" on module must be a concrete 'struct.type' attribute. Found: 12}}
 module attributes {llzk.main = 12, llzk.lang} {
   poly.template @TMustBeStruct {
     poly.param @N
@@ -431,7 +431,7 @@ module attributes {llzk.main = 12, llzk.lang} {
   }
 }
 // -----
-// expected-error@+1 {{"llzk.main" on top-level module must be a concrete 'struct.type' attribute. Found: !felt.type}}
+// expected-error@+1 {{"llzk.main" on module must be a concrete 'struct.type' attribute. Found: !felt.type}}
 module attributes {llzk.main = !felt.type, llzk.lang} {
   poly.template @TMustBeStruct {
     poly.param @N
@@ -448,7 +448,7 @@ module attributes {llzk.main = !felt.type, llzk.lang} {
   }
 }
 // -----
-// expected-error@+1 {{"llzk.main" on top-level module must be a concrete 'struct.type' attribute. Found: !struct.type<@TNotAffine::@NotAffine<[affine_map}}
+// expected-error@+1 {{"llzk.main" on module must be a concrete 'struct.type' attribute. Found: !struct.type<@TNotAffine::@NotAffine<[affine_map}}
 module attributes {llzk.main = !struct.type<@TNotAffine::@NotAffine<[affine_map<(i)->(i)>]>>, llzk.lang} {
   poly.template @TNotAffine {
     poly.param @N
@@ -465,7 +465,7 @@ module attributes {llzk.main = !struct.type<@TNotAffine::@NotAffine<[affine_map<
   }
 }
 // -----
-// expected-error@+1 {{"llzk.main" on top-level module must be a concrete 'struct.type' attribute. Found: !struct.type<@TNotSymbol::@NotSymbol<[@X]>>}}
+// expected-error@+1 {{"llzk.main" on module must be a concrete 'struct.type' attribute. Found: !struct.type<@TNotSymbol::@NotSymbol<[@X]>>}}
 module attributes {llzk.main = !struct.type<@TNotSymbol::@NotSymbol<[@X]>>, llzk.lang} {
   poly.template @TNotSymbol {
     poly.param @N
@@ -482,7 +482,7 @@ module attributes {llzk.main = !struct.type<@TNotSymbol::@NotSymbol<[@X]>>, llzk
   }
 }
 // -----
-// expected-error@+1 {{"llzk.main" on top-level module must be a concrete 'struct.type' attribute. Found: !struct.type<@TNotVar::@NotVar<[!poly.tvar<@X>]>>}}
+// expected-error@+1 {{"llzk.main" on module must be a concrete 'struct.type' attribute. Found: !struct.type<@TNotVar::@NotVar<[!poly.tvar<@X>]>>}}
 module attributes {llzk.main = !struct.type<@TNotVar::@NotVar<[!poly.tvar<@X>]>>, llzk.lang} {
   poly.template @TNotVar {
     poly.param @N

--- a/test/Transforms/InlineStructs/inline_structs_fail.llzk
+++ b/test/Transforms/InlineStructs/inline_structs_fail.llzk
@@ -128,7 +128,7 @@ module attributes {llzk.main = !struct.type<@Main>, llzk.lang} {
 }
 // -----
 
-module attributes {llzk.main = !struct.type<@Main>, llzk.lang} {
+module attributes {llzk.lang} {
   // expected-error@+1 {{Cannot inline struct within a template. Run `llzk-flatten` to instantiate templated structs.}}
   poly.template @TComponentY {
     poly.param @A

--- a/test/Transforms/InlineStructs/inline_structs_pass.llzk
+++ b/test/Transforms/InlineStructs/inline_structs_pass.llzk
@@ -405,7 +405,7 @@ module attributes {llzk.main = !struct.type<@Main>, llzk.lang} {
 // -----
 
 // TESTS: no main struct
-module attributes {llzk.main = !struct.type<@Main>, llzk.lang} {
+module attributes {llzk.lang} {
   struct.def @Component5A {
     struct.member @f1 : !felt.type
     struct.member @f2 : !felt.type

--- a/test/Transforms/RedundantAndUnusedElim/unused_declaration_pass.llzk
+++ b/test/Transforms/RedundantAndUnusedElim/unused_declaration_pass.llzk
@@ -1,7 +1,7 @@
 // RUN: llzk-opt -split-input-file -llzk-duplicate-read-write-elim -llzk-duplicate-op-elim -llzk-unused-declaration-elim="remove-structs" %s 2>&1 | FileCheck %s --check-prefix STRICT
 // RUN: llzk-opt -split-input-file -llzk-duplicate-read-write-elim -llzk-duplicate-op-elim -llzk-unused-declaration-elim %s 2>&1 | FileCheck %s --check-prefix RELAX
 
-module attributes {llzk.main = !struct.type<@Main>, llzk.lang} {
+module attributes {llzk.lang} {
   struct.def @Component {
     struct.member @matrix : !array.type<7,3 x !felt.type>
 
@@ -15,7 +15,7 @@ module attributes {llzk.main = !struct.type<@Main>, llzk.lang} {
   }
 }
 
-// STRICT-LABEL: module attributes {llzk.lang, llzk.main = !struct.type<@Main>} {
+// STRICT-LABEL: module attributes {llzk.lang} {
 // STRICT-NEXT: }
 
 // RELAX-LABEL: struct.def @Component {

--- a/tools/llzk-witgen/WitgenLowering.cpp
+++ b/tools/llzk-witgen/WitgenLowering.cpp
@@ -26,6 +26,7 @@
 #include "llzk/Dialect/Struct/IR/Ops.h"
 #include "llzk/Transforms/LLZKTransformationPasses.h"
 #include "llzk/Util/Compare.h"
+#include "llzk/Util/Constants.h"
 #include "llzk/Util/DynamicAPIntHelper.h"
 #include "llzk/Util/Field.h"
 #include "llzk/Util/SymbolHelper.h"
@@ -1756,6 +1757,9 @@ public:
       }
     }
     builder.create<func::ReturnOp>(computeFunc.getLoc());
+
+    // Remove `llzk.main` attribute because the main struct is deleted below.
+    moduleOp->removeAttr(MAIN_ATTR_NAME);
 
     SmallVector<Operation *> toErase;
     for (Operation &op : moduleOp.getBody()->getOperations()) {


### PR DESCRIPTION
Previously, the `llzk.main` attribute was only verified to reference a real `struct.def` if a pass or something happened to call `getMainInstanceDef()`.