### PR TITLE
Optimize SMT lowering for direct field division equalities

### DIFF
--- a/backends/smt/lib/Conversions/SMTLoweringPass.cpp
+++ b/backends/smt/lib/Conversions/SMTLoweringPass.cpp
@@ -140,9 +140,66 @@ public:
   FeltDivConverter(TypeConverter &_typeConverter, MLIRContext *context, APSInt _prime)
       : OpConversionPattern {_typeConverter, context, /*benefit=*/2}, prime {std::move(_prime)} {}
 
+private:
+  LogicalResult rewriteSingleUseEquality(
+      felt::DivFeltOp op, OpAdaptor adaptor, ConversionPatternRewriter &rewriter
+  ) const {
+    Value divResult = op.getResult();
+    if (!divResult.hasOneUse()) {
+      return failure();
+    }
+
+    OpOperand &use = *divResult.getUses().begin();
+    auto equalityOp = dyn_cast<constrain::EmitEqualityOp>(use.getOwner());
+    if (!equalityOp) {
+      return failure();
+    }
+
+    Value equalityOperand = use.getOperandNumber() == 0 ? equalityOp.getRhs() : equalityOp.getLhs();
+    Value target = rewriter.getRemappedValue(equalityOperand);
+    if (!target) {
+      return failure();
+    }
+
+    OpBuilder::InsertionGuard insertionGuard {rewriter};
+    rewriter.setInsertionPoint(equalityOp);
+    Location loc = equalityOp->getLoc();
+
+    auto mod = rewriter.create<smt::IntConstantOp>(loc, IntegerAttr::get(getContext(), prime));
+    auto zero = rewriter.create<smt::IntConstantOp>(
+        loc, IntegerAttr::get(getContext(), APSInt {APInt {1, 0}})
+    );
+
+    // Since the quotient is only used by this equality, lower `%x / %y == %t`
+    // directly to `ite(%y == 0, %t mod p == 0, (%y * %t) mod p == %x mod p)`.
+    // The `%y == 0` branch matches the generic lowering's quotient-is-zero convention.
+    auto denominatorIsZero = rewriter.create<smt::EqOp>(loc, adaptor.getRhs(), zero.getResult());
+
+    auto targetMod = rewriter.create<smt::IntModOp>(loc, target, mod.getResult());
+    auto targetIsZero = rewriter.create<smt::EqOp>(loc, targetMod.getResult(), zero.getResult());
+    auto product = rewriter.create<smt::IntMulOp>(loc, ValueRange {adaptor.getRhs(), target});
+    auto productMod = rewriter.create<smt::IntModOp>(loc, product.getResult(), mod.getResult());
+    auto numeratorMod = rewriter.create<smt::IntModOp>(loc, adaptor.getLhs(), mod.getResult());
+    auto productEqualsNumerator =
+        rewriter.create<smt::EqOp>(loc, productMod.getResult(), numeratorMod.getResult());
+    auto divConstraint = rewriter.create<smt::IteOp>(
+        loc, denominatorIsZero.getResult(), targetIsZero.getResult(),
+        productEqualsNumerator.getResult()
+    );
+
+    rewriter.create<smt::AssertOp>(loc, divConstraint.getResult());
+    rewriter.eraseOp(equalityOp);
+    rewriter.eraseOp(op);
+    return success();
+  }
+
+public:
   LogicalResult matchAndRewrite(
       felt::DivFeltOp op, OpAdaptor adaptor, ConversionPatternRewriter &rewriter
   ) const override {
+    if (succeeded(rewriteSingleUseEquality(op, adaptor, rewriter))) {
+      return success();
+    }
 
     // Rewrite `%z = felt.div %x, %y` into:
     // %z = smt.declare_fun "z" : !smt.int

--- a/changelogs/unreleased/smt-div-eq-lowering.yaml
+++ b/changelogs/unreleased/smt-div-eq-lowering.yaml
@@ -1,0 +1,2 @@
+changed:
+  - Optimize SMT lowering for direct equality constraints over field division

--- a/test/Conversions/llzk_to_smt_no_cf_div_eq.llzk
+++ b/test/Conversions/llzk_to_smt_no_cf_div_eq.llzk
@@ -1,0 +1,60 @@
+// RUN: llzk-opt --llzk-compute-constrain-to-product='root-struct=A' --llzk-to-smt-no-cf='field=babybear' %s | FileCheck --enable-var-scope %s
+
+!F = !felt.type<"babybear">
+
+module attributes {llzk.lang} {
+  struct.def @A {
+    struct.member @out : !F {llzk.pub}
+
+    function.def @compute(%x: !F, %y: !F, %target: !F) -> !struct.type<@A> {
+      %self = struct.new : <@A>
+      struct.writem %self[@out] = %x : <@A>, !F
+      function.return %self : !struct.type<@A>
+    }
+
+    function.def @constrain(%self: !struct.type<@A>, %x: !F, %y: !F, %target: !F) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+      %quotient = felt.div %x, %y : !F, !F
+      constrain.eq %quotient, %target : !F
+      %flipped = felt.div %target, %y : !F, !F
+      constrain.eq %x, %flipped : !F
+      %multi_use = felt.div %target, %y : !F, !F
+      %sum = felt.add %multi_use, %x : !F, !F
+      constrain.eq %multi_use, %target : !F
+      constrain.eq %sum, %x : !F
+      function.return
+    }
+  }
+}
+
+// CHECK-LABEL: module attributes {llzk.lang} {
+// CHECK: func.func @smt_A(%[[X:[0-9a-zA-Z_\.]+]]: !smt.int, %[[Y:[0-9a-zA-Z_\.]+]]: !smt.int, %[[TARGET:[0-9a-zA-Z_\.]+]]: !smt.int) {
+// CHECK-DAG: %[[OUTC:[0-9a-zA-Z_\.]+]] = smt.declare_fun "out_c" : !smt.int
+// CHECK-DAG: %[[OUTW:[0-9a-zA-Z_\.]+]] = smt.declare_fun "out_w" : !smt.int
+// CHECK: smt.assert
+// CHECK-NOT: smt.declare_fun : !smt.int
+// CHECK: %[[PRIME:[0-9a-zA-Z_\.]+]] = smt.int.constant 2013265921
+// CHECK: %[[ZERO:[0-9a-zA-Z_\.]+]] = smt.int.constant 0
+// CHECK: %[[DENOM_ZERO:[0-9a-zA-Z_\.]+]] = smt.eq %[[Y]], %[[ZERO]] : !smt.int
+// CHECK: %[[TARGET_MOD:[0-9a-zA-Z_\.]+]] = smt.int.mod %[[TARGET]], %[[PRIME]]
+// CHECK: %[[TARGET_ZERO:[0-9a-zA-Z_\.]+]] = smt.eq %[[TARGET_MOD]], %[[ZERO]] : !smt.int
+// CHECK: %[[PRODUCT:[0-9a-zA-Z_\.]+]] = smt.int.mul %[[Y]], %[[TARGET]]
+// CHECK: %[[PRODUCT_MOD:[0-9a-zA-Z_\.]+]] = smt.int.mod %[[PRODUCT]], %[[PRIME]]
+// CHECK: %[[NUMERATOR_MOD:[0-9a-zA-Z_\.]+]] = smt.int.mod %[[X]], %[[PRIME]]
+// CHECK: %[[PRODUCT_EQ_NUMERATOR:[0-9a-zA-Z_\.]+]] = smt.eq %[[PRODUCT_MOD]], %[[NUMERATOR_MOD]] : !smt.int
+// CHECK: %[[DIV_CONSTRAINT:[0-9a-zA-Z_\.]+]] = smt.ite %[[DENOM_ZERO]], %[[TARGET_ZERO]], %[[PRODUCT_EQ_NUMERATOR]] : !smt.bool
+// CHECK: smt.assert %[[DIV_CONSTRAINT]]
+// CHECK-NOT: smt.declare_fun : !smt.int
+// CHECK: %[[PRIME2:[0-9a-zA-Z_\.]+]] = smt.int.constant 2013265921
+// CHECK: %[[ZERO2:[0-9a-zA-Z_\.]+]] = smt.int.constant 0
+// CHECK: %[[DENOM_ZERO2:[0-9a-zA-Z_\.]+]] = smt.eq %[[Y]], %[[ZERO2]] : !smt.int
+// CHECK: %[[TARGET2_MOD:[0-9a-zA-Z_\.]+]] = smt.int.mod %[[X]], %[[PRIME2]]
+// CHECK: %[[TARGET2_ZERO:[0-9a-zA-Z_\.]+]] = smt.eq %[[TARGET2_MOD]], %[[ZERO2]] : !smt.int
+// CHECK: %[[PRODUCT2:[0-9a-zA-Z_\.]+]] = smt.int.mul %[[Y]], %[[X]]
+// CHECK: %[[PRODUCT2_MOD:[0-9a-zA-Z_\.]+]] = smt.int.mod %[[PRODUCT2]], %[[PRIME2]]
+// CHECK: %[[NUMERATOR2_MOD:[0-9a-zA-Z_\.]+]] = smt.int.mod %[[TARGET]], %[[PRIME2]]
+// CHECK: %[[PRODUCT2_EQ_NUMERATOR:[0-9a-zA-Z_\.]+]] = smt.eq %[[PRODUCT2_MOD]], %[[NUMERATOR2_MOD]] : !smt.int
+// CHECK: %[[DIV_CONSTRAINT2:[0-9a-zA-Z_\.]+]] = smt.ite %[[DENOM_ZERO2]], %[[TARGET2_ZERO]], %[[PRODUCT2_EQ_NUMERATOR]] : !smt.bool
+// CHECK: smt.assert %[[DIV_CONSTRAINT2]]
+// CHECK-NOT: smt.declare_fun : !smt.int
+// CHECK: %[[DIVSYM:[0-9a-zA-Z_\.]+]] = smt.declare_fun : !smt.int
+// CHECK: return


### PR DESCRIPTION
## Summary

Addresses #383 by adding a narrow SMT lowering fast path for direct equality constraints over `felt.div`.

When a `felt.div` result is used exactly once by `constrain.eq`, the lowering now avoids materializing an auxiliary SMT quotient value and emits the modular cross-multiplied assertion directly.

## Details

For a direct equality like:

```mlir
%q = felt.div %x, %y : !felt.type, !felt.type
constrain.eq %q, %t : !felt.type
```

the SMT lowering now emits:

```text
ite(%y == 0, %t mod p == 0, (%y * %t) mod p == %x mod p)
```

This preserves the current zero-divisor convention from the generic lowering while removing the fresh quotient symbol in the single-use equality case.

The existing generic `felt.div` lowering remains unchanged for all other cases, including multi-use quotients.

## Tests

Added FileCheck coverage for:

- direct `%quotient == %target`
- flipped equality `%x == %quotient`
- multi-use quotient fallback to the existing generic lowering
