### PR TITLE
Fix nested member aux rebuild

### DIFF
--- a/changelogs/unreleased/fix-nested-member-aux-rebuild.yaml
+++ b/changelogs/unreleased/fix-nested-member-aux-rebuild.yaml
@@ -1,0 +1,2 @@
+fixed:
+  - Fixed compute-side auxiliary reconstruction for nested member reads during poly and R1CS lowering.

--- a/lib/Transforms/LLZKLoweringUtils.cpp
+++ b/lib/Transforms/LLZKLoweringUtils.cpp
@@ -35,14 +35,15 @@ Value rebuildExprInCompute(
 
   if (auto barg = llvm::dyn_cast<BlockArgument>(val)) {
     unsigned index = barg.getArgNumber();
-    Value mapped = computeFunc.getArgument(index - 1);
+    Value mapped =
+        index == 0 ? computeFunc.getSelfValueFromCompute() : computeFunc.getArgument(index - 1);
     return memo[val] = mapped;
   }
 
   if (auto readOp = val.getDefiningOp<MemberReadOp>()) {
-    Value self = computeFunc.getSelfValueFromCompute();
+    Value component = rebuildExprInCompute(readOp.getComponent(), computeFunc, builder, memo);
     Value rebuilt = builder.create<MemberReadOp>(
-        readOp.getLoc(), readOp.getType(), self, readOp.getMemberNameAttr().getAttr()
+        readOp.getLoc(), readOp.getType(), component, readOp.getMemberNameAttr().getAttr()
     );
     return memo[val] = rebuilt;
   }

--- a/test/Transforms/PolyLowering/poly_lowering_pass_deg2.llzk
+++ b/test/Transforms/PolyLowering/poly_lowering_pass_deg2.llzk
@@ -193,11 +193,12 @@ module attributes {llzk.lang} {
 // CHECK:           struct.member @val : !felt.type
 // CHECK:           function.def @compute(%[[VAL_0:.*]]: !felt.type, %[[VAL_1:.*]]: !felt.type) -> !struct.type<@Mod1> attributes {function.allow_witness} {
 // CHECK:             %[[VAL_2:.*]] = struct.new : <@Mod1>
-// CHECK:             %[[VAL_3:.*]] = struct.readm %[[VAL_2]][@val] : <@Mod1>, !felt.type
-// CHECK:             %[[VAL_4:.*]] = felt.mul %[[VAL_3]], %[[VAL_3]] : !felt.type, !felt.type
-// CHECK:             struct.writem %[[VAL_2]][@__llzk_poly_lowering_pass_aux_member_1] = %[[VAL_4]] : <@Mod1>, !felt.type
-// CHECK:             %[[VAL_5:.*]] = felt.mul %[[VAL_0]], %[[VAL_1]] : !felt.type, !felt.type
-// CHECK:             struct.writem %[[VAL_2]][@__llzk_poly_lowering_pass_aux_member_2] = %[[VAL_5]] : <@Mod1>, !felt.type
+// CHECK:             %[[CHILD:.*]] = struct.readm %[[VAL_2]][@mod2] : <@Mod1>, !struct.type<@Mod2>
+// CHECK:             %[[CHILD_VAL:.*]] = struct.readm %[[CHILD]][@val] : <@Mod2>, !felt.type
+// CHECK:             %[[AUX_VAL:.*]] = felt.mul %[[CHILD_VAL]], %[[CHILD_VAL]] : !felt.type, !felt.type
+// CHECK:             struct.writem %[[VAL_2]][@__llzk_poly_lowering_pass_aux_member_1] = %[[AUX_VAL]] : <@Mod1>, !felt.type
+// CHECK:             %[[ARG_PRODUCT:.*]] = felt.mul %[[VAL_0]], %[[VAL_1]] : !felt.type, !felt.type
+// CHECK:             struct.writem %[[VAL_2]][@__llzk_poly_lowering_pass_aux_member_2] = %[[ARG_PRODUCT]] : <@Mod1>, !felt.type
 // CHECK:             function.return %[[VAL_2]] : !struct.type<@Mod1>
 // CHECK:           }
 // CHECK:           function.def @constrain(%[[VAL_6:.*]]: !struct.type<@Mod1>, %[[VAL_7:.*]]: !felt.type, %[[VAL_8:.*]]: !felt.type) attributes {function.allow_constraint} {


### PR DESCRIPTION
## Summary

Fix compute-side auxiliary expression reconstruction for nested member reads.

`rebuildExprInCompute` previously rebuilt every `MemberReadOp` from the enclosing compute function's `%self`. That preserved the member name but discarded the original read component, so a constrain-side path such as `self.mod2.val` could be rebuilt in `compute()` as `self.val`.

This updates the helper to:

- map constrain `%self` to compute `%self`
- recursively rebuild the original `MemberReadOp` component
- create the rebuilt read from that preserved component path

Fixes #491.

## Testing

Updated the existing poly-lowering FileCheck case with both `Mod1.@val` and `Mod2.@val`.

The test now requires compute-side aux reconstruction to read:

```mlir
%child = struct.readm %self[@mod2]
%child_val = struct.readm %child[@val]
```

instead of incorrectly reading direct `Mod1.@val`.
