### PR TITLE
Scalarize branch-dominated array reads

### DIFF
--- a/changelogs/unreleased/array-to-scalar-branch-dominated-write.yaml
+++ b/changelogs/unreleased/array-to-scalar-branch-dominated-write.yaml
@@ -1,0 +1,2 @@
+fixed:
+  - Scalarize array reads inside branches when a matching array write dominates the branch.

--- a/lib/Dialect/Array/Transforms/ArrayToScalarPass.cpp
+++ b/lib/Dialect/Array/Transforms/ArrayToScalarPass.cpp
@@ -69,6 +69,7 @@
 #include "llzk/Util/Compare.h"
 #include "llzk/Util/Concepts.h"
 
+#include <mlir/Dialect/SCF/IR/SCF.h>
 #include <mlir/IR/BuiltinOps.h>
 #include <mlir/Pass/PassManager.h>
 #include <mlir/Transforms/DialectConversion.h>
@@ -840,6 +841,105 @@ step2(ModuleOp modOp, SymbolTableCollection &symTables, const MemberReplacementM
   return applyFullConversion(modOp, target, std::move(patterns));
 }
 
+static bool mayWriteToIndex(WriteArrayOp writeOp, ArrayAttr index) {
+  ArrayAttr writeIndex = writeOp.indexOperandsToAttributeArray();
+  return !writeIndex || writeIndex == index;
+}
+
+static bool hasEarlierWriteInBlock(ReadArrayOp readOp, ArrayAttr readIndex) {
+  Value arrRef = readOp.getArrRef();
+  for (Operation &op : *readOp->getBlock()) {
+    if (&op == readOp.getOperation()) {
+      return false;
+    }
+
+    if (auto writeOp = dyn_cast<WriteArrayOp>(&op)) {
+      if (writeOp.getArrRef() == arrRef && mayWriteToIndex(writeOp, readIndex)) {
+        return true;
+      }
+      continue;
+    }
+
+    bool foundWrite = false;
+    op.walk([&](WriteArrayOp writeOp) {
+      if (writeOp.getArrRef() == arrRef && mayWriteToIndex(writeOp, readIndex)) {
+        foundWrite = true;
+      }
+    });
+    if (foundWrite) {
+      return true;
+    }
+  }
+  return false;
+}
+
+static std::optional<WriteArrayOp> findPrecedingWriteForIfRead(ReadArrayOp readOp) {
+  ArrayAttr readIndex = readOp.indexOperandsToAttributeArray();
+  if (!readIndex) {
+    return std::nullopt;
+  }
+
+  auto ifOp = readOp->getParentOfType<scf::IfOp>();
+  if (!ifOp || readOp->getBlock()->getParentOp() != ifOp.getOperation()) {
+    return std::nullopt;
+  }
+  if (hasEarlierWriteInBlock(readOp, readIndex)) {
+    return std::nullopt;
+  }
+
+  Block *ifBlock = ifOp->getBlock();
+  if (!ifBlock) {
+    return std::nullopt;
+  }
+
+  Value arrRef = readOp.getArrRef();
+  WriteArrayOp replacement;
+  for (Operation &op : *ifBlock) {
+    if (&op == ifOp.getOperation()) {
+      break;
+    }
+
+    if (auto writeOp = dyn_cast<WriteArrayOp>(&op)) {
+      if (writeOp.getArrRef() != arrRef) {
+        continue;
+      }
+
+      ArrayAttr writeIndex = writeOp.indexOperandsToAttributeArray();
+      if (!writeIndex) {
+        replacement = WriteArrayOp();
+      } else if (writeIndex == readIndex) {
+        replacement = writeOp;
+      }
+      continue;
+    }
+
+    op.walk([&](WriteArrayOp writeOp) {
+      if (writeOp.getArrRef() == arrRef && mayWriteToIndex(writeOp, readIndex)) {
+        replacement = WriteArrayOp();
+      }
+    });
+  }
+
+  if (!replacement) {
+    return std::nullopt;
+  }
+  return replacement;
+}
+
+static void forwardPrecedingArrayWritesIntoIf(ModuleOp modOp) {
+  SmallVector<std::pair<ReadArrayOp, Value>> replacements;
+  modOp.walk([&](ReadArrayOp readOp) {
+    if (std::optional<WriteArrayOp> writeOp = findPrecedingWriteForIfRead(readOp)) {
+      replacements.emplace_back(readOp, (*writeOp).getRvalue());
+    }
+  });
+
+  for (auto [readOp, value] : replacements) {
+    readOp.getResult().replaceAllUsesWith(value);
+    readOp.erase();
+  }
+}
+
 LogicalResult splitArrayCreateInit(ModuleOp modOp) {
   SymbolTableCollection symTables;
   MemberReplacementMap memberRepMap;
@@ -880,6 +980,8 @@ class ArrayToScalarPass : public llzk::array::impl::ArrayToScalarPassBase<ArrayT
       signalPassFailure();
       return;
     }
+    forwardPrecedingArrayWritesIntoIf(module);
+
     OpPassManager nestedPM(ModuleOp::getOperationName());
     // Use SROA (Destructurable* interfaces) to split each array with linear size N into N arrays of
     // size 1. This is necessary because the mem2reg pass cannot deal with indexing and splitting up

--- a/test/Transforms/ArrayToScalar/branch_dominated_write.llzk
+++ b/test/Transforms/ArrayToScalar/branch_dominated_write.llzk
@@ -1,0 +1,74 @@
+// RUN: llzk-opt -split-input-file -llzk-array-to-scalar %s | FileCheck --enable-var-scope %s
+
+!F = !felt.type
+module attributes {llzk.lang} {
+  struct.def @A {
+    struct.member @sums_0 : !F
+
+    function.def @constrain(%self: !struct.type<@A>, %arg1: !F, %arg2: !F, %cond: i1) {
+      %c0 = arith.constant 0 : index
+      %array = array.new  : !array.type<1 x !F>
+      %stored = struct.readm %self[@sums_0] : !struct.type<@A>, !F
+      array.write %array[%c0] = %stored : !array.type<1 x !F>, !F
+      scf.if %cond {
+        %sum = felt.add %arg1, %arg2 : !F, !F
+        %read = array.read %array[%c0] : !array.type<1 x !F>, !F
+        constrain.eq %sum, %read : !F, !F
+      } else {
+        %sum = felt.add %arg1, %arg1 : !F, !F
+        %read = array.read %array[%c0] : !array.type<1 x !F>, !F
+        constrain.eq %sum, %read : !F, !F
+      }
+      function.return
+    }
+  }
+}
+
+// CHECK-LABEL: function.def @constrain(
+// CHECK: %[[STORED:[0-9a-zA-Z_\.]+]] = struct.readm
+// CHECK-NOT: array.
+// CHECK: scf.if
+// CHECK-NOT: array.read
+// CHECK-NOT: array.write
+// CHECK: %[[THEN_SUM:[0-9a-zA-Z_\.]+]] = felt.add
+// CHECK-NEXT: constrain.eq %[[THEN_SUM]], %[[STORED]]
+// CHECK: } else {
+// CHECK-NOT: array.read
+// CHECK-NOT: array.write
+// CHECK: %[[ELSE_SUM:[0-9a-zA-Z_\.]+]] = felt.add
+// CHECK-NEXT: constrain.eq %[[ELSE_SUM]], %[[STORED]]
+
+// -----
+
+!F = !felt.type
+module attributes {llzk.lang} {
+  struct.def @A {
+    struct.member @sums_0 : !F
+
+    function.def @do_not_forward_after_branch_write(%self: !struct.type<@A>, %arg1: !F, %arg2: !F, %cond: i1) {
+      %c0 = arith.constant 0 : index
+      %array = array.new  : !array.type<1 x !F>
+      %stored = struct.readm %self[@sums_0] : !struct.type<@A>, !F
+      array.write %array[%c0] = %stored : !array.type<1 x !F>, !F
+      scf.if %cond {
+        array.write %array[%c0] = %arg1 : !array.type<1 x !F>, !F
+      }
+      scf.if %cond {
+        %read = array.read %array[%c0] : !array.type<1 x !F>, !F
+        constrain.eq %arg2, %read : !F, !F
+      } else {
+        %read = array.read %array[%c0] : !array.type<1 x !F>, !F
+        constrain.eq %arg2, %read : !F, !F
+      }
+      function.return
+    }
+  }
+}
+
+// CHECK-LABEL: function.def @do_not_forward_after_branch_write(
+// CHECK: scf.if
+// CHECK: array.write
+// CHECK: scf.if
+// CHECK: array.read
+// CHECK: } else {
+// CHECK: array.read


### PR DESCRIPTION
## Summary
- forward array reads inside `scf.if` branches when a matching same-index write occurs before the branch
- conservatively skip forwarding when branch-local, intervening, or unknown-index writes may affect the read
- add positive and negative ArrayToScalar regression coverage

Fixes #494.

## Validation
- `git diff --check HEAD~1 HEAD`
