### PR TITLE
Conservatively handle control-dependent interval writes

### DIFF
--- a/changelogs/unreleased/fix-interval-control-dependent-writes.yaml
+++ b/changelogs/unreleased/fix-interval-control-dependent-writes.yaml
@@ -1,0 +1,2 @@
+fixed:
+  - Fixed interval analysis for storage writes under control-dependent regions

--- a/include/llzk/Analysis/IntervalAnalysis.h
+++ b/include/llzk/Analysis/IntervalAnalysis.h
@@ -460,7 +460,12 @@ private:
 
   /// @brief Record a write to the given SourceRef and eagerly refine any reads that
   /// are currently tracking the same storage location.
-  void recordRefWrite(const SourceRef &writtenRef, const ExpressionValue &writeVal);
+  ///
+  /// When `mayBeSkipped` is true, handle the write as control-dependent instead
+  /// of unconditional, so the stored value also keeps the prior/no-write state.
+  void recordRefWrite(
+      const SourceRef &writtenRef, const ExpressionValue &writeVal, bool mayBeSkipped = false
+  );
 
   /// @brief Get the SourceRef state that defines `val`.
   SourceRefLatticeValue getSourceRefState(mlir::Value val);

--- a/lib/Analysis/IntervalAnalysis.cpp
+++ b/lib/Analysis/IntervalAnalysis.cpp
@@ -70,7 +70,7 @@ bool isInMaybeSkippedScfRegion(Operation *op) {
     // `writeResults` is a storage side-channel, not a path-sensitive lattice.
     // Writes nested under branch/loop control may not be absolute on every path through the
     // enclosing op, so keep the prior state instead of treating the nested write as unconditional.
-    if (llvm::isa<scf::ForOp, scf::IfOp>(parent)) {
+    if (llvm::isa<scf::ForOp, scf::IfOp, scf::WhileOp>(parent)) {
       return true;
     }
   }

--- a/lib/Analysis/IntervalAnalysis.cpp
+++ b/lib/Analysis/IntervalAnalysis.cpp
@@ -61,6 +61,22 @@ ExpressionValue refineReducedInterval(const ExpressionValue &expr, const Interva
   return refined;
 }
 
+bool isInMaybeSkippedScfRegion(Operation *op) {
+  for (Operation *parent = op->getParentOp(); parent != nullptr; parent = parent->getParentOp()) {
+    if (llvm::isa<FuncDefOp>(parent)) {
+      return false;
+    }
+
+    // `writeResults` is a storage side-channel, not a path-sensitive lattice.
+    // Writes nested under branch/loop control may not be absolute on every path through the
+    // enclosing op, so keep the prior state instead of treating the nested write as unconditional.
+    if (llvm::isa<scf::ForOp, scf::IfOp>(parent)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 std::optional<UnreducedInterval> getBooleanUnreducedInterval(const Interval &interval) {
   return interval.isBoolean() ? std::optional<UnreducedInterval>(interval.firstUnreduced())
                               : std::nullopt;
@@ -636,29 +652,41 @@ ExpressionValue IntervalDataFlowAnalysis::getRefValue(const SourceRef &ref, Valu
 }
 
 void IntervalDataFlowAnalysis::recordRefWrite(
-    const SourceRef &writtenRef, const ExpressionValue &writeVal
+    const SourceRef &writtenRef, const ExpressionValue &writeVal, bool mayBeSkipped
 ) {
-  if (auto it = writeResults.find(writtenRef); it != writeResults.end()) {
-    const ExpressionValue &old = it->second;
-    Interval combinedWrite = old.getInterval().join(writeVal.getInterval());
+  auto joinStoredWrite = [this, &writtenRef](
+                             const ExpressionValue &old, const ExpressionValue &next
+                         ) -> ExpressionValue {
+    Interval combinedWrite = old.getInterval().join(next.getInterval());
     auto combinedUnreduced = mergeUnreducedIntervals(
-        old.getOptionalUnreducedInterval(), writeVal.getOptionalUnreducedInterval()
+        old.getOptionalUnreducedInterval(), next.getOptionalUnreducedInterval()
     );
-    if (old.getExpr() != nullptr && writeVal.getExpr() != nullptr &&
-        *old.getExpr() == *writeVal.getExpr()) {
-      writeResults[writtenRef] =
-          old.withInterval(combinedWrite).withOptionalUnreducedInterval(combinedUnreduced);
-    } else {
-      llvm::SMTExprRef expr = getOrCreateSymbol(writtenRef);
-      writeResults[writtenRef] = ExpressionValue(expr, combinedWrite, std::move(combinedUnreduced));
+    if (old.getExpr() != nullptr && next.getExpr() != nullptr &&
+        *old.getExpr() == *next.getExpr()) {
+      return old.withInterval(combinedWrite).withOptionalUnreducedInterval(combinedUnreduced);
     }
+
+    return ExpressionValue(
+        getOrCreateSymbol(writtenRef), combinedWrite, std::move(combinedUnreduced)
+    );
+  };
+
+  if (auto it = writeResults.find(writtenRef); it != writeResults.end()) {
+    it->second = joinStoredWrite(it->second, writeVal);
+  } else if (mayBeSkipped) {
+    ExpressionValue noWrite(
+        getOrCreateSymbol(writtenRef), getRefInterval(writtenRef),
+        getRefUnreducedInterval(writtenRef)
+    );
+    writeResults[writtenRef] = joinStoredWrite(noWrite, writeVal);
   } else {
     writeResults[writtenRef] = writeVal;
   }
 
+  const ExpressionValue &readerUpdate = mayBeSkipped ? writeResults[writtenRef] : writeVal;
   for (Lattice *readerLattice : readResults[writtenRef]) {
     ExpressionValue prior = readerLattice->getValue().getScalarValue();
-    Interval intersection = prior.getInterval().intersect(writeVal.getInterval());
+    Interval intersection = prior.getInterval().intersect(readerUpdate.getInterval());
     ExpressionValue newVal = prior.withInterval(intersection);
     propagateIfChanged(readerLattice, readerLattice->setValue(newVal));
   }
@@ -852,6 +880,7 @@ mlir::LogicalResult IntervalDataFlowAnalysis::visitOperation(
     // No need to propagate the constraint
     (void)getLatticeElement(cond)->addSolverConstraint(assertExpr);
   } else if (auto writem = llvm::dyn_cast<MemberWriteOp>(op)) {
+    const bool maySkipWrite = isInMaybeSkippedScfRegion(op);
     // Update values stored in a member
     ExpressionValue writeVal = operandVals[1].getScalarValue();
     auto cmp = writem.getComponent();
@@ -867,7 +896,7 @@ mlir::LogicalResult IntervalDataFlowAnalysis::visitOperation(
         Type memberTy = writem.getVal().getType();
         if (!llvm::isa<ArrayType, StructType>(memberTy)) {
           // Simple scalar update
-          recordRefWrite(memberRef, writeVal);
+          recordRefWrite(memberRef, writeVal, maySkipWrite);
         } else {
           // Map the intervals of aggregates to the written member
           std::optional<SourceRef> rhsPrefix;
@@ -892,17 +921,18 @@ mlir::LogicalResult IntervalDataFlowAnalysis::visitOperation(
             }
 
             for (const auto &[translatedRef, translatedVal] : remappedWrites) {
-              recordRefWrite(translatedRef, translatedVal);
+              recordRefWrite(translatedRef, translatedVal, maySkipWrite);
             }
           }
         }
       }
     }
   } else if (auto writeArr = llvm::dyn_cast<WriteArrayOp>(op)) {
+    const bool maySkipWrite = isInMaybeSkippedScfRegion(op);
     ExpressionValue writeVal = operandVals.back().getScalarValue();
     auto arrayRef = getArrayAccessRef(op, writeArr);
     if (succeeded(arrayRef)) {
-      recordRefWrite(*arrayRef, writeVal);
+      recordRefWrite(*arrayRef, writeVal, maySkipWrite);
     }
 
     SourceRefLatticeValue arrayVals = getSourceRefState(writeArr.getArrRef());
@@ -913,7 +943,7 @@ mlir::LogicalResult IntervalDataFlowAnalysis::visitOperation(
       auto [targetRefs, _] = *targetRefsRes;
       ensure(targetRefs.isScalar(), "array write must resolve to scalar references");
       for (const SourceRef &ref : targetRefs.getScalarValue()) {
-        recordRefWrite(ref, writeVal);
+        recordRefWrite(ref, writeVal, maySkipWrite);
       }
     }
   } else if (auto createArray = llvm::dyn_cast<CreateArrayOp>(op)) {

--- a/test/Analysis/interval_analysis/interval_analysis_pass_compute.llzk
+++ b/test/Analysis/interval_analysis/interval_analysis_pass_compute.llzk
@@ -534,6 +534,40 @@ module attributes {llzk.lang} {
 // -----
 
 module attributes {llzk.lang} {
+  struct.def @NoYieldWhile {
+    struct.member @a: !felt.type
+
+    function.def @compute(%x: index) -> !struct.type<@NoYieldWhile> {
+      %self = struct.new : !struct.type<@NoYieldWhile>
+      %0 = arith.constant 0 : index
+      %1 = arith.constant 1 : index
+      scf.while (%i = %0) : (index) -> index {
+        %cond = arith.cmpi slt, %i, %x : index
+        scf.condition(%cond) %i : index
+      } do {
+      ^bb0(%i: index):
+        %c = felt.const 3
+        struct.writem %self[@a] = %c : !struct.type<@NoYieldWhile>, !felt.type
+        %next = arith.addi %i, %1 : index
+        scf.yield %next : index
+      }
+      function.return %self : !struct.type<@NoYieldWhile>
+    }
+
+    function.def @constrain(%self: !struct.type<@NoYieldWhile>, %x: index) {
+      function.return
+    }
+  }
+}
+// CHECK-LABEL: @NoYieldWhile StructIntervals {
+// CHECK-NEXT: compute {
+// CHECK-NEXT:    %arg0 in Entire
+// CHECK-NEXT:    %self[@a] in Entire
+// CHECK-NEXT:  }
+
+// -----
+
+module attributes {llzk.lang} {
   struct.def @YieldForConst {
     struct.member @a: !felt.type
 

--- a/test/Analysis/interval_analysis/interval_analysis_pass_compute.llzk
+++ b/test/Analysis/interval_analysis/interval_analysis_pass_compute.llzk
@@ -412,7 +412,7 @@ module attributes {llzk.lang} {
 // CHECK-NEXT:     %arg0 in Entire
 // CHECK-NEXT:     %arg1 in Entire
 // CHECK-NEXT:     %self[@data] in Entire
-// CHECK-NEXT:     %self[@const] in Degenerate(0)
+// CHECK-NEXT:     %self[@const] in Entire
 // CHECK-NEXT: }
 
 // -----
@@ -528,7 +528,7 @@ module attributes {llzk.lang} {
 // CHECK-LABEL: @NoYieldFor StructIntervals {
 // CHECK-NEXT: compute {
 // CHECK-NEXT:    %arg0 in Entire
-// CHECK-NEXT:    %self[@a] in Degenerate(3)
+// CHECK-NEXT:    %self[@a] in Entire
 // CHECK-NEXT:  }
 
 // -----
@@ -581,8 +581,7 @@ module attributes {llzk.lang} {
       %f0 = felt.const 0
       scf.for %i = %0 to %x step %1 {
         %3 = felt.const 3
-        // COM: This is currently unsound, as it doesn't account for whether
-        // or not the loop will run.
+        // COM: The loop body may never run, so this write is not absolute.
         struct.writem %self[@a] = %3 : !struct.type<@YieldForConst>, !felt.type
         scf.yield
       }
@@ -598,7 +597,7 @@ module attributes {llzk.lang} {
 // CHECK-LABEL: @YieldForConst StructIntervals {
 // CHECK-NEXT: compute {
 // CHECK-NEXT:    %arg0 in Entire
-// CHECK-NEXT:    %self[@a] in Degenerate(3)
+// CHECK-NEXT:    %self[@a] in Entire
 // CHECK-NEXT:  }
 
 // -----


### PR DESCRIPTION
## Summary

Fixes #317.

Fixes interval-analysis unsoundness for writes inside SCF regions that may not execute.

Previously, writes recorded through `writeResults` were treated as unconditional even when the write occurred inside control flow such as `scf.for` or `scf.if`. That could make the analysis report overly precise results when the write path is skipped, such as a loop with zero iterations.

This patch makes those storage writes conservative by joining the written value with the prior/no-write state.

## Details

- Treat `struct.writem` and `array.write` updates under `scf.for` / `scf.if` as control-dependent writes.
- Preserve the prior/no-write storage state for those writes.
- Use the joined storage value when refining existing readers.
- Update interval-analysis checks for the reported `scf.for` case and the adjacent one-armed `scf.if` case.

## Testing

```sh
git diff --check
clang-format --dry-run --Werror include/llzk/Analysis/IntervalAnalysis.h lib/Analysis/IntervalAnalysis.cpp
```

Full lit suite is expected to be covered by CI.
