### PR TITLE
Bounds-check constant `array.len` dimensions

### DIFF
--- a/changelogs/unreleased/array-len-dim-bounds.yaml
+++ b/changelogs/unreleased/array-len-dim-bounds.yaml
@@ -1,0 +1,2 @@
+fixed:
+  - Bounds-check constant `array.len` dimensions before array-to-scalar lowering

--- a/lib/Dialect/Array/IR/Ops.cpp
+++ b/lib/Dialect/Array/IR/Ops.cpp
@@ -20,6 +20,7 @@
 #include <mlir/IR/Attributes.h>
 #include <mlir/IR/BuiltinOps.h>
 #include <mlir/IR/Diagnostics.h>
+#include <mlir/IR/Matchers.h>
 #include <mlir/IR/OwningOpRef.h>
 #include <mlir/IR/SymbolTable.h>
 #include <mlir/IR/ValueRange.h>
@@ -27,6 +28,8 @@
 
 #include <llvm/ADT/ArrayRef.h>
 #include <llvm/ADT/Twine.h>
+
+#include <optional>
 
 // TableGen'd implementation files
 #include "llzk/Dialect/Array/IR/OpInterfaces.cpp.inc"
@@ -469,7 +472,27 @@ LogicalResult InsertArrayOp::verify() {
 
 LogicalResult ArrayLengthOp::verifySymbolUses(SymbolTableCollection &tables) {
   // Ensure any SymbolRef used in the type are valid
-  return verifyTypeResolution(tables, *this, getArrRefType());
+  if (failed(verifyTypeResolution(tables, *this, getArrRefType()))) {
+    return failure();
+  }
+
+  llvm::APInt dim;
+  if (!matchPattern(getDim(), m_ConstantInt(&dim))) {
+    return success();
+  }
+
+  std::optional<int64_t> idx = dim.trySExtValue();
+  if (!idx || *idx < 0 || static_cast<size_t>(*idx) >= getArrRefType().getDimensionSizes().size()) {
+    InFlightDiagnostic diag = emitOpError("dimension index ");
+    if (idx) {
+      diag << *idx;
+    } else {
+      diag << "outside the supported index range";
+    }
+    return diag << " is out of bounds for array rank "
+                << getArrRefType().getDimensionSizes().size();
+  }
+  return success();
 }
 
 } // namespace llzk::array

--- a/lib/Dialect/Array/IR/Ops.cpp
+++ b/lib/Dialect/Array/IR/Ops.cpp
@@ -482,15 +482,16 @@ LogicalResult ArrayLengthOp::verifySymbolUses(SymbolTableCollection &tables) {
   }
 
   std::optional<int64_t> idx = dim.trySExtValue();
-  if (!idx || *idx < 0 || static_cast<size_t>(*idx) >= getArrRefType().getDimensionSizes().size()) {
+  size_t rank = getArrRefType().getDimensionSizes().size();
+  if (!idx || *idx < 0 || llzk::checkedCast<size_t>(*idx) >= rank) {
     InFlightDiagnostic diag = emitOpError("dimension index ");
     if (idx) {
       diag << *idx;
     } else {
       diag << "outside the supported index range";
     }
-    return diag << " is out of bounds for array rank "
-                << getArrRefType().getDimensionSizes().size();
+    diag << " is out of bounds for array rank " << rank;
+    return diag.attachNote(getArrRef().getLoc()).append("array defined here");
   }
   return success();
 }

--- a/lib/Dialect/Array/Transforms/ArrayToScalarPass.cpp
+++ b/lib/Dialect/Array/Transforms/ArrayToScalarPass.cpp
@@ -546,8 +546,16 @@ public:
     if (splittableArray(baseArrType)) {
       llvm::APInt idxAP;
       if (mlir::matchPattern(dimIdx, mlir::m_ConstantInt(&idxAP))) {
-        size_t idx = llzk::checkedCast<size_t>(idxAP.getZExtValue());
-        Attribute dimSizeAttr = baseArrType.getDimensionSizes()[idx];
+        std::optional<int64_t> signedIdx = idxAP.trySExtValue();
+        if (!signedIdx || *signedIdx < 0) {
+          return std::nullopt;
+        }
+        size_t idx = llzk::checkedCast<size_t>(*signedIdx);
+        ArrayRef<Attribute> dimSizes = baseArrType.getDimensionSizes();
+        if (idx >= dimSizes.size()) {
+          return std::nullopt;
+        }
+        Attribute dimSizeAttr = dimSizes[idx];
         if (mlir::matchPattern(dimSizeAttr, mlir::m_ConstantInt(&idxAP))) {
           return idxAP;
         }

--- a/test/Dialect/Array/array_len_fail.llzk
+++ b/test/Dialect/Array/array_len_fail.llzk
@@ -39,3 +39,21 @@ function.def @wrong_index_type(%a: !array.type<2,3 x !felt.type>) -> index {
   %x = array.len %a, %0 : !array.type<2,3 x !felt.type>
   function.return %x: index
 }
+// -----
+
+function.def @out_of_bounds_constant_dim() -> index {
+  %a = array.new : !array.type<2,3 x !felt.type>
+  %0 = arith.constant 2 : index
+  // expected-error@+1 {{dimension index 2 is out of bounds for array rank 2}}
+  %x = array.len %a, %0 : !array.type<2,3 x !felt.type>
+  function.return %x: index
+}
+// -----
+
+function.def @negative_constant_dim() -> index {
+  %a = array.new : !array.type<2,3 x !felt.type>
+  %0 = arith.constant -1 : index
+  // expected-error@+1 {{dimension index -1 is out of bounds for array rank 2}}
+  %x = array.len %a, %0 : !array.type<2,3 x !felt.type>
+  function.return %x: index
+}

--- a/test/Dialect/Array/array_len_fail.llzk
+++ b/test/Dialect/Array/array_len_fail.llzk
@@ -42,6 +42,7 @@ function.def @wrong_index_type(%a: !array.type<2,3 x !felt.type>) -> index {
 // -----
 
 function.def @out_of_bounds_constant_dim() -> index {
+  // expected-note@+1 {{array defined here}}
   %a = array.new : !array.type<2,3 x !felt.type>
   %0 = arith.constant 2 : index
   // expected-error@+1 {{dimension index 2 is out of bounds for array rank 2}}
@@ -51,6 +52,7 @@ function.def @out_of_bounds_constant_dim() -> index {
 // -----
 
 function.def @negative_constant_dim() -> index {
+  // expected-note@+1 {{array defined here}}
   %a = array.new : !array.type<2,3 x !felt.type>
   %0 = arith.constant -1 : index
   // expected-error@+1 {{dimension index -1 is out of bounds for array rank 2}}

--- a/test/Transforms/ArrayToScalar/array_len_invalid_dim_no_crash.llzk
+++ b/test/Transforms/ArrayToScalar/array_len_invalid_dim_no_crash.llzk
@@ -1,14 +1,14 @@
-// RUN: llzk-opt --mlir-very-unsafe-disable-verifier-on-parsing --verify-each=false -llzk-array-to-scalar %s | FileCheck %s
+// RUN: llzk-opt -llzk-array-to-scalar %s -verify-diagnostics
 
-// This intentionally malformed IR checks that array-to-scalar defensively avoids
-// indexing past the array rank if verification is bypassed.
+// This intentionally malformed IR checks that array-to-scalar reports the
+// expected verifier diagnostic for an invalid constant dimension.
 module attributes {llzk.lang} {
   function.def @bad_len() -> index {
+    // expected-note@+1 {{array defined here}}
     %a = array.new : !array.type<2,3 x !felt.type>
     %dim = arith.constant 2 : index
+    // expected-error@+1 {{dimension index 2 is out of bounds for array rank 2}}
     %len = array.len %a, %dim : !array.type<2,3 x !felt.type>
     function.return %len : index
   }
 }
-
-// CHECK: array.len

--- a/test/Transforms/ArrayToScalar/array_len_invalid_dim_no_crash.llzk
+++ b/test/Transforms/ArrayToScalar/array_len_invalid_dim_no_crash.llzk
@@ -1,0 +1,14 @@
+// RUN: llzk-opt --mlir-very-unsafe-disable-verifier-on-parsing --verify-each=false -llzk-array-to-scalar %s | FileCheck %s
+
+// This intentionally malformed IR checks that array-to-scalar defensively avoids
+// indexing past the array rank if verification is bypassed.
+module attributes {llzk.lang} {
+  function.def @bad_len() -> index {
+    %a = array.new : !array.type<2,3 x !felt.type>
+    %dim = arith.constant 2 : index
+    %len = array.len %a, %dim : !array.type<2,3 x !felt.type>
+    function.return %len : index
+  }
+}
+
+// CHECK: array.len


### PR DESCRIPTION
Fixes #482.

## Summary
- Reject statically known `array.len` dimension operands outside `[0, rank)`
- Preserve support for dynamic dimension operands
- Add a defensive bounds check in `-llzk-array-to-scalar` before reading array dimension sizes
- Add verifier regressions for out-of-range and negative constant dimensions
- Add a no-crash array-to-scalar regression for malformed IR when verification is bypassed

## Testing
- Rebuilt `llzk-opt`
- Ran `test/Dialect/Array/array_len_fail.llzk`
- Ran `test/Dialect/Array/array_len_pass.llzk`
- Ran `test/Transforms/ArrayToScalar/array_to_scalar.llzk`
- Ran `test/Transforms/ArrayToScalar/array_len_invalid_dim_no_crash.llzk`
- Ran `git diff --check`
