### PR TITLE
Fix uniform random for large primes (>64 bits)

### DIFF
--- a/changelogs/unreleased/th__fix_uniform_random_large_prime.yaml
+++ b/changelogs/unreleased/th__fix_uniform_random_large_prime.yaml
@@ -4,4 +4,4 @@ added:
 fixed:
   - "Avoid unnecessary narrowing to `int` in `Field::reduce()`"
   - "Ensure distribution of random numbers is uniform for large primes (>64 bits)"
-  - "`toDynamicAPInt(APSInt)` incorrectly converted values <=64 bits but larger than MAX(int64_t) to negative numbers"
+  - "`toDynamicAPInt(APSInt)` incorrectly produced negative results for values larger than MAX(int64_t) and up to 64 bits"

--- a/changelogs/unreleased/th__fix_uniform_random_large_prime.yaml
+++ b/changelogs/unreleased/th__fix_uniform_random_large_prime.yaml
@@ -4,3 +4,4 @@ added:
 fixed:
   - "Avoid unnecessary narrowing to `int` in `Field::reduce()`"
   - "Ensure distribution of random numbers is uniform for large primes (>64 bits)"
+  - "`toDynamicAPInt(APSInt)` incorrectly converted values <=64 bits but larger than MAX(int64_t) to negative numbers"

--- a/changelogs/unreleased/th__fix_uniform_random_large_prime.yaml
+++ b/changelogs/unreleased/th__fix_uniform_random_large_prime.yaml
@@ -1,0 +1,6 @@
+added:
+  - "`toDynamicAPInt(size_t)` helper function"
+
+fixed:
+  - "Avoid unnecessary narrowing to `int` in `Field::reduce()`"
+  - "Ensure distribution of random numbers is uniform for large primes (>64 bits)"

--- a/include/llzk/Util/DynamicAPIntHelper.h
+++ b/include/llzk/Util/DynamicAPIntHelper.h
@@ -26,6 +26,10 @@
 #include <llvm/ADT/SlowDynamicAPInt.h>
 #include <llvm/ADT/StringRef.h>
 
+#include <climits>
+#include <cstddef>
+#include <cstdint>
+
 namespace llzk {
 
 llvm::DynamicAPInt operator&(const llvm::DynamicAPInt &lhs, const llvm::DynamicAPInt &rhs);

--- a/include/llzk/Util/DynamicAPIntHelper.h
+++ b/include/llzk/Util/DynamicAPIntHelper.h
@@ -18,6 +18,8 @@
 
 #pragma once
 
+#include "llzk/Util/Compare.h"
+
 #include <llvm/ADT/APInt.h>
 #include <llvm/ADT/APSInt.h>
 #include <llvm/ADT/DynamicAPInt.h>
@@ -38,6 +40,10 @@ llvm::DynamicAPInt toDynamicAPInt(const llvm::APSInt &i);
 
 inline llvm::DynamicAPInt toDynamicAPInt(const llvm::APInt &i) {
   return toDynamicAPInt(llvm::APSInt(i));
+}
+
+inline llvm::DynamicAPInt toDynamicAPInt(size_t i) {
+  return toDynamicAPInt(llvm::APInt(sizeof(size_t) * CHAR_BIT, llzk::checkedCast<uint64_t>(i)));
 }
 
 llvm::APSInt toAPSInt(const llvm::DynamicAPInt &i);

--- a/include/llzk/Util/Field.h
+++ b/include/llzk/Util/Field.h
@@ -95,7 +95,7 @@ public:
   /// Field elements are returned as signed integers so that negation functions
   /// as expected (i.e., reducing -1 will yield p-1).
   llvm::DynamicAPInt reduce(const llvm::DynamicAPInt &i) const;
-  inline llvm::DynamicAPInt reduce(int i) const { return reduce(llvm::DynamicAPInt(i)); }
+  inline llvm::DynamicAPInt reduce(int64_t i) const { return reduce(llvm::DynamicAPInt(i)); }
   llvm::DynamicAPInt reduce(const llvm::APInt &i) const;
 
   /// Converts a canonical field element to its signed integer representation:

--- a/lib/Util/DynamicAPIntHelper.cpp
+++ b/lib/Util/DynamicAPIntHelper.cpp
@@ -96,8 +96,10 @@ DynamicAPInt toDynamicAPInt(StringRef str) {
 }
 
 DynamicAPInt toDynamicAPInt(const APSInt &i) {
-  if (i.getBitWidth() <= 64) {
-    // Fast path for smaller values, just use the int64_t conversion
+  // Fast path for smaller values, just use the `int64_t` conversion. However, that only works if
+  // the value is signed or if the sign bit is clear otherwise it will incorrectly interpret the
+  // value as a negative number.
+  if (i.getBitWidth() <= 64 && (i.isSigned() || i.isSignBitClear())) {
     return DynamicAPInt(i.isNegative() ? i.getSExtValue() : static_cast<int64_t>(i.getZExtValue()));
   }
 

--- a/test/Transforms/PCLLowering/pcl_bool_pass.llzk
+++ b/test/Transforms/PCLLowering/pcl_bool_pass.llzk
@@ -44,7 +44,7 @@ module attributes {llzk.lang} {
   }
 }
 
-// CHECK-LABEL: module attributes {pcl.prime = #pcl.prime<18446744069414584321 : i65>} {
+// CHECK-LABEL: module attributes {pcl.prime = #pcl.prime<18446744069414584321 : i66>} {
 // CHECK-NEXT:    func.func @A(%arg0: !pcl.felt, %arg1: !pcl.felt, %arg2: !pcl.felt) {
 // CHECK-NEXT:      %0 = pcl.lt %arg0, %arg1
 // CHECK-NEXT:      %1 = pcl.le %arg1, %arg2
@@ -96,7 +96,7 @@ module attributes {llzk.lang} {
   }
 }
 
-// CHECK-LABEL: module attributes {pcl.prime = #pcl.prime<18446744069414584321 : i65>} {
+// CHECK-LABEL: module attributes {pcl.prime = #pcl.prime<18446744069414584321 : i66>} {
 // CHECK-NEXT:    func.func @A(%arg0: !pcl.felt, %arg1: !pcl.felt, %arg2: !pcl.felt) {
 // CHECK-NEXT:      %0 = pcl.eq %arg0, %arg1
 // CHECK-NEXT:      %1 = pcl.eq %arg1, %arg2
@@ -122,7 +122,7 @@ module attributes {llzk.lang} {
   }
 }
 
-// CHECK-LABEL: module attributes {pcl.prime = #pcl.prime<18446744069414584321 : i65>} {
+// CHECK-LABEL: module attributes {pcl.prime = #pcl.prime<18446744069414584321 : i66>} {
 // CHECK-NEXT:    func.func @A(%arg0: !pcl.felt, %arg1: !pcl.felt) {
 // CHECK-NEXT:      %0 = pcl.eq %arg0, %arg1
 // CHECK-NEXT:      %1 = pcl.not %0

--- a/tools/llzk-witgen/WitgenUtils.cpp
+++ b/tools/llzk-witgen/WitgenUtils.cpp
@@ -98,7 +98,7 @@ llvm::DynamicAPInt randomFieldElement(std::mt19937_64 &rng, const Field &field) 
   // Generate a random value with the same bit width as the prime; if it is
   // >= prime, discard and retry. The rejection probability is < 50%, so the
   // expected number of iterations is less than 2.
-  const unsigned bitWidth = toAPSInt(prime).getActiveBits();
+  const unsigned bitWidth = field.bitWidth();
   const unsigned numWords = (bitWidth + 63U) / 64U;
   std::uniform_int_distribution<uint64_t> wordDist;
   llvm::SmallVector<uint64_t, 4> words(numWords);

--- a/tools/llzk-witgen/WitgenUtils.cpp
+++ b/tools/llzk-witgen/WitgenUtils.cpp
@@ -16,6 +16,7 @@
 
 #include <mlir/IR/BuiltinTypes.h>
 
+#include <llvm/ADT/SmallVector.h>
 #include <llvm/ADT/Twine.h>
 
 #include <climits>
@@ -62,7 +63,7 @@ getStaticShapeElementCount(llvm::ArrayRef<int64_t> shape, llvm::StringRef contex
     if (!dimSize) {
       return dimSize.takeError();
     }
-    count *= llvm::DynamicAPInt(*dimSize);
+    count *= toDynamicAPInt(*dimSize);
   }
   return dynamicAPIntToSize(count, context);
 }
@@ -88,12 +89,30 @@ std::mt19937_64 makeDefaultValueRng(const WitgenOptions &options) {
 }
 
 llvm::DynamicAPInt randomFieldElement(std::mt19937_64 &rng, const Field &field) {
-  const uint64_t prime = toAPSInt(field.prime()).getZExtValue();
+  const llvm::DynamicAPInt prime = field.prime();
   if (prime == 0) {
-    return field.zero();
+    return prime;
   }
-  uint64_t candidate = std::uniform_int_distribution<uint64_t>(0, prime - 1)(rng);
-  return field.reduce(candidate);
+
+  // Use rejection sampling to produce a uniform value in [0, prime).
+  // Generate a random value with the same bit width as the prime; if it is
+  // >= prime, discard and retry. The rejection probability is < 50%, so the
+  // expected number of iterations is less than 2.
+  const unsigned bitWidth = toAPSInt(prime).getActiveBits();
+  const unsigned numWords = (bitWidth + 63U) / 64U;
+  std::uniform_int_distribution<uint64_t> wordDist;
+  llvm::SmallVector<uint64_t, 4> words(numWords);
+  while (true) {
+    for (uint64_t &word : words) {
+      word = wordDist(rng);
+    }
+    // APInt truncates the top word to exactly bitWidth bits, keeping the
+    // candidate in [0, 2^bitWidth).
+    llvm::DynamicAPInt value = toDynamicAPInt(llvm::APInt(bitWidth, words));
+    if (value < prime) {
+      return field.reduce(value);
+    }
+  }
 }
 
 int64_t randomIndexValue(std::mt19937_64 &rng) {

--- a/tools/llzk-witgen/WitgenUtils.cpp
+++ b/tools/llzk-witgen/WitgenUtils.cpp
@@ -38,6 +38,46 @@ dynamicAPIntToSize(const llvm::DynamicAPInt &value, llvm::Twine context) {
   return llzk::checkedCast<size_t>(as.getZExtValue());
 }
 
+llvm::Expected<size_t>
+checkedDynamicAPIntToSize(const llvm::DynamicAPInt &value, llvm::StringRef context) {
+  return dynamicAPIntToSize(value, context);
+}
+
+llvm::Expected<size_t> checkedShapeDimToSize(int64_t dim, llvm::StringRef context) {
+  if (ShapedType::isDynamic(dim)) {
+    return makeError(llvm::Twine(context) + " requires a static shape");
+  }
+  if (dim < 0) {
+    return makeError(llvm::Twine(context) + " has a negative dimension");
+  }
+  llvm::DynamicAPInt value(dim);
+  return dynamicAPIntToSize(value, llvm::Twine(context) + " dimension");
+}
+
+llvm::Expected<size_t>
+getStaticShapeElementCount(llvm::ArrayRef<int64_t> shape, llvm::StringRef context) {
+  llvm::DynamicAPInt count(1);
+  for (int64_t dim : shape) {
+    auto dimSize = checkedShapeDimToSize(dim, context);
+    if (!dimSize) {
+      return dimSize.takeError();
+    }
+    count *= llvm::DynamicAPInt(*dimSize);
+  }
+  return dynamicAPIntToSize(count, context);
+}
+
+llvm::Expected<size_t> getStaticElementCount(ShapedType type, llvm::StringRef context) {
+  if (!type.hasStaticShape()) {
+    return makeError(llvm::Twine(context) + " requires a static shape");
+  }
+  int64_t count = type.getNumElements();
+  if (count < 0) {
+    return makeError(llvm::Twine(context) + " has an invalid negative element count");
+  }
+  return dynamicAPIntToSize(llvm::DynamicAPInt(count), context);
+}
+
 std::mt19937_64 makeDefaultValueRng(const WitgenOptions &options) {
   if (options.randomSeed) {
     return std::mt19937_64(*options.randomSeed);
@@ -63,46 +103,6 @@ int64_t randomIndexValue(std::mt19937_64 &rng) {
 
 bool randomBoolValue(std::mt19937_64 &rng) {
   return std::uniform_int_distribution<int>(0, 1)(rng) != 0;
-}
-
-llvm::Expected<size_t> checkedShapeDimToSize(int64_t dim, llvm::StringRef context) {
-  if (ShapedType::isDynamic(dim)) {
-    return makeError(llvm::Twine(context) + " requires a static shape");
-  }
-  if (dim < 0) {
-    return makeError(llvm::Twine(context) + " has a negative dimension");
-  }
-  llvm::DynamicAPInt value(dim);
-  return dynamicAPIntToSize(value, llvm::Twine(context) + " dimension");
-}
-
-llvm::Expected<size_t>
-checkedDynamicAPIntToSize(const llvm::DynamicAPInt &value, llvm::StringRef context) {
-  return dynamicAPIntToSize(value, context);
-}
-
-llvm::Expected<size_t>
-getStaticShapeElementCount(llvm::ArrayRef<int64_t> shape, llvm::StringRef context) {
-  llvm::DynamicAPInt count(1);
-  for (int64_t dim : shape) {
-    auto dimSize = checkedShapeDimToSize(dim, context);
-    if (!dimSize) {
-      return dimSize.takeError();
-    }
-    count *= llvm::DynamicAPInt(*dimSize);
-  }
-  return dynamicAPIntToSize(count, context);
-}
-
-llvm::Expected<size_t> getStaticElementCount(ShapedType type, llvm::StringRef context) {
-  if (!type.hasStaticShape()) {
-    return makeError(llvm::Twine(context) + " requires a static shape");
-  }
-  int64_t count = type.getNumElements();
-  if (count < 0) {
-    return makeError(llvm::Twine(context) + " has an invalid negative element count");
-  }
-  return dynamicAPIntToSize(llvm::DynamicAPInt(count), context);
 }
 
 } // namespace llzk::witgen

--- a/unittests/Analysis/DynamicAPIntTests.cpp
+++ b/unittests/Analysis/DynamicAPIntTests.cpp
@@ -9,7 +9,7 @@
 
 #include "../LLZKTestUtils.h"
 
-#include <climits>
+#include <cstdint>
 #include <gtest/gtest.h>
 #include <string>
 
@@ -92,15 +92,15 @@ INSTANTIATE_TEST_SUITE_P(
 );
 
 // Verify that size_t values above INT64_MAX are not mis-converted to negative.
-// SIZE_MAX (0xFFFFFFFFFFFFFFFF) has its MSB set; if the APSInt wrapper incorrectly
-// interpreted the value as signed, it would yield -1 instead of 18446744073709551615.
+// SIZE_MAX has its MSB set; if the APSInt wrapper incorrectly interpreted the value
+// as signed, it would yield -1 instead of 18446744073709551615 (on 64-bit systems).
 TEST(DynamicAPIntSizeTTest, SizeMax1) {
   DynamicAPInt a = toDynamicAPInt(SIZE_MAX);
 
   std::string buffer;
   llvm::raw_string_ostream(buffer) << a;
 
-  ASSERT_EQ(buffer, "18446744073709551615");
+  ASSERT_EQ(buffer, std::to_string(SIZE_MAX));
 }
 
 TEST(DynamicAPIntSizeTTest, SizeMax2) {
@@ -109,7 +109,7 @@ TEST(DynamicAPIntSizeTTest, SizeMax2) {
   std::string buffer;
   llvm::raw_string_ostream(buffer) << a;
 
-  ASSERT_EQ(buffer, "18446744073709551615");
+  ASSERT_EQ(buffer, std::to_string(SIZE_MAX));
 }
 
 TEST(DynamicAPIntSizeTTest, SizeMax3) {
@@ -118,7 +118,7 @@ TEST(DynamicAPIntSizeTTest, SizeMax3) {
   std::string buffer;
   llvm::raw_string_ostream(buffer) << a;
 
-  ASSERT_EQ(buffer, "18446744073709551615");
+  ASSERT_EQ(buffer, std::to_string(SIZE_MAX));
 }
 
 //===----------------------------------------------------------------------===//

--- a/unittests/Analysis/DynamicAPIntTests.cpp
+++ b/unittests/Analysis/DynamicAPIntTests.cpp
@@ -95,7 +95,13 @@ INSTANTIATE_TEST_SUITE_P(
 // SIZE_MAX (0xFFFFFFFFFFFFFFFF) has its MSB set; if the APSInt wrapper incorrectly
 // interpreted the value as signed, it would yield -1 instead of 18446744073709551615.
 TEST(DynamicAPIntSizeTTest, SizeMax) {
-  ASSERT_EQ(toDynamicAPInt(SIZE_MAX), toDynamicAPInt("18446744073709551615"));
+  DynamicAPInt a = toDynamicAPInt(SIZE_MAX);
+
+  std::string buffer;
+  llvm::raw_string_ostream os(buffer);
+  a.print(os);
+
+  ASSERT_EQ(buffer, "18446744073709551615");
 }
 
 //===----------------------------------------------------------------------===//

--- a/unittests/Analysis/DynamicAPIntTests.cpp
+++ b/unittests/Analysis/DynamicAPIntTests.cpp
@@ -94,12 +94,29 @@ INSTANTIATE_TEST_SUITE_P(
 // Verify that size_t values above INT64_MAX are not mis-converted to negative.
 // SIZE_MAX (0xFFFFFFFFFFFFFFFF) has its MSB set; if the APSInt wrapper incorrectly
 // interpreted the value as signed, it would yield -1 instead of 18446744073709551615.
-TEST(DynamicAPIntSizeTTest, SizeMax) {
+TEST(DynamicAPIntSizeTTest, SizeMax1) {
   DynamicAPInt a = toDynamicAPInt(SIZE_MAX);
 
   std::string buffer;
-  llvm::raw_string_ostream os(buffer);
-  a.print(os);
+  llvm::raw_string_ostream(buffer) << a;
+
+  ASSERT_EQ(buffer, "18446744073709551615");
+}
+
+TEST(DynamicAPIntSizeTTest, SizeMax2) {
+  APSInt a = toAPSInt(toDynamicAPInt(SIZE_MAX));
+
+  std::string buffer;
+  llvm::raw_string_ostream(buffer) << a;
+
+  ASSERT_EQ(buffer, "18446744073709551615");
+}
+
+TEST(DynamicAPIntSizeTTest, SizeMax3) {
+  APInt a = toAPInt(toDynamicAPInt(SIZE_MAX), sizeof(size_t) * CHAR_BIT);
+
+  std::string buffer;
+  llvm::raw_string_ostream(buffer) << a;
 
   ASSERT_EQ(buffer, "18446744073709551615");
 }

--- a/unittests/Analysis/DynamicAPIntTests.cpp
+++ b/unittests/Analysis/DynamicAPIntTests.cpp
@@ -9,6 +9,7 @@
 
 #include "../LLZKTestUtils.h"
 
+#include <climits>
 #include <gtest/gtest.h>
 #include <string>
 
@@ -89,6 +90,13 @@ TEST_P(DynamicAPIntStringTest, Strings) {
 INSTANTIATE_TEST_SUITE_P(
     , DynamicAPIntStringTest, testing::ValuesIn(DynamicAPIntStringTest::TestingValues())
 );
+
+// Verify that size_t values above INT64_MAX are not mis-converted to negative.
+// SIZE_MAX (0xFFFFFFFFFFFFFFFF) has its MSB set; if the APSInt wrapper incorrectly
+// interpreted the value as signed, it would yield -1 instead of 18446744073709551615.
+TEST(DynamicAPIntSizeTTest, SizeMax) {
+  ASSERT_EQ(toDynamicAPInt(SIZE_MAX), toDynamicAPInt("18446744073709551615"));
+}
 
 //===----------------------------------------------------------------------===//
 // Test bitwise AND, OR, XOR operations

--- a/unittests/Witgen/WitgenTests.cpp
+++ b/unittests/Witgen/WitgenTests.cpp
@@ -33,6 +33,19 @@ using namespace llzk;
 
 class WitgenTests : public LLZKTest {};
 
+class WitgenFieldTests : public LLZKTest, public ::testing::WithParamInterface<std::string> {};
+
+static std::string substituteFieldName(llvm::StringRef source, llvm::StringRef fieldName) {
+  std::string result = source.str();
+  const std::string placeholder = "babybear";
+  size_t pos = 0;
+  while ((pos = result.find(placeholder, pos)) != std::string::npos) {
+    result.replace(pos, placeholder.size(), fieldName.str());
+    pos += fieldName.size();
+  }
+  return result;
+}
+
 static function::FuncDefOp getUniqueFuncByName(ModuleOp module, StringRef name) {
   function::FuncDefOp result;
   module.walk([&](function::FuncDefOp funcOp) {
@@ -43,13 +56,13 @@ static function::FuncDefOp getUniqueFuncByName(ModuleOp module, StringRef name) 
   return result;
 }
 
-TEST_F(WitgenTests, ParseJSONArrayInput) {
+TEST_P(WitgenFieldTests, ParseJSONArrayInput) {
   auto parsed = llvm::json::parse(R"([1, "2", 3])");
   ASSERT_TRUE(static_cast<bool>(parsed));
 
-  auto feltType = felt::FeltType::get(&ctx, StringAttr::get(&ctx, "babybear"));
+  auto feltType = felt::FeltType::get(&ctx, StringAttr::get(&ctx, GetParam()));
   auto arrayType = array::ArrayType::get(feltType, {3});
-  auto field = Field::tryGetField("babybear");
+  auto field = Field::tryGetField(GetParam());
   ASSERT_TRUE(succeeded(field));
 
   auto value = witgen::parseJSONValue(&*parsed, arrayType, field->get(), nullptr);
@@ -62,13 +75,13 @@ TEST_F(WitgenTests, ParseJSONArrayInput) {
   EXPECT_EQ(std::get<llvm::DynamicAPInt>(arrayValue->elements[2]), field->get().reduce(3));
 }
 
-TEST_F(WitgenTests, ParseJSONArrayNestedInput) {
+TEST_P(WitgenFieldTests, ParseJSONArrayNestedInput) {
   auto parsed = llvm::json::parse(R"([[1, 2], [3, "4"]])");
   ASSERT_TRUE(static_cast<bool>(parsed));
 
-  auto feltType = felt::FeltType::get(&ctx, StringAttr::get(&ctx, "babybear"));
+  auto feltType = felt::FeltType::get(&ctx, StringAttr::get(&ctx, GetParam()));
   auto arrayType = array::ArrayType::get(feltType, {2, 2});
-  auto field = Field::tryGetField("babybear");
+  auto field = Field::tryGetField(GetParam());
   ASSERT_TRUE(succeeded(field));
 
   auto value = witgen::parseJSONValue(&*parsed, arrayType, field->get(), nullptr);
@@ -82,9 +95,9 @@ TEST_F(WitgenTests, ParseJSONArrayNestedInput) {
   EXPECT_EQ(std::get<llvm::DynamicAPInt>(arrayValue->elements[3]), field->get().reduce(4));
 }
 
-TEST_F(WitgenTests, DefaultValueFailsOnUninitializedRead) {
-  auto feltType = felt::FeltType::get(&ctx, StringAttr::get(&ctx, "babybear"));
-  auto field = Field::tryGetField("babybear");
+TEST_P(WitgenFieldTests, DefaultValueFailsOnUninitializedRead) {
+  auto feltType = felt::FeltType::get(&ctx, StringAttr::get(&ctx, GetParam()));
+  auto field = Field::tryGetField(GetParam());
   ASSERT_TRUE(succeeded(field));
 
   SymbolTableCollection tables;
@@ -98,10 +111,10 @@ TEST_F(WitgenTests, DefaultValueFailsOnUninitializedRead) {
   EXPECT_NE(llvm::toString(felt.takeError()).find("uninitialized felt value"), std::string::npos);
 }
 
-TEST_F(WitgenTests, RandomDefaultValueIsSeeded) {
-  auto feltType = felt::FeltType::get(&ctx, StringAttr::get(&ctx, "babybear"));
+TEST_P(WitgenFieldTests, RandomDefaultValueIsSeeded) {
+  auto feltType = felt::FeltType::get(&ctx, StringAttr::get(&ctx, GetParam()));
   auto arrayType = array::ArrayType::get(feltType, {2});
-  auto field = Field::tryGetField("babybear");
+  auto field = Field::tryGetField(GetParam());
   ASSERT_TRUE(succeeded(field));
 
   SymbolTableCollection tables;
@@ -141,8 +154,8 @@ TEST_F(WitgenTests, SharedWitgenRngUsesDeterministicSeed) {
   EXPECT_EQ(lhs(), rhs());
 }
 
-TEST_F(WitgenTests, SharedRandomHelpersAreSeeded) {
-  auto field = Field::tryGetField("babybear");
+TEST_P(WitgenFieldTests, SharedRandomHelpersAreSeeded) {
+  auto field = Field::tryGetField(GetParam());
   ASSERT_TRUE(succeeded(field));
 
   std::mt19937_64 rngA(1234);
@@ -155,8 +168,8 @@ TEST_F(WitgenTests, SharedRandomHelpersAreSeeded) {
   EXPECT_EQ(witgen::randomBoolValue(rngA), witgen::randomBoolValue(rngB));
 }
 
-TEST_F(WitgenTests, RandomFieldHelperReturnsReducedValues) {
-  auto field = Field::tryGetField("babybear");
+TEST_P(WitgenFieldTests, RandomFieldHelperReturnsReducedValues) {
+  auto field = Field::tryGetField(GetParam());
   ASSERT_TRUE(succeeded(field));
 
   std::mt19937_64 rng(1234);
@@ -168,13 +181,13 @@ TEST_F(WitgenTests, RandomFieldHelperReturnsReducedValues) {
   }
 }
 
-TEST_F(WitgenTests, ParseJSONArrayRejectsDynamicShape) {
+TEST_P(WitgenFieldTests, ParseJSONArrayRejectsDynamicShape) {
   auto parsed = llvm::json::parse(R"([1])");
   ASSERT_TRUE(static_cast<bool>(parsed));
 
-  auto feltType = felt::FeltType::get(&ctx, StringAttr::get(&ctx, "babybear"));
+  auto feltType = felt::FeltType::get(&ctx, StringAttr::get(&ctx, GetParam()));
   auto arrayType = array::ArrayType::get(feltType, {ShapedType::kDynamic});
-  auto field = Field::tryGetField("babybear");
+  auto field = Field::tryGetField(GetParam());
   ASSERT_TRUE(succeeded(field));
 
   auto value = witgen::parseJSONValue(&*parsed, arrayType, field->get(), nullptr);
@@ -182,13 +195,13 @@ TEST_F(WitgenTests, ParseJSONArrayRejectsDynamicShape) {
   EXPECT_NE(llvm::toString(value.takeError()).find("requires a static shape"), std::string::npos);
 }
 
-TEST_F(WitgenTests, SerializeJSONArrayRejectsDynamicShape) {
-  auto feltType = felt::FeltType::get(&ctx, StringAttr::get(&ctx, "babybear"));
+TEST_P(WitgenFieldTests, SerializeJSONArrayRejectsDynamicShape) {
+  auto feltType = felt::FeltType::get(&ctx, StringAttr::get(&ctx, GetParam()));
   auto arrayType = array::ArrayType::get(feltType, {ShapedType::kDynamic});
 
   auto arrayValue = std::make_shared<witgen::ArrayValue>();
   arrayValue->type = arrayType;
-  arrayValue->elements.push_back(Field::getField("babybear").reduce(1));
+  arrayValue->elements.push_back(Field::getField(GetParam()).reduce(1));
 
   SymbolTableCollection tables;
   auto value = witgen::serializeJSONValue(arrayValue, arrayType, tables, nullptr);
@@ -196,13 +209,13 @@ TEST_F(WitgenTests, SerializeJSONArrayRejectsDynamicShape) {
   EXPECT_NE(llvm::toString(value.takeError()).find("requires a static shape"), std::string::npos);
 }
 
-TEST_F(WitgenTests, SerializeJSONArrayNestedOutput) {
-  auto feltType = felt::FeltType::get(&ctx, StringAttr::get(&ctx, "babybear"));
+TEST_P(WitgenFieldTests, SerializeJSONArrayNestedOutput) {
+  auto feltType = felt::FeltType::get(&ctx, StringAttr::get(&ctx, GetParam()));
   auto arrayType = array::ArrayType::get(feltType, {2, 2});
 
   auto arrayValue = std::make_shared<witgen::ArrayValue>();
   arrayValue->type = arrayType;
-  auto field = Field::getField("babybear");
+  auto field = Field::getField(GetParam());
   arrayValue->elements.push_back(field.reduce(1));
   arrayValue->elements.push_back(field.reduce(2));
   arrayValue->elements.push_back(field.reduce(3));
@@ -237,10 +250,10 @@ TEST_F(WitgenTests, CheckedDynamicAPIntToSizeRejectsOverflow) {
   EXPECT_NE(llvm::toString(checked.takeError()).find("overflow"), std::string::npos);
 }
 
-TEST_F(WitgenTests, NestedAggregateFailModeMaterializesMonostate) {
-  auto feltType = felt::FeltType::get(&ctx, StringAttr::get(&ctx, "babybear"));
+TEST_P(WitgenFieldTests, NestedAggregateFailModeMaterializesMonostate) {
+  auto feltType = felt::FeltType::get(&ctx, StringAttr::get(&ctx, GetParam()));
   auto arrayType = array::ArrayType::get(feltType, {2});
-  auto field = Field::tryGetField("babybear");
+  auto field = Field::tryGetField(GetParam());
   ASSERT_TRUE(succeeded(field));
 
   SymbolTableCollection tables;
@@ -255,8 +268,9 @@ TEST_F(WitgenTests, NestedAggregateFailModeMaterializesMonostate) {
   EXPECT_TRUE(std::holds_alternative<std::monostate>(arrayValue->elements[1]));
 }
 
-TEST_F(WitgenTests, SerializeStructOnlyEmitsPublicMembers) {
-  constexpr llvm::StringLiteral source = R"llzk(
+TEST_P(WitgenFieldTests, SerializeStructOnlyEmitsPublicMembers) {
+  std::string source = substituteFieldName(
+      R"llzk(
     module attributes {llzk.lang, llzk.main = !struct.type<@Main>} {
       struct.def @Main {
         struct.member @out : !felt.type<"babybear"> {llzk.pub}
@@ -270,7 +284,9 @@ TEST_F(WitgenTests, SerializeStructOnlyEmitsPublicMembers) {
         }
       }
     }
-  )llzk";
+  )llzk",
+      GetParam()
+  );
 
   auto module = parseSourceString<ModuleOp>(source, ParserConfig(&ctx));
   ASSERT_TRUE(static_cast<bool>(module));
@@ -282,8 +298,8 @@ TEST_F(WitgenTests, SerializeStructOnlyEmitsPublicMembers) {
 
   auto structValue = std::make_shared<witgen::StructValue>();
   structValue->type = *mainType;
-  structValue->members["out"] = Field::getField("babybear").reduce(7);
-  structValue->members["tmp"] = Field::getField("babybear").reduce(9);
+  structValue->members["out"] = Field::getField(GetParam()).reduce(7);
+  structValue->members["tmp"] = Field::getField(GetParam()).reduce(9);
 
   auto json = witgen::serializeJSONValue(structValue, *mainType, tables, module->getOperation());
   ASSERT_TRUE(static_cast<bool>(json)) << llvm::toString(json.takeError());
@@ -294,7 +310,7 @@ TEST_F(WitgenTests, SerializeStructOnlyEmitsPublicMembers) {
   EXPECT_EQ(obj->get("tmp"), nullptr);
 }
 
-TEST_F(WitgenTests, InterpreterHandlesNegativeUnsignedDivUIOperands) {
+TEST_P(WitgenFieldTests, InterpreterHandlesNegativeUnsignedDivUIOperands) {
   constexpr llvm::StringLiteral source = R"mlir(
     module attributes {llzk.lang} {
       function.def @u_div(%lhs: index, %rhs: index) -> index {
@@ -312,7 +328,7 @@ TEST_F(WitgenTests, InterpreterHandlesNegativeUnsignedDivUIOperands) {
 
   SymbolTableCollection tables;
   witgen::FunctionInterpreter interpreter(
-      *module, tables, Field::getField("babybear"), witgen::UninitializedBehavior::Zero,
+      *module, tables, Field::getField(GetParam()), witgen::UninitializedBehavior::Zero,
       std::mt19937_64(0)
   );
   llvm::SmallVector<witgen::WitnessVal> args = {int64_t(-1), int64_t(2)};
@@ -324,7 +340,7 @@ TEST_F(WitgenTests, InterpreterHandlesNegativeUnsignedDivUIOperands) {
   EXPECT_EQ(*quotient, std::numeric_limits<int64_t>::max());
 }
 
-TEST_F(WitgenTests, InterpreterHandlesNegativeUnsignedForBounds) {
+TEST_P(WitgenFieldTests, InterpreterHandlesNegativeUnsignedForBounds) {
   constexpr llvm::StringLiteral source = R"mlir(
     module attributes {llzk.lang} {
       function.def @count_unsigned(%lb: index, %ub: index, %step: index) -> index {
@@ -352,7 +368,7 @@ TEST_F(WitgenTests, InterpreterHandlesNegativeUnsignedForBounds) {
 
   SymbolTableCollection tables;
   witgen::FunctionInterpreter interpreter(
-      *module, tables, Field::getField("babybear"), witgen::UninitializedBehavior::Zero,
+      *module, tables, Field::getField(GetParam()), witgen::UninitializedBehavior::Zero,
       std::mt19937_64(0)
   );
   llvm::SmallVector<witgen::WitnessVal> args = {int64_t(-1), int64_t(1), int64_t(2)};
@@ -364,7 +380,7 @@ TEST_F(WitgenTests, InterpreterHandlesNegativeUnsignedForBounds) {
   EXPECT_EQ(*count, 0);
 }
 
-TEST_F(WitgenTests, InterpreterHandlesIfWithoutElseWhenFalse) {
+TEST_P(WitgenFieldTests, InterpreterHandlesIfWithoutElseWhenFalse) {
   constexpr llvm::StringLiteral source = R"mlir(
     module attributes {llzk.lang} {
       function.def @if_without_else(%cond: i1) -> index {
@@ -386,7 +402,7 @@ TEST_F(WitgenTests, InterpreterHandlesIfWithoutElseWhenFalse) {
 
   SymbolTableCollection tables;
   witgen::FunctionInterpreter interpreter(
-      *module, tables, Field::getField("babybear"), witgen::UninitializedBehavior::Zero,
+      *module, tables, Field::getField(GetParam()), witgen::UninitializedBehavior::Zero,
       std::mt19937_64(0)
   );
   llvm::SmallVector<witgen::WitnessVal> args = {false};
@@ -398,7 +414,7 @@ TEST_F(WitgenTests, InterpreterHandlesIfWithoutElseWhenFalse) {
   EXPECT_EQ(*value, 1);
 }
 
-TEST_F(WitgenTests, InterpreterHandlesIfWithoutElseWhenTrue) {
+TEST_P(WitgenFieldTests, InterpreterHandlesIfWithoutElseWhenTrue) {
   constexpr llvm::StringLiteral source = R"mlir(
     module attributes {llzk.lang} {
       function.def @if_without_else(%cond: i1) -> index {
@@ -420,7 +436,7 @@ TEST_F(WitgenTests, InterpreterHandlesIfWithoutElseWhenTrue) {
 
   SymbolTableCollection tables;
   witgen::FunctionInterpreter interpreter(
-      *module, tables, Field::getField("babybear"), witgen::UninitializedBehavior::Zero,
+      *module, tables, Field::getField(GetParam()), witgen::UninitializedBehavior::Zero,
       std::mt19937_64(0)
   );
   llvm::SmallVector<witgen::WitnessVal> args = {true};
@@ -463,8 +479,9 @@ TEST_F(WitgenTests, InterpreterRejectsUnsignedToSignedIndexUnderflow) {
   EXPECT_NE(llvm::toString(std::move(error)).find("fit in index"), std::string::npos);
 }
 
-TEST_F(WitgenTests, InterpreterFailsDuringFinalWitnessSerialization) {
-  constexpr llvm::StringLiteral source = R"mlir(
+TEST_P(WitgenFieldTests, InterpreterFailsDuringFinalWitnessSerialization) {
+  std::string source = substituteFieldName(
+      R"mlir(
     module attributes {llzk.lang, llzk.main = !struct.type<@Main>} {
       struct.def @Main {
         struct.member @out : !felt.type<"babybear"> {llzk.pub}
@@ -479,14 +496,16 @@ TEST_F(WitgenTests, InterpreterFailsDuringFinalWitnessSerialization) {
         }
       }
     }
-  )mlir";
+  )mlir",
+      GetParam()
+  );
 
   auto module = parseSourceString<ModuleOp>(source, ParserConfig(&ctx));
   ASSERT_TRUE(static_cast<bool>(module));
 
   SymbolTableCollection tables;
   witgen::Interpreter interpreter(
-      *module, tables, Field::getField("babybear"), witgen::UninitializedBehavior::Fail,
+      *module, tables, Field::getField(GetParam()), witgen::UninitializedBehavior::Fail,
       std::mt19937_64(0)
   );
   interpreter.setOutputScope(witgen::OutputScope::Public);
@@ -494,3 +513,9 @@ TEST_F(WitgenTests, InterpreterFailsDuringFinalWitnessSerialization) {
   ASSERT_FALSE(static_cast<bool>(result));
   EXPECT_NE(llvm::toString(result.takeError()).find("uninitialized felt value"), std::string::npos);
 }
+
+INSTANTIATE_TEST_SUITE_P(
+    AllFields, WitgenFieldTests,
+    // Test small, medium, and large prime fields to cover different code paths.
+    ::testing::Values("babybear", "goldilocks", "bn254")
+);


### PR DESCRIPTION
`toAPSInt(field.prime()).getZExtValue()` would assert for prime >64 bits