### PR TITLE
Validate function.res_name attributes

### DIFF
--- a/changelogs/unreleased/function-res-name-attrs.yaml
+++ b/changelogs/unreleased/function-res-name-attrs.yaml
@@ -1,0 +1,2 @@
+added:
+  - Add verifier support for `function.res_name` result attributes.

--- a/include/llzk/Dialect/Function/IR/Ops.h
+++ b/include/llzk/Dialect/Function/IR/Ops.h
@@ -33,6 +33,9 @@ namespace llzk::function {
 /// Attribute name for source-level function argument names.
 constexpr char ARG_NAME_ATTR_NAME[] = "function.arg_name";
 
+/// Attribute name for source-level function result names.
+constexpr char RES_NAME_ATTR_NAME[] = "function.res_name";
+
 /// @brief Kinds of functions in LLZK.
 enum class FunctionKind : std::uint8_t {
   /// @brief Function within a struct named `FUNC_NAME_COMPUTE`.

--- a/include/llzk/Dialect/Function/IR/Ops.td
+++ b/include/llzk/Dialect/Function/IR/Ops.td
@@ -68,6 +68,11 @@ def FuncDefOp
     names for generated arguments, such as `input[0]` for array elements or
     `self.member` for struct members.
 
+    Function results may similarly carry an optional `function.res_name`
+    attribute. The value must be a non-empty, untyped `StringAttr`, all attached
+    result names must be unique within the function, and the attribute is only
+    valid on function results.
+
     Example:
 
     ```llzk
@@ -79,7 +84,8 @@ def FuncDefOp
 
     // A function that returns its argument twice:
     function.def @count(%x: !felt.type {function.arg_name = "x"})
-        -> (!felt.type, !felt.type) {
+        -> (!felt.type {function.res_name = "first"},
+            !felt.type {function.res_name = "second"}) {
       function.return %x, %x: !felt.type, !felt.type
     }
 

--- a/lib/Dialect/Function/IR/Ops.cpp
+++ b/lib/Dialect/Function/IR/Ops.cpp
@@ -269,13 +269,41 @@ LogicalResult FuncDefOp::verify() {
   if ((*this)->hasAttr(ARG_NAME_ATTR_NAME)) {
     return emitOpError() << "'" << ARG_NAME_ATTR_NAME << "' is only valid on function arguments";
   }
+  if ((*this)->hasAttr(RES_NAME_ATTR_NAME)) {
+    return emitOpError() << "'" << RES_NAME_ATTR_NAME << "' is only valid on function results";
+  }
 
   if (ArrayAttr resAttrs = getAllResultAttrs()) {
+    llvm::DenseSet<StringAttr> seenNames;
     for (auto [i, attr] : llvm::enumerate(resAttrs)) {
       auto dictAttr = llvm::dyn_cast<DictionaryAttr>(attr);
       if (dictAttr && dictAttr.contains(ARG_NAME_ATTR_NAME)) {
         return emitOpError() << "'" << ARG_NAME_ATTR_NAME
                              << "' is only valid on function arguments but found on result " << i;
+      }
+      if (!dictAttr) {
+        continue;
+      }
+      Attribute resNameAttr = dictAttr.get(RES_NAME_ATTR_NAME);
+      if (!resNameAttr) {
+        continue;
+      }
+      auto resName = llvm::dyn_cast<StringAttr>(resNameAttr);
+      if (!resName) {
+        return emitOpError() << "'" << RES_NAME_ATTR_NAME << "' on result " << i
+                             << " must be a string attribute";
+      }
+      if (!llvm::isa<NoneType>(resName.getType())) {
+        return emitOpError() << "'" << RES_NAME_ATTR_NAME << "' on result " << i
+                             << " must not have an explicit type";
+      }
+      if (resName.getValue().empty()) {
+        return emitOpError() << "'" << RES_NAME_ATTR_NAME << "' on result " << i
+                             << " must not be empty";
+      }
+      if (!seenNames.insert(resName).second) {
+        return emitOpError() << "duplicate '" << RES_NAME_ATTR_NAME << "' value \""
+                             << resName.getValue() << "\" on result " << i;
       }
     }
   }
@@ -286,6 +314,10 @@ LogicalResult FuncDefOp::verify() {
       auto dictAttr = llvm::dyn_cast<DictionaryAttr>(attr);
       if (!dictAttr) {
         continue;
+      }
+      if (dictAttr.contains(RES_NAME_ATTR_NAME)) {
+        return emitOpError() << "'" << RES_NAME_ATTR_NAME
+                             << "' is only valid on function results but found on argument " << i;
       }
       Attribute argNameAttr = dictAttr.get(ARG_NAME_ATTR_NAME);
       if (!argNameAttr) {

--- a/test/Dialect/Function/functions_fail.llzk
+++ b/test/Dialect/Function/functions_fail.llzk
@@ -40,6 +40,24 @@ function.def private @bad_arg_name_function_attr(i1) attributes {function.arg_na
 // expected-error@+1 {{'function.def' op 'function.arg_name' is only valid on function arguments but found on result 0}}
 function.def private @bad_arg_name_result_attr() -> (i1 {function.arg_name = "out"})
 // -----
+// expected-error@+1 {{'function.def' op 'function.res_name' on result 0 must be a string attribute}}
+function.def private @bad_res_name_non_string() -> (i1 {function.res_name = 7 : i64})
+// -----
+// expected-error@+1 {{'function.def' op 'function.res_name' on result 0 must not be empty}}
+function.def private @bad_res_name_empty() -> (i1 {function.res_name = ""})
+// -----
+// expected-error@+1 {{'function.def' op 'function.res_name' on result 0 must not have an explicit type}}
+function.def private @bad_res_name_typed_string() -> (i1 {function.res_name = "out" : i1})
+// -----
+// expected-error@+1 {{'function.def' op duplicate 'function.res_name' value "out" on result 1}}
+function.def private @bad_res_name_duplicate() -> (i1 {function.res_name = "out"}, index {function.res_name = "out"})
+// -----
+// expected-error@+1 {{'function.def' op 'function.res_name' is only valid on function results}}
+function.def private @bad_res_name_function_attr() -> i1 attributes {function.res_name = "out"}
+// -----
+// expected-error@+1 {{'function.def' op 'function.res_name' is only valid on function results but found on argument 0}}
+function.def private @bad_res_name_arg_attr(%x: i1 {function.res_name = "in"})
+// -----
 function.def @fail_07() {
   // expected-error@+1 {{'function.def' op expects parent op to be one of 'builtin.module, struct.def, poly.template'}}
   function.def @inner() {

--- a/test/Dialect/Function/functions_pass.llzk
+++ b/test/Dialect/Function/functions_pass.llzk
@@ -69,3 +69,15 @@ function.def @example_arg_name_body(
 function.def private @example_arg_name_with_pub(%x: i1 {function.arg_name = "public", llzk.pub})
 //CHECK-LABEL:  function.def private @example_arg_name_with_pub(i1 {function.arg_name = "public", llzk.pub})
 // -----
+
+function.def private @example_res_name_external() -> (i1 {function.res_name = "out"})
+//CHECK-LABEL:  function.def private @example_res_name_external() -> (i1 {function.res_name = "out"})
+// -----
+
+function.def @example_res_name_body(%x: i1) -> (i1 {function.res_name = "out"}) {
+  function.return %x : i1
+}
+//CHECK-LABEL:  function.def @example_res_name_body(%arg0: i1) -> (i1 {function.res_name = "out"}) {
+//CHECK-NEXT:     function.return %arg0 : i1
+//CHECK-NEXT:   }
+// -----


### PR DESCRIPTION
## Summary

Add verifier support for `function.res_name` result attributes.

This mirrors the existing `function.arg_name` validation rules for function results:
- `function.res_name` is only valid on function results
- values must be non-empty, untyped `StringAttr`s
- result names must be unique within the function

Fixes #490.

## Testing

- `git diff --check`
