### PR TITLE
Make interval analysis interprocedural for subcomponent constrains

### DIFF
--- a/include/llzk/Analysis/IntervalAnalysis.h
+++ b/include/llzk/Analysis/IntervalAnalysis.h
@@ -32,11 +32,13 @@
 
 #include <llvm/ADT/DynamicAPInt.h>
 #include <llvm/ADT/MapVector.h>
+#include <llvm/ADT/ScopeExit.h>
 #include <llvm/Support/SMTAPI.h>
 
 #include <array>
 #include <mutex>
 #include <optional>
+#include <unordered_set>
 
 namespace llzk {
 
@@ -520,17 +522,18 @@ public:
   /// @return
   static mlir::FailureOr<StructIntervals> compute(
       mlir::ModuleOp mod, component::StructDefOp s, mlir::DataFlowSolver &solver,
-      const IntervalAnalysisContext &ctx
+      mlir::AnalysisManager &am, const IntervalAnalysisContext &ctx
   ) {
     StructIntervals si(mod, s);
-    if (si.computeIntervals(solver, ctx).failed()) {
+    if (si.computeIntervals(solver, am, ctx).failed()) {
       return mlir::failure();
     }
     return si;
   }
 
-  mlir::LogicalResult
-  computeIntervals(mlir::DataFlowSolver &solver, const IntervalAnalysisContext &ctx);
+  mlir::LogicalResult computeIntervals(
+      mlir::DataFlowSolver &solver, mlir::AnalysisManager &am, const IntervalAnalysisContext &ctx
+  );
 
   void print(
       mlir::raw_ostream &os, bool withConstraints = false, bool printCompute = false,
@@ -589,16 +592,29 @@ public:
   using StructAnalysis::StructAnalysis;
   ~StructIntervalAnalysis() override = default;
 
+  bool inProgress(const IntervalAnalysisContext &ctx) const {
+    return inProgressContexts.contains(ctx);
+  }
+
   mlir::LogicalResult runAnalysis(
-      mlir::DataFlowSolver &solver, mlir::AnalysisManager &, const IntervalAnalysisContext &ctx
+      mlir::DataFlowSolver &solver, mlir::AnalysisManager &am, const IntervalAnalysisContext &ctx
   ) override {
-    auto computeRes = StructIntervals::compute(getModule(), getStruct(), solver, ctx);
+    if (inProgress(ctx)) {
+      return mlir::failure();
+    }
+    inProgressContexts.insert(ctx);
+    auto cleanup = llvm::make_scope_exit([this, &ctx] { inProgressContexts.erase(ctx); });
+
+    auto computeRes = StructIntervals::compute(getModule(), getStruct(), solver, am, ctx);
     if (mlir::failed(computeRes)) {
       return mlir::failure();
     }
     setResult(ctx, std::move(*computeRes));
     return mlir::success();
   }
+
+private:
+  std::unordered_set<IntervalAnalysisContext> inProgressContexts;
 };
 
 /* ModuleIntervalAnalysis */

--- a/lib/Analysis/IntervalAnalysis.cpp
+++ b/lib/Analysis/IntervalAnalysis.cpp
@@ -14,7 +14,9 @@
 #include "llzk/Dialect/Array/Util/ArrayTypeHelper.h"
 #include "llzk/Util/Debug.h"
 #include "llzk/Util/StreamHelper.h"
+#include "llzk/Util/SymbolHelper.h"
 
+#include <mlir/Analysis/DataFlow/DeadCodeAnalysis.h>
 #include <mlir/Dialect/SCF/IR/SCF.h>
 
 #include <llvm/ADT/TypeSwitch.h>
@@ -34,6 +36,18 @@ using namespace felt;
 using namespace function;
 
 namespace {
+
+bool isOperationLive(DataFlowSolver &solver, Operation *op) {
+  if (!op->getBlock()) {
+    return true;
+  }
+  if (const auto *exec = solver.lookupState<mlir::dataflow::Executable>(
+          solver.getProgramPointBefore(op->getBlock())
+      )) {
+    return exec->isLive();
+  }
+  return true;
+}
 
 std::optional<UnreducedInterval> mergeUnreducedIntervals(
     const std::optional<UnreducedInterval> &lhs, const std::optional<UnreducedInterval> &rhs
@@ -64,6 +78,90 @@ ExpressionValue refineReducedInterval(const ExpressionValue &expr, const Interva
 std::optional<UnreducedInterval> getBooleanUnreducedInterval(const Interval &interval) {
   return interval.isBoolean() ? std::optional<UnreducedInterval>(interval.firstUnreduced())
                               : std::nullopt;
+}
+
+FailureOr<std::vector<SourceRef>>
+translateRef(const SourceRef &ref, const SourceRefRemappings &translations) {
+  std::vector<SourceRef> refs;
+  for (const auto &[prefix, vals] : translations) {
+    if (!ref.isValidPrefix(prefix)) {
+      continue;
+    }
+
+    if (vals.isArray()) {
+      auto suffix = ref.getSuffix(prefix);
+      ensure(succeeded(suffix), "prefix checked before SourceRef suffix extraction");
+
+      std::vector<SourceRefIndex> arraySuffix, remainingSuffix;
+      bool suffixIsPastArray = false;
+      for (const SourceRefIndex &idx : *suffix) {
+        if (!suffixIsPastArray && arraySuffix.size() < vals.getNumArrayDims() &&
+            (idx.isIndex() || idx.isIndexRange())) {
+          arraySuffix.push_back(idx);
+          continue;
+        }
+        suffixIsPastArray = true;
+        remainingSuffix.push_back(idx);
+      }
+
+      auto resolvedValsRes = vals.extract(arraySuffix);
+      ensure(succeeded(resolvedValsRes), "could not resolve translated SourceRef array child");
+      SourceRefSet folded = resolvedValsRes->first.foldToScalar();
+      if (remainingSuffix.empty()) {
+        refs.insert(refs.end(), folded.begin(), folded.end());
+        continue;
+      }
+
+      for (const SourceRef &baseRef : folded) {
+        auto translatedRef = mlir::FailureOr<SourceRef>(baseRef);
+        for (const SourceRefIndex &idx : remainingSuffix) {
+          if (failed(translatedRef)) {
+            break;
+          }
+          translatedRef = translatedRef->createChild(idx);
+        }
+        if (succeeded(translatedRef)) {
+          refs.push_back(*translatedRef);
+        }
+      }
+    } else {
+      for (const SourceRef &replacement : vals.getScalarValue()) {
+        auto translated = ref.translate(prefix, replacement);
+        if (succeeded(translated)) {
+          refs.push_back(*translated);
+        }
+      }
+    }
+  }
+
+  if (refs.empty()) {
+    return failure();
+  }
+  return refs;
+}
+
+FailureOr<SymbolLookupResult<FuncDefOp>>
+resolveCallableSilently(SymbolTableCollection &tables, CallOp fnCall) {
+  mlir::CallInterfaceCallable callable = fnCall.getCallableForCallee();
+  if (auto symbolVal = llvm::dyn_cast<Value>(callable)) {
+    SymbolLookupResult<FuncDefOp> result(symbolVal.getDefiningOp());
+    if (!result) {
+      return failure();
+    }
+    return result;
+  }
+
+  auto symbolRef = llvm::cast<SymbolRefAttr>(callable);
+  if (Operation *op = tables.lookupNearestSymbolFrom(fnCall.getOperation(), symbolRef)) {
+    SymbolLookupResult<FuncDefOp> result(op);
+    if (!result) {
+      return failure();
+    }
+    return result;
+  }
+  return lookupTopLevelSymbol<FuncDefOp>(
+      tables, symbolRef, fnCall.getOperation(), /*reportMissing=*/false
+  );
 }
 
 } // namespace
@@ -1544,11 +1642,12 @@ IntervalDataFlowAnalysis::getGeneralizedDecompInterval(
 /* StructIntervals */
 
 LogicalResult StructIntervals::computeIntervals(
-    mlir::DataFlowSolver &solver, const IntervalAnalysisContext &ctx
+    mlir::DataFlowSolver &solver, mlir::AnalysisManager &am, const IntervalAnalysisContext &ctx
 ) {
+  SymbolTableCollection tables;
 
   auto computeIntervalsImpl =
-      [&solver, &ctx, this](
+      [&solver, &am, &ctx, &tables, this](
           FuncDefOp fn, llvm::MapVector<SourceRef, Interval> &memberRanges,
           llvm::MapVector<SourceRef, UnreducedInterval> &memberUnreducedRanges,
           llvm::SetVector<ExpressionValue> & /*solverConstraints*/
@@ -1571,6 +1670,36 @@ LogicalResult StructIntervals::computeIntervals(
       }
       searchSet.insert(ref);
     }
+    SourceRefSet functionRefs = searchSet;
+
+    auto mergeInterval = [&memberRanges, &memberUnreducedRanges](
+                             const SourceRef &ref, const Interval &interval,
+                             std::optional<UnreducedInterval> unreducedInterval = std::nullopt
+                         ) {
+      auto existing = memberRanges.find(ref);
+      if (existing != memberRanges.end()) {
+        Interval mergedInterval = existing->second.intersect(interval);
+        bool intervalChanged = mergedInterval != existing->second;
+        existing->second = mergedInterval;
+
+        if (unreducedInterval.has_value()) {
+          auto existingUnreduced = memberUnreducedRanges.find(ref);
+          if (existingUnreduced != memberUnreducedRanges.end()) {
+            existingUnreduced->second = existingUnreduced->second.intersect(*unreducedInterval);
+          } else {
+            memberUnreducedRanges.insert({ref, *unreducedInterval});
+          }
+        } else if (intervalChanged) {
+          memberUnreducedRanges.erase(ref);
+        }
+        return;
+      }
+
+      memberRanges[ref] = interval;
+      if (unreducedInterval.has_value()) {
+        memberUnreducedRanges.insert({ref, *unreducedInterval});
+      }
+    };
 
     // Iterate over arguments
     for (BlockArgument arg : fn.getArguments()) {
@@ -1628,6 +1757,81 @@ LogicalResult StructIntervals::computeIntervals(
         }
         assert(memberRanges[ref].getField() == ctx.getField() && "bad interval defaults");
       }
+    }
+
+    // Child constrain calls refine parent-visible storage, but only after the callee
+    // summary is translated through the call operands. If translation cannot prove
+    // which parent ref owns a child interval, the local overapproximation remains.
+    if (fn.isStructConstrain()) {
+      auto mergeChildConstrainIntervals = [&](CallOp fnCall) {
+        if (!isOperationLive(solver, fnCall.getOperation())) {
+          return;
+        }
+
+        auto res = resolveCallableSilently(tables, fnCall);
+        if (failed(res)) {
+          return;
+        }
+
+        FuncDefOp calledFn = res->get();
+        if (!calledFn.isStructConstrain()) {
+          return;
+        }
+
+        auto calledStruct = calledFn->getParentOfType<StructDefOp>();
+        if (calledStruct == structDef) {
+          return;
+        }
+
+        auto &childAnalysis = am.getChildAnalysis<StructIntervalAnalysis>(calledStruct);
+        if (childAnalysis.inProgress(ctx)) {
+          return;
+        }
+        if (!childAnalysis.constructed(ctx)) {
+          ensure(
+              succeeded(childAnalysis.runAnalysis(solver, am, ctx)),
+              "could not construct interval analysis for child struct"
+          );
+        }
+
+        SourceRefRemappings translations;
+        for (unsigned i = 0; i < calledFn.getNumArguments(); i++) {
+          SourceRef prefix(calledFn.getArgument(i));
+          SourceRefLatticeValue val =
+              SourceRefAnalysis::getValueState(solver, fnCall.getOperand(i));
+          translations.push_back({prefix, val});
+        }
+
+        const StructIntervals &childIntervals = childAnalysis.getResult(ctx);
+        for (const auto &[childRef, childInterval] : childIntervals.getConstrainIntervals()) {
+          auto translatedRefs = translateRef(childRef, translations);
+          if (failed(translatedRefs)) {
+            continue;
+          }
+
+          std::optional<UnreducedInterval> childUnreduced = std::nullopt;
+          auto childUnreducedIt = childIntervals.getConstrainUnreducedIntervals().find(childRef);
+          if (childUnreducedIt != childIntervals.getConstrainUnreducedIntervals().end()) {
+            childUnreduced = childUnreducedIt->second;
+          }
+
+          SourceRefSet uniqueTranslatedRefs;
+          for (const SourceRef &translatedRef : *translatedRefs) {
+            uniqueTranslatedRefs.insert(translatedRef);
+          }
+          if (uniqueTranslatedRefs.size() != 1) {
+            continue;
+          }
+
+          const SourceRef &translatedRef = *uniqueTranslatedRefs.begin();
+          if (functionRefs.contains(translatedRef)) {
+            mergeInterval(translatedRef, childInterval, childUnreduced);
+            searchSet.erase(translatedRef);
+          }
+        }
+      };
+
+      fn.walk(mergeChildConstrainIntervals);
     }
 
     // For all unfound refs, default to the entire range.
@@ -1704,8 +1908,9 @@ void StructIntervals::print(
       os << '\n';
       os.indent(indent) << ref << " in " << interval;
       if (printUnreduced) {
-        if (const auto *it = memberUnreducedRanges.find(ref); it != memberUnreducedRanges.end()) {
-          os << " ( " << it->second << " )";
+        auto unreducedIt = memberUnreducedRanges.find(ref);
+        if (unreducedIt != memberUnreducedRanges.end()) {
+          os << " ( " << unreducedIt->second << " )";
         }
       }
     }

--- a/test/Analysis/interval_analysis/edwards2montgomery.llzk
+++ b/test/Analysis/interval_analysis/edwards2montgomery.llzk
@@ -353,12 +353,12 @@ module attributes {llzk.lang} {
 // CHECK-NEXT:     %arg0[@$temp_1][@$super] in Entire
 // CHECK-NEXT:     %arg0[@$temp_1][@reg] in Entire
 // CHECK-NEXT:     %arg0[@$temp_0][@$super] in Entire
-// CHECK-NEXT:     %arg0[@$temp_0][@reciprocal] in Entire
+// CHECK-NEXT:     %arg0[@$temp_0][@reciprocal] in TypeC:[ 1, 2013265920 ]
 // CHECK-NEXT:     %arg0[@$temp][@$super] in Entire
 // CHECK-NEXT:     %arg0[@$temp][@reg] in Entire
 // CHECK-NEXT:     %arg0[@v][@$super] in Entire
-// CHECK-NEXT:     %arg0[@v][@reciprocal] in Entire
-// CHECK-NEXT:     %arg1[0] in Entire
+// CHECK-NEXT:     %arg0[@v][@reciprocal] in TypeC:[ 1, 2013265920 ]
+// CHECK-NEXT:     %arg1[0] in TypeC:[ 1, 2013265920 ]
 // CHECK-NEXT:     %arg1[1] in Entire
 // CHECK-NEXT: }
 

--- a/test/Analysis/interval_analysis/interprocedural_subcomponent.llzk
+++ b/test/Analysis/interval_analysis/interprocedural_subcomponent.llzk
@@ -1,0 +1,203 @@
+// RUN: llzk-opt -split-input-file -llzk-print-interval-analysis %s 2>&1 | FileCheck %s --implicit-check-not=error:
+
+module attributes {llzk.lang} {
+  struct.def @Child {
+    struct.member @out : !felt.type
+
+    function.def @compute() -> !struct.type<@Child> {
+      %self = struct.new : !struct.type<@Child>
+      function.return %self : !struct.type<@Child>
+    }
+
+    function.def @constrain(%self: !struct.type<@Child>) {
+      %out = struct.readm %self[@out] : !struct.type<@Child>, !felt.type
+      %seven = felt.const 7
+      constrain.eq %out, %seven : !felt.type
+      function.return
+    }
+  }
+
+  struct.def @Parent {
+    struct.member @child : !struct.type<@Child>
+
+    function.def @compute() -> !struct.type<@Parent> {
+      %self = struct.new : !struct.type<@Parent>
+      function.return %self : !struct.type<@Parent>
+    }
+
+    function.def @constrain(%self: !struct.type<@Parent>) {
+      %child = struct.readm %self[@child] : !struct.type<@Parent>, !struct.type<@Child>
+      function.call @Child::@constrain(%child) : (!struct.type<@Child>) -> ()
+      function.return
+    }
+  }
+}
+
+// CHECK-LABEL: @Child StructIntervals {
+// CHECK-NEXT:     %arg0[@out] in Degenerate(7)
+// CHECK-NEXT: }
+
+// CHECK-LABEL: @Parent StructIntervals {
+// CHECK-NEXT:     %arg0[@child][@out] in Degenerate(7)
+// CHECK-NEXT: }
+
+// -----
+
+module attributes {llzk.lang} {
+  struct.def @ArrayChild {
+    struct.member @out : !felt.type
+
+    function.def @compute() -> !struct.type<@ArrayChild> {
+      %self = struct.new : !struct.type<@ArrayChild>
+      function.return %self : !struct.type<@ArrayChild>
+    }
+
+    function.def @constrain(%self: !struct.type<@ArrayChild>) {
+      %out = struct.readm %self[@out] : !struct.type<@ArrayChild>, !felt.type
+      %seven = felt.const 7
+      constrain.eq %out, %seven : !felt.type
+      function.return
+    }
+  }
+
+  struct.def @DynamicArrayParent {
+    struct.member @children : !array.type<2 x !struct.type<@ArrayChild>>
+
+    function.def @compute(%idx: index) -> !struct.type<@DynamicArrayParent> {
+      %self = struct.new : !struct.type<@DynamicArrayParent>
+      function.return %self : !struct.type<@DynamicArrayParent>
+    }
+
+    function.def @constrain(%self: !struct.type<@DynamicArrayParent>, %idx: index) {
+      %children = struct.readm %self[@children] : !struct.type<@DynamicArrayParent>, !array.type<2 x !struct.type<@ArrayChild>>
+      %child = array.read %children[%idx] : !array.type<2 x !struct.type<@ArrayChild>>, !struct.type<@ArrayChild>
+      function.call @ArrayChild::@constrain(%child) : (!struct.type<@ArrayChild>) -> ()
+      function.return
+    }
+  }
+
+  struct.def @ArrayConsumer {
+    function.def @compute(%items: !array.type<2 x !struct.type<@ArrayChild>>) -> !struct.type<@ArrayConsumer> {
+      %self = struct.new : !struct.type<@ArrayConsumer>
+      function.return %self : !struct.type<@ArrayConsumer>
+    }
+
+    function.def @constrain(%self: !struct.type<@ArrayConsumer>, %items: !array.type<2 x !struct.type<@ArrayChild>>) {
+      %c0 = arith.constant 0 : index
+      %item = array.read %items[%c0] : !array.type<2 x !struct.type<@ArrayChild>>, !struct.type<@ArrayChild>
+      function.call @ArrayChild::@constrain(%item) : (!struct.type<@ArrayChild>) -> ()
+      function.return
+    }
+  }
+
+  struct.def @ArrayValueParent {
+    struct.member @left : !struct.type<@ArrayChild>
+    struct.member @right : !struct.type<@ArrayChild>
+    struct.member @consumer : !struct.type<@ArrayConsumer>
+
+    function.def @compute() -> !struct.type<@ArrayValueParent> {
+      %self = struct.new : !struct.type<@ArrayValueParent>
+      function.return %self : !struct.type<@ArrayValueParent>
+    }
+
+    function.def @constrain(%self: !struct.type<@ArrayValueParent>) {
+      %left = struct.readm %self[@left] : !struct.type<@ArrayValueParent>, !struct.type<@ArrayChild>
+      %right = struct.readm %self[@right] : !struct.type<@ArrayValueParent>, !struct.type<@ArrayChild>
+      %items = array.new %left, %right : !array.type<2 x !struct.type<@ArrayChild>>
+      %consumer = struct.readm %self[@consumer] : !struct.type<@ArrayValueParent>, !struct.type<@ArrayConsumer>
+      function.call @ArrayConsumer::@constrain(%consumer, %items) : (!struct.type<@ArrayConsumer>, !array.type<2 x !struct.type<@ArrayChild>>) -> ()
+      function.return
+    }
+  }
+}
+
+// CHECK-LABEL: @ArrayChild StructIntervals {
+// CHECK-NEXT:     %arg0[@out] in Degenerate(7)
+// CHECK-NEXT: }
+
+// CHECK-LABEL: @DynamicArrayParent StructIntervals {
+// CHECK-NEXT:     %arg0[@children][0][@out] in Entire
+// CHECK-NEXT:     %arg0[@children][1][@out] in Entire
+// CHECK-NEXT:     %arg1 in Entire
+// CHECK-NEXT: }
+
+// CHECK-LABEL: @ArrayConsumer StructIntervals {
+// CHECK-DAG:     %arg1[0][@out] in Degenerate(7)
+// CHECK-DAG:     %arg1[1][@out] in Entire
+// CHECK: }
+
+// CHECK-LABEL: @ArrayValueParent StructIntervals {
+// CHECK-DAG:     %arg0[@left][@out] in Degenerate(7)
+// CHECK-DAG:     %arg0[@right][@out] in Entire
+// CHECK: }
+
+// -----
+
+module attributes {llzk.lang} {
+  poly.template @TUnknownTargetParent {
+    poly.param @T
+
+    struct.def @UnknownTargetParent {
+      struct.member @child : !poly.tvar<@T>
+
+      function.def @compute(%child: !poly.tvar<@T>) -> !struct.type<@TUnknownTargetParent::@UnknownTargetParent<[@T]>> {
+        %self = struct.new : !struct.type<@TUnknownTargetParent::@UnknownTargetParent<[@T]>>
+        struct.writem %self[@child] = %child : !struct.type<@TUnknownTargetParent::@UnknownTargetParent<[@T]>>, !poly.tvar<@T>
+        function.return %self : !struct.type<@TUnknownTargetParent::@UnknownTargetParent<[@T]>>
+      }
+
+      function.def @constrain(%self: !struct.type<@TUnknownTargetParent::@UnknownTargetParent<[@T]>>, %x: !felt.type) {
+        %child = struct.readm %self[@child] : !struct.type<@TUnknownTargetParent::@UnknownTargetParent<[@T]>>, !poly.tvar<@T>
+        function.call @T::@constrain(%child, %x) : (!poly.tvar<@T>, !felt.type) -> ()
+        function.return
+      }
+    }
+  }
+}
+
+// CHECK-LABEL: @UnknownTargetParent StructIntervals {
+// CHECK-DAG:     %arg0[@child] in Entire
+// CHECK-DAG:     %arg1 in Entire
+// CHECK: }
+
+// -----
+
+module attributes {llzk.lang} {
+  struct.def @CycleA {
+    struct.member @out : !felt.type
+
+    function.def @compute() -> !struct.type<@CycleA> {
+      %self = struct.new : !struct.type<@CycleA>
+      function.return %self : !struct.type<@CycleA>
+    }
+
+    function.def @constrain(%self: !struct.type<@CycleA>, %other: !struct.type<@CycleB>) {
+      function.call @CycleB::@constrain(%other, %self) : (!struct.type<@CycleB>, !struct.type<@CycleA>) -> ()
+      function.return
+    }
+  }
+
+  struct.def @CycleB {
+    struct.member @out : !felt.type
+
+    function.def @compute() -> !struct.type<@CycleB> {
+      %self = struct.new : !struct.type<@CycleB>
+      function.return %self : !struct.type<@CycleB>
+    }
+
+    function.def @constrain(%self: !struct.type<@CycleB>, %other: !struct.type<@CycleA>) {
+      function.call @CycleA::@constrain(%other, %self) : (!struct.type<@CycleA>, !struct.type<@CycleB>) -> ()
+      function.return
+    }
+  }
+}
+
+// CHECK-LABEL: @CycleA StructIntervals {
+// CHECK-DAG:     %arg0[@out] in Entire
+// CHECK-DAG:     %arg1[@out] in Entire
+// CHECK: }
+
+// CHECK-LABEL: @CycleB StructIntervals {
+// CHECK-DAG:     %arg0[@out] in Entire
+// CHECK-DAG:     %arg1[@out] in Entire
+// CHECK: }


### PR DESCRIPTION
## Summary

Addresses #136 by allowing interval analysis to reuse concrete subcomponent constrain summaries.

This updates interval analysis to:
- propagate callee struct constrain intervals into parent-visible refs
- translate child `SourceRef`s through call operands before merging
- merge only when translation resolves to one concrete parent ref
- conservatively skip unresolved/template calls, dynamic multi-ref translations, and recursive constrain cycles

The patch also adds regression coverage for direct subcomponent propagation, static vs dynamic array paths, unresolved template calls, and mutual constrain-call cycles.

## Testing

- `git diff --check`
- `nix --extra-experimental-features "nix-command flakes" build -L --extra-substituters https://veridise-public.cachix.org --extra-trusted-public-keys "veridise-public.cachix.org-1:FvpZ8GzAj1mmJA5PnO9UgKxC6CQdmPutuIKtEpGmeig=" .#debugClang`

Result:
- Lit: 201 passed, 6 unsupported, 2 expected failures, 0 failed
- Gtests: 1086/1086 passed
