### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Ensure core-devs are tagged in all ready PRs
+*   @project-llzk/core-devs


### PR DESCRIPTION
Add a `CODEOWNERS` file so that @project-llzk/core-devs will automatically be tagged on reviews.