### PR TITLE
Keep nondet ops distinct in duplicate elimination

### DIFF
--- a/changelogs/unreleased/fix-duplicate-op-elim-nondet.yaml
+++ b/changelogs/unreleased/fix-duplicate-op-elim-nondet.yaml
@@ -1,0 +1,2 @@
+fixed:
+  - Fixed `llzk-duplicate-op-elim` so it does not merge distinct `llzk.nondet` witness values.

--- a/lib/Transforms/LLZKRedundantOperationEliminationPass.cpp
+++ b/lib/Transforms/LLZKRedundantOperationEliminationPass.cpp
@@ -15,6 +15,7 @@
 #include "llzk/Analysis/CallGraphAnalyses.h"
 #include "llzk/Dialect/Bool/IR/Ops.h"
 #include "llzk/Dialect/Constrain/IR/Ops.h"
+#include "llzk/Dialect/LLZK/IR/Ops.h"
 #include "llzk/Dialect/Struct/IR/Dialect.h"
 #include "llzk/Transforms/LLZKTransformationPasses.h"
 #include "llzk/Util/SymbolHelper.h"
@@ -220,15 +221,17 @@ class RedundantOperationEliminationPass
 
       // Case 2: An equivalent operation A has already been performed before
       // the current operation B and A dominates B.
-      OperationComparator comp(op, map);
-      if (auto it = uniqueOps.find(comp);
-          it != uniqueOps.end() && domInfo.dominates(it->getOp(), op)) {
-        redundantOps.push_back(op);
-        for (unsigned opNum = 0; opNum < op->getNumResults(); opNum++) {
-          map[op->getResult(opNum)] = it->getOp()->getResult(opNum);
+      if (!isa<NonDetOp>(op)) {
+        OperationComparator comp(op, map);
+        if (auto it = uniqueOps.find(comp);
+            it != uniqueOps.end() && domInfo.dominates(it->getOp(), op)) {
+          redundantOps.push_back(op);
+          for (unsigned opNum = 0; opNum < op->getNumResults(); opNum++) {
+            map[op->getResult(opNum)] = it->getOp()->getResult(opNum);
+          }
+        } else {
+          uniqueOps.insert(comp);
         }
-      } else {
-        uniqueOps.insert(comp);
       }
 
       return WalkResult::advance();

--- a/test/Transforms/RedundantAndUnusedElim/redundant_op_pass.llzk
+++ b/test/Transforms/RedundantAndUnusedElim/redundant_op_pass.llzk
@@ -299,3 +299,30 @@ module attributes {llzk.lang} {
 // CHECK-NEXT:      function.return
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
+
+// -----
+
+module attributes {llzk.lang} {
+  struct.def @NondetCSE {
+    function.def @compute(%a: !felt.type, %b: !felt.type) -> !struct.type<@NondetCSE> {
+      %self = struct.new : !struct.type<@NondetCSE>
+      function.return %self : !struct.type<@NondetCSE>
+    }
+
+    function.def @constrain(%self: !struct.type<@NondetCSE>, %a: !felt.type, %b: !felt.type) {
+      %x = llzk.nondet : !felt.type
+      %y = llzk.nondet : !felt.type
+      constrain.eq %x, %a : !felt.type
+      constrain.eq %y, %b : !felt.type
+      function.return
+    }
+  }
+}
+
+// CHECK-LABEL: struct.def @NondetCSE {
+// CHECK:        function.def @constrain
+// CHECK-NEXT:     %[[NONDET_0:.*]] = llzk.nondet : !felt.type
+// CHECK-NEXT:     %[[NONDET_1:.*]] = llzk.nondet : !felt.type
+// CHECK-NEXT:     constrain.eq %[[NONDET_0]], %{{.*}} : !felt.type, !felt.type
+// CHECK-NEXT:     constrain.eq %[[NONDET_1]], %{{.*}} : !felt.type, !felt.type
+// CHECK-NEXT:     function.return


### PR DESCRIPTION
Fixes #488.

## Summary
- Skip duplicate-op elimination for `llzk.nondet`
- Add a regression proving distinct nondet witnesses remain distinct
- Add an unreleased changelog entry

## Testing
- `clang-format`
- `git diff --check`
