### PR TITLE
Fix clang-tidy warnings and capture some more overflow cases

### DIFF
--- a/backends/r1cs/lib/r1cs/Dialect/Dialect.cpp
+++ b/backends/r1cs/lib/r1cs/Dialect/Dialect.cpp
@@ -30,11 +30,15 @@ void r1cs::R1CSDialect::initialize() {
     #include "r1cs/Dialect/IR/Ops.cpp.inc"
   >();
 
+  // Suppress false positive from `clang-tidy`
+  // NOLINTNEXTLINE(clang-analyzer-core.StackAddressEscape)
   addTypes<
     #define GET_TYPEDEF_LIST
     #include "r1cs/Dialect/IR/Types.cpp.inc"
   >();
 
+  // Suppress false positive from `clang-tidy`
+  // NOLINTNEXTLINE(clang-analyzer-core.StackAddressEscape)
   addAttributes<
     #define GET_ATTRDEF_LIST
     #include "r1cs/Dialect/IR/Attrs.cpp.inc"

--- a/backends/zklean/lib/Dialect/ZKBuilder/IR/ZKBuilderDialect.cpp
+++ b/backends/zklean/lib/Dialect/ZKBuilder/IR/ZKBuilderDialect.cpp
@@ -27,14 +27,18 @@
 namespace llzk::zkbuilder {
 
 void ZKBuilderDialect::initialize() {
+  // clang-format off
+  // Suppress false positive from `clang-tidy`
+  // NOLINTNEXTLINE(clang-analyzer-core.StackAddressEscape)
   addTypes<
-#define GET_TYPEDEF_LIST
-#include "zklean/Dialect/ZKBuilder/IR/ZKBuilderTypes.cpp.inc"
-      >();
+    #define GET_TYPEDEF_LIST
+    #include "zklean/Dialect/ZKBuilder/IR/ZKBuilderTypes.cpp.inc"
+  >();
   addOperations<
-#define GET_OP_LIST
-#include "zklean/Dialect/ZKBuilder/IR/ZKBuilderOps.cpp.inc"
-      >();
+    #define GET_OP_LIST
+    #include "zklean/Dialect/ZKBuilder/IR/ZKBuilderOps.cpp.inc"
+  >();
+  // clang-format on
 }
 
 } // namespace llzk::zkbuilder

--- a/backends/zklean/lib/Dialect/ZKExpr/IR/ZKExprDialect.cpp
+++ b/backends/zklean/lib/Dialect/ZKExpr/IR/ZKExprDialect.cpp
@@ -24,12 +24,16 @@
 #include "zklean/Dialect/ZKExpr/IR/ZKExprOps.cpp.inc"
 
 auto llzk::zkexpr::ZKExprDialect::initialize() -> void {
+  // clang-format off
+  // Suppress false positive from `clang-tidy`
+  // NOLINTNEXTLINE(clang-analyzer-core.StackAddressEscape)
   addTypes<
-#define GET_TYPEDEF_LIST
-#include "zklean/Dialect/ZKExpr/IR/ZKExprTypes.cpp.inc"
-      >();
+    #define GET_TYPEDEF_LIST
+    #include "zklean/Dialect/ZKExpr/IR/ZKExprTypes.cpp.inc"
+  >();
   addOperations<
-#define GET_OP_LIST
-#include "zklean/Dialect/ZKExpr/IR/ZKExprOps.cpp.inc"
-      >();
+    #define GET_OP_LIST
+    #include "zklean/Dialect/ZKExpr/IR/ZKExprOps.cpp.inc"
+  >();
+  // clang-format on
 }

--- a/backends/zklean/lib/Dialect/ZKLeanLean/IR/ZKLeanLeanDialect.cpp
+++ b/backends/zklean/lib/Dialect/ZKLeanLean/IR/ZKLeanLeanDialect.cpp
@@ -42,12 +42,16 @@ auto llzk::zkleanlean::StructDefOp::verifyRegions() -> mlir::LogicalResult {
 }
 
 auto llzk::zkleanlean::ZKLeanLeanDialect::initialize() -> void {
+  // clang-format off
+  // Suppress false positive from `clang-tidy`
+  // NOLINTNEXTLINE(clang-analyzer-core.StackAddressEscape)
   addTypes<
-#define GET_TYPEDEF_LIST
-#include "zklean/Dialect/ZKLeanLean/IR/ZKLeanLeanTypes.cpp.inc"
-      >();
+    #define GET_TYPEDEF_LIST
+    #include "zklean/Dialect/ZKLeanLean/IR/ZKLeanLeanTypes.cpp.inc"
+  >();
   addOperations<
-#define GET_OP_LIST
-#include "zklean/Dialect/ZKLeanLean/IR/ZKLeanLeanOps.cpp.inc"
-      >();
+    #define GET_OP_LIST
+    #include "zklean/Dialect/ZKLeanLean/IR/ZKLeanLeanOps.cpp.inc"
+  >();
+  // clang-format on
 }

--- a/lib/Analysis/IntervalAnalysis.cpp
+++ b/lib/Analysis/IntervalAnalysis.cpp
@@ -1704,7 +1704,7 @@ void StructIntervals::print(
       os << '\n';
       os.indent(indent) << ref << " in " << interval;
       if (printUnreduced) {
-        if (auto it = memberUnreducedRanges.find(ref); it != memberUnreducedRanges.end()) {
+        if (const auto *it = memberUnreducedRanges.find(ref); it != memberUnreducedRanges.end()) {
           os << " ( " << it->second << " )";
         }
       }

--- a/lib/Dialect/Bool/IR/Dialect.cpp
+++ b/lib/Dialect/Bool/IR/Dialect.cpp
@@ -51,6 +51,8 @@ auto llzk::boolean::BoolDialect::initialize() -> void {
     #include "llzk/Dialect/Bool/IR/Ops.cpp.inc"
   >();
 
+  // Suppress false positive from `clang-tidy`
+  // NOLINTNEXTLINE(clang-analyzer-core.StackAddressEscape)
   addAttributes<
     #define GET_ATTRDEF_LIST
     #include "llzk/Dialect/Bool/IR/Attrs.cpp.inc"

--- a/lib/Dialect/Function/IR/Dialect.cpp
+++ b/lib/Dialect/Function/IR/Dialect.cpp
@@ -35,6 +35,8 @@ auto llzk::function::FunctionDialect::initialize() -> void {
     #include "llzk/Dialect/Function/IR/Ops.cpp.inc"
   >();
 
+  // Suppress false positive from `clang-tidy`
+  // NOLINTNEXTLINE(clang-analyzer-core.StackAddressEscape)
   addAttributes<
     #define GET_ATTRDEF_LIST
     #include "llzk/Dialect/Function/IR/Attrs.cpp.inc"

--- a/lib/Dialect/LLZK/IR/Dialect.cpp
+++ b/lib/Dialect/LLZK/IR/Dialect.cpp
@@ -70,6 +70,8 @@ LogicalResult LLZKDialect::verifyOperationAttribute(Operation *op, NamedAttribut
 
 auto LLZKDialect::initialize() -> void {
   // clang-format off
+  // Suppress false positive from `clang-tidy`
+  // NOLINTNEXTLINE(clang-analyzer-core.StackAddressEscape)
   addAttributes<
     #define GET_ATTRDEF_LIST
     #include "llzk/Dialect/LLZK/IR/Attrs.cpp.inc"

--- a/lib/Dialect/String/IR/Dialect.cpp
+++ b/lib/Dialect/String/IR/Dialect.cpp
@@ -34,6 +34,8 @@ auto llzk::string::StringDialect::initialize() -> void {
     #include "llzk/Dialect/String/IR/Ops.cpp.inc"
   >();
 
+  // Suppress false positive from `clang-tidy`
+  // NOLINTNEXTLINE(clang-analyzer-core.StackAddressEscape)
   addTypes<
     #define GET_TYPEDEF_LIST
     #include "llzk/Dialect/String/IR/Types.cpp.inc"

--- a/lib/Dialect/Struct/IR/Dialect.cpp
+++ b/lib/Dialect/Struct/IR/Dialect.cpp
@@ -236,6 +236,8 @@ auto llzk::component::StructDialect::initialize() -> void {
     #include "llzk/Dialect/Struct/IR/Ops.cpp.inc"
   >();
 
+  // Suppress false positive from `clang-tidy`
+  // NOLINTNEXTLINE(clang-analyzer-core.StackAddressEscape)
   addTypes<
     #define GET_TYPEDEF_LIST
     #include "llzk/Dialect/Struct/IR/Types.cpp.inc"

--- a/tools/llzk-witgen/ExecutionEngineBackend.cpp
+++ b/tools/llzk-witgen/ExecutionEngineBackend.cpp
@@ -48,6 +48,7 @@
 #include <llvm/Support/raw_ostream.h>
 
 #include <cstdint>
+#include <limits>
 
 using namespace mlir;
 
@@ -171,20 +172,36 @@ static llvm::Expected<BufferPack> createBufferPack(Type type, const Field &field
 }
 
 /// Store one field element into the buffer at the given flat element index.
-static void storeElement(BufferPack &buffer, size_t flatIndex, const llvm::DynamicAPInt &value) {
+static llvm::Error
+storeElement(BufferPack &buffer, size_t flatIndex, const llvm::DynamicAPInt &value) {
+  bool overflow = false;
+  size_t byteOffset = llvm::SaturatingMultiply(flatIndex, buffer.elemBytes, &overflow);
+  if (overflow) {
+    return makeError("execution-engine buffer store offset would overflow size_t");
+  }
+  if (buffer.elemBytes > std::numeric_limits<unsigned>::max()) {
+    return makeError("execution-engine buffer element size would overflow unsigned");
+  }
   llvm::APInt raw = toAPInt(value, buffer.feltBitWidth);
   llvm::StoreIntToMemory(
-      raw, buffer.storage.data() + flatIndex * buffer.elemBytes,
-      llzk::checkedCast<unsigned>(buffer.elemBytes)
+      raw, buffer.storage.data() + byteOffset, static_cast<unsigned>(buffer.elemBytes)
   );
+  return llvm::Error::success();
 }
 
 /// Load one field element from the buffer at the given flat element index.
-static llvm::DynamicAPInt loadElement(const BufferPack &buffer, size_t flatIndex) {
+static llvm::Expected<llvm::DynamicAPInt> loadElement(const BufferPack &buffer, size_t flatIndex) {
+  bool overflow = false;
+  size_t byteOffset = llvm::SaturatingMultiply(flatIndex, buffer.elemBytes, &overflow);
+  if (overflow) {
+    return makeError("execution-engine buffer load offset would overflow size_t");
+  }
+  if (buffer.elemBytes > std::numeric_limits<unsigned>::max()) {
+    return makeError("execution-engine buffer element size would overflow unsigned");
+  }
   llvm::APInt raw(buffer.feltBitWidth, 0);
   llvm::LoadIntFromMemory(
-      raw, buffer.storage.data() + flatIndex * buffer.elemBytes,
-      llzk::checkedCast<unsigned>(buffer.elemBytes)
+      raw, buffer.storage.data() + byteOffset, static_cast<unsigned>(buffer.elemBytes)
   );
   return toDynamicAPInt(raw);
 }
@@ -196,8 +213,7 @@ static llvm::Error fillInputBuffer(BufferPack &buffer, const WitnessVal &value) 
     if (!feltValue) {
       return feltValue.takeError();
     }
-    storeElement(buffer, 0, *feltValue);
-    return llvm::Error::success();
+    return storeElement(buffer, 0, *feltValue);
   }
 
   auto arrayValue = asArray(value);
@@ -216,17 +232,23 @@ static llvm::Error fillInputBuffer(BufferPack &buffer, const WitnessVal &value) 
     if (!feltValue) {
       return feltValue.takeError();
     }
-    storeElement(buffer, i, *feltValue);
+    if (auto err = storeElement(buffer, i, *feltValue)) {
+      return err;
+    }
   }
   return llvm::Error::success();
 }
 
 /// Render one field element buffer entry as the stable JSON decimal string form.
-static llvm::json::Value feltElementToJSON(const BufferPack &buffer, size_t flatIndex) {
+static llvm::Expected<llvm::json::Value>
+feltElementToJSON(const BufferPack &buffer, size_t flatIndex) {
+  auto element = loadElement(buffer, flatIndex);
+  if (!element) {
+    return element.takeError();
+  }
   std::string rendered;
-  llvm::raw_string_ostream os(rendered);
-  os << loadElement(buffer, flatIndex);
-  return llvm::json::Value(os.str());
+  llvm::raw_string_ostream(rendered) << *element;
+  return llvm::json::Value(rendered);
 }
 
 /// Recursively serialize a felt buffer into nested JSON arrays.
@@ -247,7 +269,11 @@ bufferToJSONArray(const BufferPack &buffer, size_t dimIndex, size_t flatOffset) 
       if (overflow) {
         return makeError("execution-engine JSON output would overflow size_t");
       }
-      result.push_back(feltElementToJSON(buffer, elementOffset));
+      auto element = feltElementToJSON(buffer, elementOffset);
+      if (!element) {
+        return element.takeError();
+      }
+      result.push_back(*element);
     }
     return llvm::json::Value(std::move(result));
   }

--- a/tools/llzk-witgen/ExecutionEngineBackend.cpp
+++ b/tools/llzk-witgen/ExecutionEngineBackend.cpp
@@ -48,7 +48,6 @@
 #include <llvm/Support/raw_ostream.h>
 
 #include <cstdint>
-#include <limits>
 
 using namespace mlir;
 
@@ -108,9 +107,12 @@ static llvm::Expected<std::vector<int64_t>> computeStaticStrides(ArrayRef<int64_
 
 /// Populate the raw memref descriptor for a host buffer.
 static llvm::Error buildDescriptor(BufferPack &buffer) {
-  const int64_t rank = llzk::checkedCast<int64_t>(buffer.shape.size());
+  auto rank = checkedCast<int64_t>(buffer.shape.size());
+  if (!rank) {
+    return rank.takeError();
+  }
   auto descriptorSize = llvm::DynamicAPInt(sizeof(void *)) * 2;
-  auto shapeAndStrideCount = llvm::DynamicAPInt(1) + rank + rank;
+  auto shapeAndStrideCount = llvm::DynamicAPInt(1) + *rank + *rank;
   auto dynamicPart = llvm::DynamicAPInt(sizeof(int64_t)) * shapeAndStrideCount;
   auto totalSize = descriptorSize + dynamicPart;
   auto checkedTotalSize =
@@ -179,13 +181,12 @@ storeElement(BufferPack &buffer, size_t flatIndex, const llvm::DynamicAPInt &val
   if (overflow) {
     return makeError("execution-engine buffer store offset would overflow size_t");
   }
-  if (buffer.elemBytes > std::numeric_limits<unsigned>::max()) {
-    return makeError("execution-engine buffer element size would overflow unsigned");
+  auto elemBytesU = checkedCast<unsigned>(buffer.elemBytes);
+  if (!elemBytesU) {
+    return elemBytesU.takeError();
   }
   llvm::APInt raw = toAPInt(value, buffer.feltBitWidth);
-  llvm::StoreIntToMemory(
-      raw, buffer.storage.data() + byteOffset, static_cast<unsigned>(buffer.elemBytes)
-  );
+  llvm::StoreIntToMemory(raw, buffer.storage.data() + byteOffset, *elemBytesU);
   return llvm::Error::success();
 }
 
@@ -196,13 +197,12 @@ static llvm::Expected<llvm::DynamicAPInt> loadElement(const BufferPack &buffer, 
   if (overflow) {
     return makeError("execution-engine buffer load offset would overflow size_t");
   }
-  if (buffer.elemBytes > std::numeric_limits<unsigned>::max()) {
-    return makeError("execution-engine buffer element size would overflow unsigned");
+  auto elemBytesU = checkedCast<unsigned>(buffer.elemBytes);
+  if (!elemBytesU) {
+    return elemBytesU.takeError();
   }
   llvm::APInt raw(buffer.feltBitWidth, 0);
-  llvm::LoadIntFromMemory(
-      raw, buffer.storage.data() + byteOffset, static_cast<unsigned>(buffer.elemBytes)
-  );
+  llvm::LoadIntFromMemory(raw, buffer.storage.data() + byteOffset, *elemBytesU);
   return toDynamicAPInt(raw);
 }
 

--- a/tools/llzk-witgen/ExecutionEngineBackend.cpp
+++ b/tools/llzk-witgen/ExecutionEngineBackend.cpp
@@ -119,10 +119,10 @@ static llvm::Error buildDescriptor(BufferPack &buffer) {
   }
   buffer.descriptor.resize(*checkedTotalSize);
   uint8_t *cursor = buffer.descriptor.data();
-  void *base = buffer.storage.data();
-  std::memcpy(cursor, &base, sizeof(void *));
+  uint8_t *base = buffer.storage.data();
+  std::memcpy(cursor, static_cast<const void *>(&base), sizeof(void *));
   cursor += sizeof(void *);
-  std::memcpy(cursor, &base, sizeof(void *));
+  std::memcpy(cursor, static_cast<const void *>(&base), sizeof(void *));
   cursor += sizeof(void *);
   const int64_t offset = 0;
   std::memcpy(cursor, &offset, sizeof(int64_t));
@@ -350,8 +350,8 @@ llvm::Expected<llvm::json::Value> runWithExecutionEngine(
 
   auto parsedArgs = [&]() -> llvm::Expected<llvm::SmallVector<WitnessVal>> {
     llvm::SmallVector<WitnessVal> args;
-    auto *jsonObject = input.getAsObject();
-    auto *jsonArray = input.getAsArray();
+    const auto *jsonObject = input.getAsObject();
+    const auto *jsonArray = input.getAsArray();
     if (!jsonObject && !jsonArray) {
       return makeError("inputs JSON must be either an object or an array");
     }
@@ -472,7 +472,7 @@ llvm::Expected<llvm::json::Value> runWithExecutionEngine(
   llvm::SmallVector<void *> packedArgs;
   packedArgs.reserve(descriptorPtrs.size());
   for (void *&descriptorPtr : descriptorPtrs) {
-    packedArgs.push_back(&descriptorPtr);
+    packedArgs.push_back(static_cast<void *>(&descriptorPtr));
   }
 
   if (auto err = (*maybeEngine)->invokePacked("_mlir_ciface___llzk_witgen_main", packedArgs)) {

--- a/tools/llzk-witgen/ExecutionEngineBackend.cpp
+++ b/tools/llzk-witgen/ExecutionEngineBackend.cpp
@@ -43,6 +43,7 @@
 
 #include <llvm/ADT/APInt.h>
 #include <llvm/Support/Endian.h>
+#include <llvm/Support/MathExtras.h>
 #include <llvm/Support/TargetSelect.h>
 #include <llvm/Support/raw_ostream.h>
 
@@ -106,7 +107,7 @@ static llvm::Expected<std::vector<int64_t>> computeStaticStrides(ArrayRef<int64_
 
 /// Populate the raw memref descriptor for a host buffer.
 static llvm::Error buildDescriptor(BufferPack &buffer) {
-  const size_t rank = buffer.shape.size();
+  const int64_t rank = llzk::checkedCast<int64_t>(buffer.shape.size());
   auto descriptorSize = llvm::DynamicAPInt(sizeof(void *)) * 2;
   auto shapeAndStrideCount = llvm::DynamicAPInt(1) + rank + rank;
   auto dynamicPart = llvm::DynamicAPInt(sizeof(int64_t)) * shapeAndStrideCount;
@@ -157,13 +158,12 @@ static llvm::Expected<BufferPack> createBufferPack(Type type, const Field &field
   if (!elementCount) {
     return elementCount.takeError();
   }
-  auto storageBytes = llvm::DynamicAPInt(*elementCount) * buffer.elemBytes;
-  auto checkedStorageBytes =
-      checkedDynamicAPIntToSize(storageBytes, "execution-engine buffer storage");
-  if (!checkedStorageBytes) {
-    return checkedStorageBytes.takeError();
+  bool overflow = false;
+  size_t storageBytes = llvm::SaturatingMultiply(*elementCount, buffer.elemBytes, &overflow);
+  if (overflow) {
+    return makeError("execution-engine buffer storage would overflow size_t");
   }
-  buffer.storage.resize(*checkedStorageBytes);
+  buffer.storage.resize(storageBytes);
   if (auto error = buildDescriptor(buffer)) {
     return std::move(error);
   }
@@ -231,7 +231,10 @@ static llvm::json::Value feltElementToJSON(const BufferPack &buffer, size_t flat
 
 /// Recursively serialize a felt buffer into nested JSON arrays.
 static llvm::Expected<llvm::json::Value>
-bufferToJSONArray(const BufferPack &buffer, size_t dimIndex, const llvm::DynamicAPInt &flatOffset) {
+bufferToJSONArray(const BufferPack &buffer, size_t dimIndex, size_t flatOffset) {
+  if (dimIndex == SIZE_MAX) {
+    return makeError("execution-engine JSON output would overflow size_t");
+  }
   auto dimSize = checkedShapeDimToSize(buffer.shape[dimIndex], "execution-engine JSON output");
   if (!dimSize) {
     return dimSize.takeError();
@@ -239,13 +242,12 @@ bufferToJSONArray(const BufferPack &buffer, size_t dimIndex, const llvm::Dynamic
   if (dimIndex + 1 == buffer.shape.size()) {
     llvm::json::Array result;
     for (size_t i = 0; i < *dimSize; ++i) {
-      llvm::DynamicAPInt elementOffset = flatOffset + i;
-      auto checkedElementOffset =
-          checkedDynamicAPIntToSize(elementOffset, "execution-engine JSON output");
-      if (!checkedElementOffset) {
-        return checkedElementOffset.takeError();
+      bool overflow = false;
+      size_t elementOffset = llvm::SaturatingAdd(i, flatOffset, &overflow);
+      if (overflow) {
+        return makeError("execution-engine JSON output would overflow size_t");
       }
-      result.push_back(feltElementToJSON(buffer, *checkedElementOffset));
+      result.push_back(feltElementToJSON(buffer, elementOffset));
     }
     return llvm::json::Value(std::move(result));
   }
@@ -259,7 +261,11 @@ bufferToJSONArray(const BufferPack &buffer, size_t dimIndex, const llvm::Dynamic
 
   llvm::json::Array result;
   for (size_t i = 0; i < *dimSize; ++i) {
-    llvm::DynamicAPInt nextOffset = flatOffset + (llvm::DynamicAPInt(i) * *subArraySize);
+    bool overflow = false;
+    size_t nextOffset = llvm::SaturatingMultiplyAdd(i, *subArraySize, flatOffset, &overflow);
+    if (overflow) {
+      return makeError("execution-engine JSON output would overflow size_t");
+    }
     auto subArray = bufferToJSONArray(buffer, dimIndex + 1, nextOffset);
     if (!subArray) {
       return subArray.takeError();
@@ -274,7 +280,7 @@ static llvm::Expected<llvm::json::Value> bufferToJSON(const BufferPack &buffer) 
   if (isa<felt::FeltType>(buffer.originalType)) {
     return feltElementToJSON(buffer, 0);
   }
-  return bufferToJSONArray(buffer, 0, llvm::DynamicAPInt(0));
+  return bufferToJSONArray(buffer, 0, 0);
 }
 
 /// Lower the module through the shared LLZK-to-core witgen passes.

--- a/tools/llzk-witgen/Interpreter.cpp
+++ b/tools/llzk-witgen/Interpreter.cpp
@@ -86,7 +86,7 @@ FunctionInterpreter::FunctionInterpreter(
     UninitializedBehavior behavior, std::mt19937_64 r
 )
     : moduleOp(module), tables(symbolTables), field(moduleField), uninitializedBehavior(behavior),
-      rng(std::move(r)) {}
+      rng(r) {}
 
 namespace {
 

--- a/tools/llzk-witgen/Interpreter.cpp
+++ b/tools/llzk-witgen/Interpreter.cpp
@@ -48,14 +48,6 @@ static bool usesUnsignedCmp(scf::ForOp forOp) {
   return forOp->hasAttr("unsignedCmp");
 }
 
-/// Convert an unsigned intermediate back to `int64_t`, rejecting underflow.
-static llvm::Expected<int64_t> toCheckedInt64(uint64_t value) {
-  if (value > static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
-    return makeError("value of uint64_t does not fit in signed int64_t");
-  }
-  return static_cast<int64_t>(value);
-}
-
 /// Represent the values yielded by a block or region along with termination state.
 struct BlockResult {
   bool terminated = false;
@@ -828,50 +820,36 @@ private:
     }
     if (auto divUIOp = dyn_cast<arith::DivUIOp>(op)) {
       return handleBinaryIndex(divUIOp, [](int64_t lhs, int64_t rhs) {
+        // Unsigned division directly interprets int64 as unsigned value.
         auto divRes = static_cast<uint64_t>(lhs) / static_cast<uint64_t>(rhs);
         return static_cast<int64_t>(divRes);
       });
     }
     if (auto cmpIOp = dyn_cast<arith::CmpIOp>(op)) {
       return handleBinaryIndex(cmpIOp, [&cmpIOp](int64_t lhs, int64_t rhs) -> bool {
-        bool result = false;
         switch (cmpIOp.getPredicate()) {
         case arith::CmpIPredicate::eq:
-          result = lhs == rhs;
-          break;
+          return lhs == rhs;
         case arith::CmpIPredicate::ne:
-          result = lhs != rhs;
-          break;
+          return lhs != rhs;
         case arith::CmpIPredicate::slt:
-          result = lhs < rhs;
-          break;
+          return lhs < rhs;
         case arith::CmpIPredicate::sle:
-          result = lhs <= rhs;
-          break;
+          return lhs <= rhs;
         case arith::CmpIPredicate::sgt:
-          result = lhs > rhs;
-          break;
+          return lhs > rhs;
         case arith::CmpIPredicate::sge:
-          result = lhs >= rhs;
-          break;
-        case arith::CmpIPredicate::ult: {
-          result = static_cast<uint64_t>(lhs) < static_cast<uint64_t>(rhs);
-          break;
+          return lhs >= rhs;
+        // Unsigned comparisons directly interprets int64 as unsigned value.
+        case arith::CmpIPredicate::ult:
+          return static_cast<uint64_t>(lhs) < static_cast<uint64_t>(rhs);
+        case arith::CmpIPredicate::ule:
+          return static_cast<uint64_t>(lhs) <= static_cast<uint64_t>(rhs);
+        case arith::CmpIPredicate::ugt:
+          return static_cast<uint64_t>(lhs) > static_cast<uint64_t>(rhs);
+        case arith::CmpIPredicate::uge:
+          return static_cast<uint64_t>(lhs) >= static_cast<uint64_t>(rhs);
         }
-        case arith::CmpIPredicate::ule: {
-          result = static_cast<uint64_t>(lhs) <= static_cast<uint64_t>(rhs);
-          break;
-        }
-        case arith::CmpIPredicate::ugt: {
-          result = static_cast<uint64_t>(lhs) > static_cast<uint64_t>(rhs);
-          break;
-        }
-        case arith::CmpIPredicate::uge: {
-          result = static_cast<uint64_t>(lhs) >= static_cast<uint64_t>(rhs);
-          break;
-        }
-        }
-        return result;
       });
     }
 
@@ -929,14 +907,14 @@ private:
         return stepValue.takeError();
       }
       auto lowerBound = asIndex(*lowerBoundValue);
-      auto upperBound = asIndex(*upperBoundValue);
-      auto step = asIndex(*stepValue);
       if (!lowerBound) {
         return lowerBound.takeError();
       }
+      auto upperBound = asIndex(*upperBoundValue);
       if (!upperBound) {
         return upperBound.takeError();
       }
+      auto step = asIndex(*stepValue);
       if (!step) {
         return step.takeError();
       }
@@ -947,12 +925,13 @@ private:
       llvm::SmallVector<WitnessVal> iterValues = std::move(*iterValuesOrErr);
 
       if (usesUnsignedCmp(forOp)) {
+        // Unsigned comparison directly interprets int64 as unsigned value.
         auto lowerBoundUIntValue = static_cast<uint64_t>(*lowerBound);
         auto upperBoundUIntValue = static_cast<uint64_t>(*upperBound);
         auto stepUInt = static_cast<uint64_t>(*step);
         for (uint64_t iv = lowerBoundUIntValue, ub = upperBoundUIntValue, unsignedStep = stepUInt;
              iv < ub; iv += unsignedStep) {
-          auto signedIV = toCheckedInt64(iv);
+          auto signedIV = checkedCast<int64_t>(iv);
           if (!signedIV) {
             return signedIV.takeError();
           }

--- a/tools/llzk-witgen/Interpreter.cpp
+++ b/tools/llzk-witgen/Interpreter.cpp
@@ -50,10 +50,10 @@ static bool usesUnsignedCmp(scf::ForOp forOp) {
 
 /// Convert an unsigned intermediate back to `int64_t`, rejecting underflow.
 static llvm::Expected<int64_t> toCheckedInt64(uint64_t value) {
-  if (value > llzk::checkedCast<uint64_t>(std::numeric_limits<int64_t>::max())) {
-    return makeError("unsigned value does not fit in signed int64_t");
+  if (value > static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
+    return makeError("value of uint64_t does not fit in signed int64_t");
   }
-  return llzk::checkedCast<int64_t>(value);
+  return static_cast<int64_t>(value);
 }
 
 /// Represent the values yielded by a block or region along with termination state.

--- a/tools/llzk-witgen/Interpreter.cpp
+++ b/tools/llzk-witgen/Interpreter.cpp
@@ -30,6 +30,7 @@
 
 #include <llvm/ADT/STLExtras.h>
 #include <llvm/ADT/SmallVector.h>
+#include <llvm/Support/MathExtras.h>
 
 #include <limits>
 #include <random>

--- a/tools/llzk-witgen/Interpreter.cpp
+++ b/tools/llzk-witgen/Interpreter.cpp
@@ -850,6 +850,7 @@ private:
         case arith::CmpIPredicate::uge:
           return static_cast<uint64_t>(lhs) >= static_cast<uint64_t>(rhs);
         }
+        llvm_unreachable("unknown comparison predicate");
       });
     }
 

--- a/tools/llzk-witgen/Interpreter.cpp
+++ b/tools/llzk-witgen/Interpreter.cpp
@@ -689,19 +689,21 @@ private:
       if (!prefixOffset) {
         return prefixOffset.takeError();
       }
+      bool baseOverflow = false;
+      size_t base = llvm::SaturatingMultiply(*prefixOffset, *subArraySize, &baseOverflow);
+      if (baseOverflow) {
+        return makeError("array.extract element offset would overflow size_t");
+      }
       auto subArray = std::make_shared<ArrayValue>();
       subArray->type = extractArrayOp.getType();
       subArray->elements.reserve(*subArraySize);
-      llvm::DynamicAPInt base(*prefixOffset);
-      base *= *subArraySize;
       for (size_t i = 0; i < *subArraySize; ++i) {
-        auto elementOffset = base + i;
-        auto checkedElementOffset =
-            checkedDynamicAPIntToSize(elementOffset, "array.extract element offset");
-        if (!checkedElementOffset) {
-          return checkedElementOffset.takeError();
+        bool overflow = false;
+        size_t elementOffset = llvm::SaturatingAdd(base, i, &overflow);
+        if (overflow) {
+          return makeError("array.extract element offset would overflow size_t");
         }
-        subArray->elements.push_back((*arrayRef)->elements[*checkedElementOffset]);
+        subArray->elements.push_back((*arrayRef)->elements[elementOffset]);
       }
       return bind({subArray});
     }
@@ -735,26 +737,24 @@ private:
         indices.push_back(*index);
       }
       llvm::ArrayRef<int64_t> shape = (*arrayRef)->type.getShape();
-      llvm::DynamicAPInt subArraySize((*subArrayRef)->elements.size());
+      size_t subArraySize = (*subArrayRef)->elements.size();
       auto prefixOffset =
           checkedLinearize(shape.take_front(indices.size()), indices, "array index out of bounds");
       if (!prefixOffset) {
         return prefixOffset.takeError();
       }
-      llvm::DynamicAPInt base(*prefixOffset);
-      base *= subArraySize;
-      auto checkedSubArraySize = checkedDynamicAPIntToSize(subArraySize, "array.insert shape");
-      if (!checkedSubArraySize) {
-        return checkedSubArraySize.takeError();
+      bool baseOverflow = false;
+      size_t base = llvm::SaturatingMultiply(*prefixOffset, subArraySize, &baseOverflow);
+      if (baseOverflow) {
+        return makeError("array.insert element offset would overflow size_t");
       }
-      for (size_t i = 0; i < *checkedSubArraySize; ++i) {
-        llvm::DynamicAPInt elementOffset = base + i;
-        auto checkedElementOffset =
-            checkedDynamicAPIntToSize(elementOffset, "array.insert element offset");
-        if (!checkedElementOffset) {
-          return checkedElementOffset.takeError();
+      for (size_t i = 0; i < subArraySize; ++i) {
+        bool overflow = false;
+        size_t elementOffset = llvm::SaturatingAdd(base, i, &overflow);
+        if (overflow) {
+          return makeError("array.insert element offset would overflow size_t");
         }
-        (*arrayRef)->elements[*checkedElementOffset] = (*subArrayRef)->elements[i];
+        (*arrayRef)->elements[elementOffset] = (*subArrayRef)->elements[i];
       }
       return BlockResult {};
     }

--- a/tools/llzk-witgen/Interpreter.cpp
+++ b/tools/llzk-witgen/Interpreter.cpp
@@ -75,7 +75,7 @@ llvm::Expected<size_t> checkedLinearize(
     }
   }
   auto strides = mlir::computeStrides(shape);
-  return llzk::checkedCast<size_t>(mlir::linearize(indices, strides));
+  return checkedCast<size_t>(mlir::linearize(indices, strides));
 }
 
 } // namespace

--- a/tools/llzk-witgen/JSON.cpp
+++ b/tools/llzk-witgen/JSON.cpp
@@ -20,6 +20,7 @@
 #include <mlir/IR/Operation.h>
 
 #include <llvm/ADT/TypeSwitch.h>
+#include <llvm/Support/MathExtras.h>
 #include <llvm/Support/raw_ostream.h>
 
 using namespace mlir;

--- a/tools/llzk-witgen/JSON.cpp
+++ b/tools/llzk-witgen/JSON.cpp
@@ -116,8 +116,7 @@ static llvm::Expected<llvm::json::Value> feltToJSON(const llvm::DynamicAPInt &va
 /// Serialize a flattened LLZK array into nested JSON arrays.
 static llvm::Expected<llvm::json::Value> serializeJSONArray(
     const ArrayValueRef &arrayValue, array::ArrayType type, SymbolTableCollection &tables,
-    Operation *origin, SerializationMode mode, size_t dimIndex = 0,
-    const llvm::DynamicAPInt &flatOffset = llvm::DynamicAPInt(0)
+    Operation *origin, SerializationMode mode, size_t dimIndex = 0, size_t flatOffset = 0
 ) {
   llvm::json::Array jsonArray;
   llvm::ArrayRef<int64_t> shape = type.getShape();
@@ -127,14 +126,13 @@ static llvm::Expected<llvm::json::Value> serializeJSONArray(
   }
   if (dimIndex == shape.size() - 1) {
     for (size_t i = 0; i < *dimSize; ++i) {
-      llvm::DynamicAPInt elementOffset = flatOffset + i;
-      auto checkedElementOffset =
-          checkedDynamicAPIntToSize(elementOffset, "JSON array output flat index");
-      if (!checkedElementOffset) {
-        return checkedElementOffset.takeError();
+      bool overflow = false;
+      size_t elementOffset = llvm::SaturatingAdd(flatOffset, i, &overflow);
+      if (overflow) {
+        return makeError("JSON array output flat index would overflow size_t");
       }
       auto elem = serializeJSONValue(
-          arrayValue->elements[*checkedElementOffset], type.getElementType(), tables, origin, mode
+          arrayValue->elements[elementOffset], type.getElementType(), tables, origin, mode
       );
       if (!elem) {
         return elem.takeError();
@@ -144,17 +142,25 @@ static llvm::Expected<llvm::json::Value> serializeJSONArray(
     return llvm::json::Value(std::move(jsonArray));
   }
 
-  llvm::DynamicAPInt subArraySize(1);
+  size_t subArraySize = 1;
   for (size_t i = dimIndex + 1; i < shape.size(); ++i) {
     auto nextDimSize = checkedShapeDimToSize(shape[i], "JSON array output");
     if (!nextDimSize) {
       return nextDimSize.takeError();
     }
-    subArraySize *= llvm::DynamicAPInt(*nextDimSize);
+    bool overflow = false;
+    subArraySize = llvm::SaturatingMultiply(subArraySize, *nextDimSize, &overflow);
+    if (overflow) {
+      return makeError("JSON array output sub-array size would overflow size_t");
+    }
   }
 
   for (size_t i = 0; i < *dimSize; ++i) {
-    llvm::DynamicAPInt nextOffset = flatOffset + (llvm::DynamicAPInt(i) * subArraySize);
+    bool overflow = false;
+    size_t nextOffset = llvm::SaturatingMultiplyAdd(i, subArraySize, flatOffset, &overflow);
+    if (overflow) {
+      return makeError("JSON array output flat offset would overflow size_t");
+    }
     auto subArray =
         serializeJSONArray(arrayValue, type, tables, origin, mode, dimIndex + 1, nextOffset);
     if (!subArray) {

--- a/tools/llzk-witgen/JSON.cpp
+++ b/tools/llzk-witgen/JSON.cpp
@@ -57,7 +57,7 @@ static llvm::Expected<WitnessVal> parseJSONArray(
     const llvm::json::Value *json, array::ArrayType type, const Field &field, Operation *origin,
     size_t dimIndex = 0
 ) {
-  auto *jsonArray = json->getAsArray();
+  const auto *jsonArray = json->getAsArray();
   if (!jsonArray) {
     return makeError("expected JSON array");
   }

--- a/tools/llzk-witgen/JSON.h
+++ b/tools/llzk-witgen/JSON.h
@@ -18,7 +18,7 @@
 namespace llzk::witgen {
 
 /// Select how struct values are filtered during JSON serialization.
-enum class SerializationMode {
+enum class SerializationMode : std::uint8_t {
   PublicOutputsOnly,
   AllSignals,
 };

--- a/tools/llzk-witgen/ValueModel.cpp
+++ b/tools/llzk-witgen/ValueModel.cpp
@@ -25,7 +25,7 @@ namespace llzk::witgen {
 
 /// Require a boolean value from the runtime variant.
 llvm::Expected<bool> asBool(const WitnessVal &value) {
-  if (auto boolValue = std::get_if<bool>(&value)) {
+  if (const auto *boolValue = std::get_if<bool>(&value)) {
     return *boolValue;
   }
   if (std::holds_alternative<std::monostate>(value)) {
@@ -36,7 +36,7 @@ llvm::Expected<bool> asBool(const WitnessVal &value) {
 
 /// Require an index value from the runtime variant.
 llvm::Expected<int64_t> asIndex(const WitnessVal &value) {
-  if (auto indexValue = std::get_if<int64_t>(&value)) {
+  if (const auto *indexValue = std::get_if<int64_t>(&value)) {
     return *indexValue;
   }
   if (std::holds_alternative<std::monostate>(value)) {
@@ -47,7 +47,7 @@ llvm::Expected<int64_t> asIndex(const WitnessVal &value) {
 
 /// Require a felt value from the runtime variant.
 llvm::Expected<llvm::DynamicAPInt> asFelt(const WitnessVal &value) {
-  if (auto feltValue = std::get_if<llvm::DynamicAPInt>(&value)) {
+  if (const auto *feltValue = std::get_if<llvm::DynamicAPInt>(&value)) {
     return *feltValue;
   }
   if (std::holds_alternative<std::monostate>(value)) {
@@ -58,7 +58,7 @@ llvm::Expected<llvm::DynamicAPInt> asFelt(const WitnessVal &value) {
 
 /// Require an array value from the runtime variant.
 llvm::Expected<ArrayValueRef> asArray(const WitnessVal &value) {
-  if (auto arrayValue = std::get_if<ArrayValueRef>(&value)) {
+  if (const auto *arrayValue = std::get_if<ArrayValueRef>(&value)) {
     return *arrayValue;
   }
   if (std::holds_alternative<std::monostate>(value)) {
@@ -69,7 +69,7 @@ llvm::Expected<ArrayValueRef> asArray(const WitnessVal &value) {
 
 /// Require a POD value from the runtime variant.
 llvm::Expected<PodValueRef> asPod(const WitnessVal &value) {
-  if (auto podValue = std::get_if<PodValueRef>(&value)) {
+  if (const auto *podValue = std::get_if<PodValueRef>(&value)) {
     return *podValue;
   }
   if (std::holds_alternative<std::monostate>(value)) {
@@ -80,7 +80,7 @@ llvm::Expected<PodValueRef> asPod(const WitnessVal &value) {
 
 /// Require a struct value from the runtime variant.
 llvm::Expected<StructValueRef> asStruct(const WitnessVal &value) {
-  if (auto structValue = std::get_if<StructValueRef>(&value)) {
+  if (const auto *structValue = std::get_if<StructValueRef>(&value)) {
     return *structValue;
   }
   if (std::holds_alternative<std::monostate>(value)) {

--- a/tools/llzk-witgen/ValueModel.h
+++ b/tools/llzk-witgen/ValueModel.h
@@ -52,7 +52,7 @@ using WitnessVal = std::variant<
     std::monostate, bool, int64_t, llvm::DynamicAPInt, ArrayValueRef, PodValueRef, StructValueRef>;
 
 /// Control how witgen materializes uninitialized/default values.
-enum class UninitializedBehavior {
+enum class UninitializedBehavior : std::uint8_t {
   Zero,
   Random,
   Fail,

--- a/tools/llzk-witgen/WitgenDriver.cpp
+++ b/tools/llzk-witgen/WitgenDriver.cpp
@@ -55,15 +55,15 @@ Interpreter::Interpreter(
     UninitializedBehavior behavior, std::mt19937_64 r
 )
     : moduleOp(mod), tables(symbolTables), field(moduleField), uninitializedBehavior(behavior),
-      rng(std::move(r)) {}
+      rng(r) {}
 
 /// Parse main-function JSON arguments in either object or positional form.
 static llvm::Expected<llvm::SmallVector<WitnessVal>> parseArgumentsFromJSON(
     function::FuncDefOp computeFunc, const llvm::json::Value &input, const Field &field
 ) {
   llvm::SmallVector<WitnessVal> args;
-  auto *jsonObject = input.getAsObject();
-  auto *jsonArray = input.getAsArray();
+  const auto *jsonObject = input.getAsObject();
+  const auto *jsonArray = input.getAsArray();
   if (!jsonObject && !jsonArray) {
     return makeError("inputs JSON must be either an object or an array");
   }
@@ -126,7 +126,7 @@ llvm::Expected<llvm::json::Value> Interpreter::runMainFromJSON(const llvm::json:
     return args.takeError();
   }
 
-  FunctionInterpreter interpreter(moduleOp, tables, field, uninitializedBehavior, std::move(rng));
+  FunctionInterpreter interpreter(moduleOp, tables, field, uninitializedBehavior, rng);
   auto results = interpreter.run(computeFunc, *args);
   if (!results) {
     return results.takeError();

--- a/tools/llzk-witgen/WitgenDriver.h
+++ b/tools/llzk-witgen/WitgenDriver.h
@@ -25,13 +25,13 @@
 namespace llzk::witgen {
 
 /// Select the execution backend used by `llzk-witgen`.
-enum class Backend {
+enum class Backend : std::uint8_t {
   Interpreter,
   ExecutionEngine,
 };
 
 /// Select the JSON scope emitted by `llzk-witgen`.
-enum class OutputScope {
+enum class OutputScope : std::uint8_t {
   Public,
   FullWitness,
 };

--- a/tools/llzk-witgen/WitgenLowering.cpp
+++ b/tools/llzk-witgen/WitgenLowering.cpp
@@ -385,8 +385,13 @@ static FailureOr<Value> createZeroMemRef(OpBuilder &builder, Location loc, MemRe
   }
   auto strides = mlir::computeStrides(memrefType.getShape());
   for (size_t flat = 0; flat < *elementCount; ++flat) {
+    auto flatSigned = checkedCast<int64_t>(flat);
+    if (!flatSigned) {
+      emitError(loc) << llvm::toString(flatSigned.takeError());
+      return failure();
+    }
     SmallVector<Value> indices;
-    for (int64_t index : mlir::delinearize(llzk::checkedCast<int64_t>(flat), strides)) {
+    for (int64_t index : mlir::delinearize(*flatSigned, strides)) {
       indices.push_back(makeIndexConstant(builder, loc, index));
     }
     builder.create<memref::StoreOp>(loc, zero, alloc, indices);
@@ -408,8 +413,13 @@ static FailureOr<Value> createRandomMemRef(
   auto elementType = memrefType.getElementType();
   auto strides = mlir::computeStrides(memrefType.getShape());
   for (size_t flat = 0; flat < *elementCount; ++flat) {
+    auto flatSigned = checkedCast<int64_t>(flat);
+    if (!flatSigned) {
+      emitError(loc) << llvm::toString(flatSigned.takeError());
+      return failure();
+    }
     SmallVector<Value> indices;
-    for (int64_t index : mlir::delinearize(llzk::checkedCast<int64_t>(flat), strides)) {
+    for (int64_t index : mlir::delinearize(*flatSigned, strides)) {
       indices.push_back(makeIndexConstant(builder, loc, index));
     }
     if (isa<IndexType>(elementType)) {
@@ -689,35 +699,49 @@ static LogicalResult writeNamedAggregateValue(
 }
 
 /// Create a static subview representing one aggregate array element leaf.
-static Value
+static FailureOr<Value>
 createElementSubview(OpBuilder &builder, Location loc, Value source, ValueRange outerIndices) {
   auto sourceType = mlir::cast<MemRefType>(source.getType());
   SmallVector<OpFoldResult> mixedOffsets;
   SmallVector<OpFoldResult> mixedSizes;
   SmallVector<OpFoldResult> mixedStrides;
-  const int64_t indexedRank = llzk::checkedCast<int64_t>(outerIndices.size());
+  auto indexedRank = checkedCast<int64_t>(outerIndices.size());
+  if (!indexedRank) {
+    emitError(loc) << llvm::toString(indexedRank.takeError());
+    return failure();
+  }
   mixedOffsets.reserve(sourceType.getRank());
   mixedSizes.reserve(sourceType.getRank());
   mixedStrides.reserve(sourceType.getRank());
   for (Value index : outerIndices) {
     mixedOffsets.push_back(index);
   }
-  for (int64_t dim = indexedRank; dim < sourceType.getRank(); ++dim) {
+  for (int64_t dim = *indexedRank; dim < sourceType.getRank(); ++dim) {
     mixedOffsets.push_back(builder.getIndexAttr(0));
   }
-  for (int64_t dim = 0; dim < indexedRank; ++dim) {
+  for (int64_t dim = 0; dim < *indexedRank; ++dim) {
     mixedSizes.push_back(builder.getIndexAttr(1));
   }
-  for (int64_t dim = indexedRank; dim < sourceType.getRank(); ++dim) {
+  for (int64_t dim = *indexedRank; dim < sourceType.getRank(); ++dim) {
     mixedSizes.push_back(memref::getMixedSize(builder, loc, source, dim));
   }
   for (int64_t dim = 0; dim < sourceType.getRank(); ++dim) {
     mixedStrides.push_back(builder.getIndexAttr(1));
   }
   SmallVector<int64_t> desiredShape;
-  desiredShape.reserve(llzk::checkedCast<size_t>(sourceType.getRank() - indexedRank));
-  for (int64_t dim = indexedRank; dim < sourceType.getRank(); ++dim) {
-    if (auto attr = llvm::dyn_cast<Attribute>(mixedSizes[llzk::checkedCast<size_t>(dim)])) {
+  auto reserveSize = checkedCast<size_t>(sourceType.getRank() - *indexedRank);
+  if (!reserveSize) {
+    emitError(loc) << llvm::toString(reserveSize.takeError());
+    return failure();
+  }
+  desiredShape.reserve(*reserveSize);
+  for (int64_t dim = *indexedRank; dim < sourceType.getRank(); ++dim) {
+    auto dimIndex = checkedCast<size_t>(dim);
+    if (!dimIndex) {
+      emitError(loc) << llvm::toString(dimIndex.takeError());
+      return failure();
+    }
+    if (auto attr = llvm::dyn_cast<Attribute>(mixedSizes[*dimIndex])) {
       desiredShape.push_back(mlir::cast<IntegerAttr>(attr).getInt());
     } else {
       desiredShape.push_back(ShapedType::kDynamic);
@@ -729,9 +753,10 @@ createElementSubview(OpBuilder &builder, Location loc, Value source, ValueRange 
   auto resultType = mlir::cast<MemRefType>(memref::SubViewOp::inferRankReducedResultType(
       desiredShape, sourceType, mixedOffsets, mixedSizes, mixedStrides
   ));
-  return builder.create<memref::SubViewOp>(
+  auto op = builder.create<memref::SubViewOp>(
       loc, resultType, source, mixedOffsets, mixedSizes, mixedStrides
   );
+  return success(op.getResult());
 }
 
 /// Read one LLZK array element.
@@ -749,7 +774,11 @@ static FailureOr<LoweredValue> readArrayElement(
   }
 
   for (Value sourceLeaf : arrayValue.leaves) {
-    result.leaves.push_back(createElementSubview(builder, loc, sourceLeaf, indices));
+    auto subview = createElementSubview(builder, loc, sourceLeaf, indices);
+    if (failed(subview)) {
+      return failure();
+    }
+    result.leaves.push_back(*subview);
   }
   return result;
 }
@@ -768,8 +797,11 @@ static LogicalResult writeArrayElement(
   }
 
   for (auto [destLeaf, srcLeaf] : llvm::zip(arrayValue.leaves, elementValue.leaves)) {
-    Value subview = createElementSubview(builder, loc, destLeaf, indices);
-    builder.create<memref::CopyOp>(loc, srcLeaf, subview);
+    auto subview = createElementSubview(builder, loc, destLeaf, indices);
+    if (failed(subview)) {
+      return failure();
+    }
+    builder.create<memref::CopyOp>(loc, srcLeaf, *subview);
   }
   return success();
 }
@@ -1272,8 +1304,12 @@ private:
         return failure();
       }
       if (!arrayNewOp.getElements().empty()) {
-        size_t elementCount = llzk::checkedCast<size_t>(arrayNewOp.getType().getNumElements());
-        if (arrayNewOp.getElements().size() != elementCount) {
+        auto elementCount = checkedCast<size_t>(arrayNewOp.getType().getNumElements());
+        if (!elementCount) {
+          arrayNewOp.emitError() << llvm::toString(elementCount.takeError());
+          return failure();
+        }
+        if (arrayNewOp.getElements().size() != *elementCount) {
           arrayNewOp.emitError("expected one explicit element per array slot in witgen lowering");
           return failure();
         }
@@ -1285,7 +1321,12 @@ private:
           }
           SmallVector<Value> indices;
           auto strides = mlir::computeStrides(shape);
-          for (int64_t index : mlir::delinearize(llzk::checkedCast<int64_t>(flatIndex), strides)) {
+          auto flatSigned = checkedCast<int64_t>(flatIndex);
+          if (!flatSigned) {
+            arrayNewOp.emitError() << llvm::toString(flatSigned.takeError());
+            return failure();
+          }
+          for (int64_t index : mlir::delinearize(*flatSigned, strides)) {
             indices.push_back(makeIndexConstant(builder, loc, index));
           }
           if (failed(writeArrayElement(

--- a/tools/llzk-witgen/WitgenLowering.cpp
+++ b/tools/llzk-witgen/WitgenLowering.cpp
@@ -367,8 +367,7 @@ getNamedSubType(Type ownerType, StringRef name, SymbolTableCollection &tables, O
 }
 
 /// Create one static memref filled with zeros.
-static FailureOr<Value>
-createZeroMemRef(OpBuilder &builder, Location loc, MemRefType memrefType, const Field &field) {
+static FailureOr<Value> createZeroMemRef(OpBuilder &builder, Location loc, MemRefType memrefType) {
   auto elementCount = getStaticElementCount(memrefType, "witgen zero memref");
   if (!elementCount) {
     emitError(loc) << llvm::toString(elementCount.takeError());
@@ -490,7 +489,7 @@ static FailureOr<LoweredValue> createDefaultValue(
       continue;
     }
     if (auto memrefType = dyn_cast<MemRefType>(leafType)) {
-      auto zeroMemRef = createZeroMemRef(builder, loc, memrefType, field);
+      auto zeroMemRef = createZeroMemRef(builder, loc, memrefType);
       if (failed(zeroMemRef)) {
         return failure();
       }
@@ -738,7 +737,7 @@ createElementSubview(OpBuilder &builder, Location loc, Value source, ValueRange 
 /// Read one LLZK array element.
 static FailureOr<LoweredValue> readArrayElement(
     OpBuilder &builder, Location loc, array::ArrayType arrayType, const LoweredValue &arrayValue,
-    ArrayRef<Value> indices, SymbolTableCollection &tables, Operation *origin, const Field &field
+    ArrayRef<Value> indices
 ) {
   Type elementType = arrayType.getElementType();
   LoweredValue result {elementType, {}};
@@ -758,8 +757,7 @@ static FailureOr<LoweredValue> readArrayElement(
 /// Write one LLZK array element.
 static LogicalResult writeArrayElement(
     OpBuilder &builder, Location loc, array::ArrayType arrayType, LoweredValue &arrayValue,
-    ArrayRef<Value> indices, const LoweredValue &elementValue, SymbolTableCollection &tables,
-    Operation *origin, const Field &field
+    ArrayRef<Value> indices, const LoweredValue &elementValue
 ) {
   Type elementType = arrayType.getElementType();
   if (isScalarType(elementType)) {
@@ -1291,8 +1289,7 @@ private:
             indices.push_back(makeIndexConstant(builder, loc, index));
           }
           if (failed(writeArrayElement(
-                  builder, loc, arrayNewOp.getType(), *lowered, indices, *elementValue, tables,
-                  arrayNewOp.getOperation(), field
+                  builder, loc, arrayNewOp.getType(), *lowered, indices, *elementValue
               ))) {
             return failure();
           }
@@ -1315,7 +1312,7 @@ private:
       }
       auto lowered = readArrayElement(
           builder, loc, mlir::cast<array::ArrayType>(readArrayOp.getArrRef().getType()),
-          *arrayValue, indices, tables, readArrayOp.getOperation(), field
+          *arrayValue, indices
       );
       if (failed(lowered)) {
         return failure();
@@ -1337,8 +1334,7 @@ private:
       }
       return writeArrayElement(
           builder, loc, mlir::cast<array::ArrayType>(writeArrayOp.getArrRef().getType()),
-          valueMap[writeArrayOp.getArrRef()], indices, *elementValue, tables,
-          writeArrayOp.getOperation(), field
+          valueMap[writeArrayOp.getArrRef()], indices, *elementValue
       );
     }
 
@@ -1809,10 +1805,10 @@ private:
 } // namespace
 
 void addWitgenPreparePipeline(OpPassManager &pm, const WitgenOptions &) {
-  llzk::polymorphic::FlatteningPassOptions flatteningOptions = {
-      .cleanupMode = llzk::polymorphic::StructCleanupMode::ConcreteAsRoot
-  };
-  pm.addPass(llzk::polymorphic::createFlatteningPass(std::move(flatteningOptions)));
+  using namespace llzk::polymorphic;
+  pm.addPass(
+      createFlatteningPass(FlatteningPassOptions {.cleanupMode = StructCleanupMode::ConcreteAsRoot})
+  );
   pm.addPass(mlir::createLowerAffinePass());
   pm.addPass(llzk::createInlineStructsPass());
   pm.addPass(mlir::createCanonicalizerPass());

--- a/tools/llzk-witgen/WitgenLowering.cpp
+++ b/tools/llzk-witgen/WitgenLowering.cpp
@@ -51,6 +51,7 @@
 #include <llvm/ADT/SmallString.h>
 #include <llvm/ADT/StringMap.h>
 #include <llvm/ADT/TypeSwitch.h>
+#include <llvm/Support/MathExtras.h>
 
 #include <limits>
 

--- a/tools/llzk-witgen/WitgenLowering.cpp
+++ b/tools/llzk-witgen/WitgenLowering.cpp
@@ -88,7 +88,7 @@ static std::string mangleFunctionName(function::FuncDefOp funcOp) {
       result += "__";
     }
     for (char c : piece) {
-      result += llvm::isAlnum(static_cast<unsigned char>(c)) ? c : '_';
+      result += llvm::isAlnum(c) ? c : '_';
     }
   }
   return std::string(result);
@@ -387,7 +387,7 @@ createZeroMemRef(OpBuilder &builder, Location loc, MemRefType memrefType, const 
   auto strides = mlir::computeStrides(memrefType.getShape());
   for (size_t flat = 0; flat < *elementCount; ++flat) {
     SmallVector<Value> indices;
-    for (int64_t index : mlir::delinearize(flat, strides)) {
+    for (int64_t index : mlir::delinearize(llzk::checkedCast<int64_t>(flat), strides)) {
       indices.push_back(makeIndexConstant(builder, loc, index));
     }
     builder.create<memref::StoreOp>(loc, zero, alloc, indices);
@@ -410,7 +410,7 @@ static FailureOr<Value> createRandomMemRef(
   auto strides = mlir::computeStrides(memrefType.getShape());
   for (size_t flat = 0; flat < *elementCount; ++flat) {
     SmallVector<Value> indices;
-    for (int64_t index : mlir::delinearize(flat, strides)) {
+    for (int64_t index : mlir::delinearize(llzk::checkedCast<int64_t>(flat), strides)) {
       indices.push_back(makeIndexConstant(builder, loc, index));
     }
     if (isa<IndexType>(elementType)) {
@@ -1287,7 +1287,7 @@ private:
           }
           SmallVector<Value> indices;
           auto strides = mlir::computeStrides(shape);
-          for (int64_t index : mlir::delinearize(flatIndex, strides)) {
+          for (int64_t index : mlir::delinearize(llzk::checkedCast<int64_t>(flatIndex), strides)) {
             indices.push_back(makeIndexConstant(builder, loc, index));
           }
           if (failed(writeArrayElement(
@@ -1412,19 +1412,27 @@ private:
       }
       auto loweredCall =
           builder.create<func::CallOp>(loc, mangleFunctionName(callee), resultTypes, flatArgs);
-      unsigned cursor = 0;
+      auto loweredCallResults = loweredCall.getResults();
+      size_t totalResults = loweredCallResults.size();
+      size_t cursor = 0;
       for (auto [oldResult, oldType] : llvm::zip(callOp.getResults(), callOp.getResultTypes())) {
         auto leafCount = getLeafCount(oldType, tables, callOp.getOperation(), field);
         if (failed(leafCount)) {
           return failure();
         }
+        bool overflow = false;
+        size_t nextCursor = llvm::SaturatingAdd(cursor, *leafCount, &overflow);
+        if (overflow || nextCursor > totalResults) {
+          callOp.emitError("leaf count overflow while lowering function call results");
+          return failure();
+        }
         LoweredValue lowered {oldType, {}};
         lowered.leaves.append(
-            loweredCall.getResults().begin() + cursor,
-            loweredCall.getResults().begin() + cursor + *leafCount
+            loweredCallResults.begin() + static_cast<ptrdiff_t>(cursor),
+            loweredCallResults.begin() + static_cast<ptrdiff_t>(nextCursor)
         );
-        cursor += *leafCount;
         valueMap[oldResult] = std::move(lowered);
+        cursor = nextCursor;
       }
       return success();
     }
@@ -1438,7 +1446,7 @@ private:
       }
 
       SmallVector<Value> initArgs;
-      SmallVector<unsigned> initLeafCounts;
+      SmallVector<size_t> initLeafCounts;
       for (auto [init, resultType] : llvm::zip(forOp.getInitArgs(), forOp.getResultTypes())) {
         auto lowered = lookup(init, valueMap, forOp.getOperation());
         auto leafTypes = getABILeafTypes(resultType, tables, forOp.getOperation(), field);
@@ -1462,32 +1470,54 @@ private:
       DenseMap<Value, LoweredValue> bodyMap(valueMap.begin(), valueMap.end());
       bodyMap[forOp.getInductionVar()] =
           LoweredValue {forOp.getInductionVar().getType(), {newFor.getInductionVar()}};
-      unsigned cursor = 0;
-      for (auto [oldIterArg, oldType, leafCount] :
-           llvm::zip(forOp.getRegionIterArgs(), forOp.getResultTypes(), initLeafCounts)) {
-        LoweredValue lowered {oldType, {}};
-        lowered.leaves.append(
-            newFor.getRegionIterArgs().begin() + cursor,
-            newFor.getRegionIterArgs().begin() + cursor + leafCount
-        );
-        bodyMap[oldIterArg] = std::move(lowered);
-        cursor += leafCount;
+      {
+        auto newForIterArgs = newFor.getRegionIterArgs();
+        size_t totalIterArgs = newForIterArgs.size();
+        size_t cursor = 0;
+        for (auto [oldIterArg, oldType, leafCount] :
+             llvm::zip(forOp.getRegionIterArgs(), forOp.getResultTypes(), initLeafCounts)) {
+          bool overflow = false;
+          size_t nextCursor = llvm::SaturatingAdd(cursor, leafCount, &overflow);
+          if (overflow || nextCursor > totalIterArgs) {
+            forOp.emitError("leaf count overflow while lowering for-loop region iter args");
+            return failure();
+          }
+          LoweredValue lowered {oldType, {}};
+          lowered.leaves.append(
+              newForIterArgs.begin() + static_cast<ptrdiff_t>(cursor),
+              newForIterArgs.begin() + static_cast<ptrdiff_t>(nextCursor)
+          );
+          bodyMap[oldIterArg] = std::move(lowered);
+          cursor = nextCursor;
+        }
       }
+
       newFor.getBody()->clear();
       OpBuilder bodyBuilder = OpBuilder::atBlockBegin(newFor.getBody());
       if (failed(lowerBlock(bodyBuilder, *forOp.getBody(), bodyMap))) {
         return failure();
       }
 
-      cursor = 0;
-      for (auto [oldResult, oldType, leafCount] :
-           llvm::zip(forOp.getResults(), forOp.getResultTypes(), initLeafCounts)) {
-        LoweredValue lowered {oldType, {}};
-        lowered.leaves.append(
-            newFor.getResults().begin() + cursor, newFor.getResults().begin() + cursor + leafCount
-        );
-        valueMap[oldResult] = std::move(lowered);
-        cursor += leafCount;
+      {
+        auto newForResults = newFor.getResults();
+        size_t totalForResults = newForResults.size();
+        size_t cursor = 0;
+        for (auto [oldResult, oldType, leafCount] :
+             llvm::zip(forOp.getResults(), forOp.getResultTypes(), initLeafCounts)) {
+          bool overflow = false;
+          size_t nextCursor = llvm::SaturatingAdd(cursor, leafCount, &overflow);
+          if (overflow || nextCursor > totalForResults) {
+            forOp.emitError("leaf count overflow while lowering for-loop results");
+            return failure();
+          }
+          LoweredValue lowered {oldType, {}};
+          lowered.leaves.append(
+              newForResults.begin() + static_cast<ptrdiff_t>(cursor),
+              newForResults.begin() + static_cast<ptrdiff_t>(nextCursor)
+          );
+          valueMap[oldResult] = std::move(lowered);
+          cursor = nextCursor;
+        }
       }
       return success();
     }

--- a/tools/llzk-witgen/WitgenUtils.cpp
+++ b/tools/llzk-witgen/WitgenUtils.cpp
@@ -36,7 +36,7 @@ dynamicAPIntToSize(const llvm::DynamicAPInt &value, llvm::Twine context) {
   if (as.getActiveBits() > std::numeric_limits<size_t>::digits) {
     return makeError(context + " would overflow size_t");
   }
-  return llzk::checkedCast<size_t>(as.getZExtValue());
+  return static_cast<size_t>(as.getZExtValue());
 }
 
 llvm::Expected<size_t>

--- a/tools/llzk-witgen/WitgenUtils.h
+++ b/tools/llzk-witgen/WitgenUtils.h
@@ -21,6 +21,7 @@
 
 #include <cstddef>
 #include <random>
+#include <utility>
 
 namespace llzk::witgen {
 

--- a/tools/llzk-witgen/WitgenUtils.h
+++ b/tools/llzk-witgen/WitgenUtils.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include "Errors.h"
 #include "WitgenDriver.h"
 
 #include <mlir/IR/BuiltinTypes.h>
@@ -22,6 +23,13 @@
 #include <random>
 
 namespace llzk::witgen {
+
+template <typename T, typename U> inline llvm::Expected<T> checkedCast(U u) {
+  if (std::in_range<T>(u)) {
+    return static_cast<T>(u);
+  }
+  return makeError("lossy integer conversion");
+}
 
 /// Seed an RNG for random/default witness value materialization.
 std::mt19937_64 makeDefaultValueRng(const WitgenOptions &options);


### PR DESCRIPTION
Started out as applying fixes to clang-tidy warnings but I also ended up adding some more checks for overflows in all the type conversions used in witgen and doing a few small refactorings.