### PR TITLE
Reject unsupported zero-result ops in ZKLean conversion

### DIFF
--- a/backends/zklean/lib/Conversions/LLZKToZKLean.cpp
+++ b/backends/zklean/lib/Conversions/LLZKToZKLean.cpp
@@ -421,9 +421,10 @@ static bool convertFunction(llzk::function::FuncDefOp func, LLZKToZKLeanState &s
 
 // Convert all eligible LLZK functions into a new ZKLean module.
 // Emits struct defs first, then lowers each function via `convertFunction`.
-static LogicalResult convertModule(ModuleOp source, ModuleOp dest, bool &hadError) {
+static LogicalResult convertModule(ModuleOp source, ModuleOp dest) {
   OpBuilder builder(dest.getContext());
   auto zkType = llzk::zkexpr::ZKExprType::get(dest.getContext());
+  bool hadError = false;
   bool createdAny = false;
 
   LLZKToZKLeanState state {dest, builder, zkType, hadError};
@@ -436,11 +437,11 @@ static LogicalResult convertModule(ModuleOp source, ModuleOp dest, bool &hadErro
   });
 
   if (!hadError && !createdAny) {
-    source.emitError("failed to produce ZKLean module").report();
+    source.emitError("did not produce any ops in ZKLean module").report();
     hadError = true;
   }
 
-  return success(!hadError && createdAny);
+  return failure(hadError);
 }
 
 // Pass wrapper that appends a converted ZKLean module to the source.
@@ -461,8 +462,7 @@ class PassImpl : public zklean::impl::ConvertLLZKToZKLeanPassBase<PassImpl> {
       zkLeanModule->setAttr(llzk::LANG_ATTR_NAME, lang);
     }
 
-    bool hadError = false;
-    if (failed(convertModule(original, zkLeanModule, hadError))) {
+    if (failed(convertModule(original, zkLeanModule))) {
       signalPassFailure();
       return;
     }

--- a/backends/zklean/lib/Conversions/LLZKToZKLean.cpp
+++ b/backends/zklean/lib/Conversions/LLZKToZKLean.cpp
@@ -421,11 +421,10 @@ static bool convertFunction(llzk::function::FuncDefOp func, LLZKToZKLeanState &s
 
 // Convert all eligible LLZK functions into a new ZKLean module.
 // Emits struct defs first, then lowers each function via `convertFunction`.
-static LogicalResult convertModule(ModuleOp source, ModuleOp dest) {
+static LogicalResult convertModule(ModuleOp source, ModuleOp dest, bool &hadError) {
   OpBuilder builder(dest.getContext());
   auto zkType = llzk::zkexpr::ZKExprType::get(dest.getContext());
   bool createdAny = false;
-  bool hadError = false;
 
   LLZKToZKLeanState state {dest, builder, zkType, hadError};
   emitZKLeanStructDefs(source, state);
@@ -435,6 +434,11 @@ static LogicalResult convertModule(ModuleOp source, ModuleOp dest) {
       createdAny = true;
     }
   });
+
+  if (!hadError && !createdAny) {
+    source.emitError("failed to produce ZKLean module").report();
+    hadError = true;
+  }
 
   return success(!hadError && createdAny);
 }
@@ -457,8 +461,8 @@ class PassImpl : public zklean::impl::ConvertLLZKToZKLeanPassBase<PassImpl> {
       zkLeanModule->setAttr(llzk::LANG_ATTR_NAME, lang);
     }
 
-    if (failed(convertModule(original, zkLeanModule))) {
-      original.emitError("failed to produce ZKLean module").report();
+    bool hadError = false;
+    if (failed(convertModule(original, zkLeanModule, hadError))) {
       signalPassFailure();
       return;
     }

--- a/backends/zklean/lib/Conversions/LLZKToZKLean.cpp
+++ b/backends/zklean/lib/Conversions/LLZKToZKLean.cpp
@@ -377,10 +377,13 @@ struct FunctionConverter {
       state.builder.create<llzk::zkbuilder::ConstrainEqOp>(eq.getLoc(), stateType, lhs, rhs);
       return;
     }
-    if (op->getNumResults() != 0) {
-      op->emitError("unsupported op in ZKLean conversion").report();
-      state.hadError = true;
+    if (auto ret = dyn_cast<llzk::function::ReturnOp>(op)) {
+      if (ret.getOperands().empty()) {
+        return;
+      }
     }
+    op->emitError("unsupported op in ZKLean conversion").report();
+    state.hadError = true;
   }
 
   // Emit the final `mlir::func::ReturnOp` for the new function.
@@ -396,6 +399,11 @@ struct FunctionConverter {
 // Skips non-constrain functions and stops early on errors.
 static bool convertFunction(llzk::function::FuncDefOp func, LLZKToZKLeanState &state) {
   if (state.hadError || !shouldConvertFunc(func)) {
+    return false;
+  }
+  if (!func.getBody().hasOneBlock()) {
+    func.emitError("ZKLean conversion only supports single-block functions").report();
+    state.hadError = true;
     return false;
   }
 

--- a/changelogs/unreleased/reject-unsupported-zklean-ops.yaml
+++ b/changelogs/unreleased/reject-unsupported-zklean-ops.yaml
@@ -1,0 +1,2 @@
+fixed:
+  - Reject unsupported zero-result operations during LLZK-to-ZKLean conversion instead of silently dropping them.

--- a/test/Conversions/llzk_to_zklean_no_eligible_fail.llzk
+++ b/test/Conversions/llzk_to_zklean_no_eligible_fail.llzk
@@ -1,0 +1,8 @@
+// RUN: llzk-opt --convert-llzk-to-zklean -verify-diagnostics %s
+
+// expected-error@+1 {{failed to produce ZKLean module}}
+module attributes {llzk.lang = "llzk"} {
+  function.def @helper() {
+    function.return
+  }
+}

--- a/test/Conversions/llzk_to_zklean_no_eligible_fail.llzk
+++ b/test/Conversions/llzk_to_zklean_no_eligible_fail.llzk
@@ -1,6 +1,6 @@
 // RUN: llzk-opt --convert-llzk-to-zklean -verify-diagnostics %s
 
-// expected-error@+1 {{failed to produce ZKLean module}}
+// expected-error@+1 {{did not produce any ops in ZKLean module}}
 module attributes {llzk.lang = "llzk"} {
   function.def @helper() {
     function.return

--- a/test/Conversions/llzk_to_zklean_unsupported_zero_result_fail.llzk
+++ b/test/Conversions/llzk_to_zklean_unsupported_zero_result_fail.llzk
@@ -1,7 +1,5 @@
 // RUN: llzk-opt -split-input-file --convert-llzk-to-zklean -verify-diagnostics %s
 
-// -----
-
 module attributes {llzk.lang = "llzk"} {
   function.def @contains(%xs: !array.type<2 x !felt.type<"babybear">>, %x: !felt.type<"babybear">) attributes {function.allow_constraint} {
     // expected-error@+1 {{unsupported op in ZKLean conversion}}

--- a/test/Conversions/llzk_to_zklean_unsupported_zero_result_fail.llzk
+++ b/test/Conversions/llzk_to_zklean_unsupported_zero_result_fail.llzk
@@ -39,3 +39,15 @@ module attributes {llzk.lang = "llzk"} {
     function.return %x : !felt.type<"babybear">
   }
 }
+
+// -----
+
+module attributes {llzk.lang = "llzk"} {
+  // expected-error@+1 {{ZKLean conversion only supports single-block functions}}
+  function.def @multi_block(%x: !felt.type<"babybear">) attributes {function.allow_constraint} {
+    cf.br ^next
+  ^next:
+    constrain.eq %x, %x : !felt.type<"babybear">
+    function.return
+  }
+}

--- a/test/Conversions/llzk_to_zklean_unsupported_zero_result_fail.llzk
+++ b/test/Conversions/llzk_to_zklean_unsupported_zero_result_fail.llzk
@@ -1,0 +1,46 @@
+// RUN: llzk-opt -split-input-file --convert-llzk-to-zklean -verify-diagnostics %s
+
+// -----
+
+// expected-error@+1 {{failed to produce ZKLean module}}
+module attributes {llzk.lang = "llzk"} {
+  function.def @contains(%xs: !array.type<2 x !felt.type<"babybear">>, %x: !felt.type<"babybear">) attributes {function.allow_constraint} {
+    // expected-error@+1 {{unsupported op in ZKLean conversion}}
+    constrain.in %xs, %x : !array.type<2 x !felt.type<"babybear">>, !felt.type<"babybear">
+    function.return
+  }
+}
+
+// -----
+
+// expected-error@+1 {{failed to produce ZKLean module}}
+module attributes {llzk.lang = "llzk"} {
+  struct.def @Child {
+    struct.member @out : !felt.type<"babybear">
+    function.def @compute(%x: !felt.type<"babybear">) -> !struct.type<@Child> {
+      %self = struct.new : !struct.type<@Child>
+      struct.writem %self[@out] = %x : !struct.type<@Child>, !felt.type<"babybear">
+      function.return %self : !struct.type<@Child>
+    }
+    function.def @constrain(%self: !struct.type<@Child>, %x: !felt.type<"babybear">) attributes {function.allow_constraint} {
+      %one = felt.const 1 <"babybear">
+      constrain.eq %x, %one : !felt.type<"babybear">
+      function.return
+    }
+  }
+  function.def @parent(%child: !struct.type<@Child>, %x: !felt.type<"babybear">) attributes {function.allow_constraint} {
+    // expected-error@+1 {{unsupported op in ZKLean conversion}}
+    function.call @Child::@constrain(%child, %x) : (!struct.type<@Child>, !felt.type<"babybear">) -> ()
+    function.return
+  }
+}
+
+// -----
+
+// expected-error@+1 {{failed to produce ZKLean module}}
+module attributes {llzk.lang = "llzk"} {
+  function.def @returns_value(%x: !felt.type<"babybear">) -> !felt.type<"babybear"> attributes {function.allow_constraint} {
+    // expected-error@+1 {{unsupported op in ZKLean conversion}}
+    function.return %x : !felt.type<"babybear">
+  }
+}

--- a/test/Conversions/llzk_to_zklean_unsupported_zero_result_fail.llzk
+++ b/test/Conversions/llzk_to_zklean_unsupported_zero_result_fail.llzk
@@ -2,7 +2,6 @@
 
 // -----
 
-// expected-error@+1 {{failed to produce ZKLean module}}
 module attributes {llzk.lang = "llzk"} {
   function.def @contains(%xs: !array.type<2 x !felt.type<"babybear">>, %x: !felt.type<"babybear">) attributes {function.allow_constraint} {
     // expected-error@+1 {{unsupported op in ZKLean conversion}}
@@ -13,7 +12,6 @@ module attributes {llzk.lang = "llzk"} {
 
 // -----
 
-// expected-error@+1 {{failed to produce ZKLean module}}
 module attributes {llzk.lang = "llzk"} {
   struct.def @Child {
     struct.member @out : !felt.type<"babybear">
@@ -37,7 +35,6 @@ module attributes {llzk.lang = "llzk"} {
 
 // -----
 
-// expected-error@+1 {{failed to produce ZKLean module}}
 module attributes {llzk.lang = "llzk"} {
   function.def @returns_value(%x: !felt.type<"babybear">) -> !felt.type<"babybear"> attributes {function.allow_constraint} {
     // expected-error@+1 {{unsupported op in ZKLean conversion}}


### PR DESCRIPTION
### Summary

Fixes #495.

`--convert-llzk-to-zklean` previously rejected unsupported operations only when they produced SSA results. Unsupported zero-result operations could therefore fall through without diagnostics, allowing constraint operations such as `constrain.in` or zero-result `function.call` to be omitted from the emitted ZKLean module while conversion still succeeded.

This change makes the converter fail on every unhandled operation except an empty `function.return`.

### Changes

- Treat only zero-operand `function.return` as an intentional no-op during LLZK-to-ZKLean conversion.
- Emit an unsupported-op diagnostic for all other unhandled operations, including zero-result ops.
- Reject multi-block LLZK functions before conversion, since the converter only processes a single block.
- Add regression coverage for:
  - `constrain.in`
  - zero-result constraint helper calls
  - result-bearing `function.return`

### Testing

- `git diff --check`
