### PR TITLE
avoid duplication in `FuncDefOp::verify()` with helper

### DIFF
--- a/lib/Analysis/IntervalAnalysisPass.cpp
+++ b/lib/Analysis/IntervalAnalysisPass.cpp
@@ -83,7 +83,7 @@ protected:
       );
     } else {
       modOp->emitWarning() << "could not detect a unique module field; falling back to '"
-                           << selectedField.get().name() << "'";
+                           << selectedField.get().name() << '\'';
       LLVM_DEBUG(
           llvm::dbgs() << "[IntervalAnalysisPrinterPass] no explicit or detectable module field; "
                           "falling back to '"

--- a/lib/Analysis/LightweightSignalEquivalenceAnalysis.cpp
+++ b/lib/Analysis/LightweightSignalEquivalenceAnalysis.cpp
@@ -51,7 +51,7 @@ Value replaceReadWithWrite(Value v) {
 bool LightweightSignalEquivalenceAnalysis::areSignalsEquivalent(Value v1, Value v2) {
   v1 = replaceReadWithWrite(v1);
   v2 = replaceReadWithWrite(v2);
-  LLVM_DEBUG(llvm::outs() << "Asking for equivalence between " << v1 << " and " << v2 << "\n");
+  LLVM_DEBUG(llvm::outs() << "Asking for equivalence between " << v1 << " and " << v2 << '\n');
   if (equivalentSignals.isEquivalent(v1, v2)) {
     return true;
   }

--- a/lib/Analysis/MemberOverwriteAnalysis.cpp
+++ b/lib/Analysis/MemberOverwriteAnalysis.cpp
@@ -87,7 +87,7 @@ LogicalResult MemberOverwriteAnalysis::visitOperation(
 ) {
   ChangeResult result = after->join(before);
 
-  LLVM_DEBUG(llvm::dbgs() << "Visiting operation: " << *op << ": " << before << "\n");
+  LLVM_DEBUG(llvm::dbgs() << "Visiting operation: " << *op << ": " << before << '\n');
 
   if (auto write = dyn_cast<MemberWriteOp>(op)) {
     result |= after->record(write);

--- a/lib/Dialect/Function/IR/OpTraits.cpp
+++ b/lib/Dialect/Function/IR/OpTraits.cpp
@@ -54,7 +54,7 @@ LogicalResult verifyNotFieldNativeTraitImpl(Operation *op) {
   }
   return op->emitOpError() << "only valid within a '" << FuncDefOp::getOperationName() << "' with '"
                            << AllowNonNativeFieldOpsAttr::name << "' attribute or a '"
-                           << llzk::polymorphic::TemplateExprOp::getOperationName() << "'";
+                           << llzk::polymorphic::TemplateExprOp::getOperationName() << '\'';
 }
 
 } // namespace llzk::function

--- a/lib/Dialect/Function/IR/Ops.cpp
+++ b/lib/Dialect/Function/IR/Ops.cpp
@@ -69,6 +69,56 @@ verifyTypeResolution(SymbolTableCollection &tables, Operation *origin, FunctionT
       tables, origin, ArrayRef<ArrayRef<Type>> {funcType.getInputs(), funcType.getResults()}
   );
 }
+
+/// Verify the name attributes on function arguments or results.
+/// ownAttrName/ownLabel describe the attribute valid on this side (e.g. RES_NAME_ATTR_NAME /
+/// "result"), while crossAttrName/crossLabel describe the attribute that belongs on the other
+/// side and must not appear here.
+static LogicalResult verifyArgOrResNameAttrs(
+    ArrayAttr attrs, StringRef ownAttrName, StringRef crossAttrName, StringRef ownLabel,
+    StringRef crossLabel, EmitErrorFn emitFn
+) {
+  if (!attrs) {
+    return success();
+  }
+  llvm::DenseSet<StringAttr> seenNames;
+  for (auto [i, attr] : llvm::enumerate(attrs)) {
+    auto dictAttr = llvm::dyn_cast<DictionaryAttr>(attr);
+    if (!dictAttr) {
+      continue;
+    }
+    if (dictAttr.contains(crossAttrName)) {
+      return emitFn().append(
+          '\'', crossAttrName, "' is only valid on function ", crossLabel, "s but found on ",
+          ownLabel, ' ', i
+      );
+    }
+    Attribute nameAttr = dictAttr.get(ownAttrName);
+    if (!nameAttr) {
+      continue;
+    }
+    auto name = llvm::dyn_cast<StringAttr>(nameAttr);
+    if (!name) {
+      return emitFn().append(
+          '\'', ownAttrName, "' on ", ownLabel, ' ', i, " must be a string attribute"
+      );
+    }
+    if (!llvm::isa<NoneType>(name.getType())) {
+      return emitFn().append(
+          '\'', ownAttrName, "' on ", ownLabel, ' ', i, " must not have an explicit type"
+      );
+    }
+    if (name.getValue().empty()) {
+      return emitFn().append('\'', ownAttrName, "' on ", ownLabel, ' ', i, " must not be empty");
+    }
+    if (!seenNames.insert(name).second) {
+      return emitFn().append(
+          "duplicate '", ownAttrName, "' value \"", name.getValue(), "\" on ", ownLabel, ' ', i
+      );
+    }
+  }
+  return success();
+}
 } // namespace
 
 //===----------------------------------------------------------------------===//
@@ -267,80 +317,24 @@ LogicalResult FuncDefOp::verify() {
   OwningEmitErrorFn emitErrorFunc = getEmitOpErrFn(this);
 
   if ((*this)->hasAttr(ARG_NAME_ATTR_NAME)) {
-    return emitOpError() << "'" << ARG_NAME_ATTR_NAME << "' is only valid on function arguments";
+    return emitErrorFunc() << '\'' << ARG_NAME_ATTR_NAME << "' is only valid on function arguments";
   }
   if ((*this)->hasAttr(RES_NAME_ATTR_NAME)) {
-    return emitOpError() << "'" << RES_NAME_ATTR_NAME << "' is only valid on function results";
+    return emitErrorFunc() << '\'' << RES_NAME_ATTR_NAME << "' is only valid on function results";
   }
 
-  if (ArrayAttr resAttrs = getAllResultAttrs()) {
-    llvm::DenseSet<StringAttr> seenNames;
-    for (auto [i, attr] : llvm::enumerate(resAttrs)) {
-      auto dictAttr = llvm::dyn_cast<DictionaryAttr>(attr);
-      if (dictAttr && dictAttr.contains(ARG_NAME_ATTR_NAME)) {
-        return emitOpError() << "'" << ARG_NAME_ATTR_NAME
-                             << "' is only valid on function arguments but found on result " << i;
-      }
-      if (!dictAttr) {
-        continue;
-      }
-      Attribute resNameAttr = dictAttr.get(RES_NAME_ATTR_NAME);
-      if (!resNameAttr) {
-        continue;
-      }
-      auto resName = llvm::dyn_cast<StringAttr>(resNameAttr);
-      if (!resName) {
-        return emitOpError() << "'" << RES_NAME_ATTR_NAME << "' on result " << i
-                             << " must be a string attribute";
-      }
-      if (!llvm::isa<NoneType>(resName.getType())) {
-        return emitOpError() << "'" << RES_NAME_ATTR_NAME << "' on result " << i
-                             << " must not have an explicit type";
-      }
-      if (resName.getValue().empty()) {
-        return emitOpError() << "'" << RES_NAME_ATTR_NAME << "' on result " << i
-                             << " must not be empty";
-      }
-      if (!seenNames.insert(resName).second) {
-        return emitOpError() << "duplicate '" << RES_NAME_ATTR_NAME << "' value \""
-                             << resName.getValue() << "\" on result " << i;
-      }
-    }
+  if (failed(verifyArgOrResNameAttrs(
+          getAllResultAttrs(), RES_NAME_ATTR_NAME, ARG_NAME_ATTR_NAME, "result", "argument",
+          emitErrorFunc
+      ))) {
+    return failure();
   }
 
-  if (ArrayAttr argAttrs = getAllArgAttrs()) {
-    llvm::DenseSet<StringAttr> seenNames;
-    for (auto [i, attr] : llvm::enumerate(argAttrs)) {
-      auto dictAttr = llvm::dyn_cast<DictionaryAttr>(attr);
-      if (!dictAttr) {
-        continue;
-      }
-      if (dictAttr.contains(RES_NAME_ATTR_NAME)) {
-        return emitOpError() << "'" << RES_NAME_ATTR_NAME
-                             << "' is only valid on function results but found on argument " << i;
-      }
-      Attribute argNameAttr = dictAttr.get(ARG_NAME_ATTR_NAME);
-      if (!argNameAttr) {
-        continue;
-      }
-      auto argName = llvm::dyn_cast<StringAttr>(argNameAttr);
-      if (!argName) {
-        return emitOpError() << "'" << ARG_NAME_ATTR_NAME << "' on argument " << i
-                             << " must be a string attribute";
-      }
-      if (!llvm::isa<NoneType>(argName.getType())) {
-        return emitOpError() << "'" << ARG_NAME_ATTR_NAME << "' on argument " << i
-                             << " must not have an explicit type";
-      }
-      if (argName.getValue().empty()) {
-        return emitOpError() << "'" << ARG_NAME_ATTR_NAME << "' on argument " << i
-                             << " must not be empty";
-      }
-      if (!seenNames.insert(argName).second) {
-        return emitOpError() << "duplicate '" << ARG_NAME_ATTR_NAME << "' value \""
-                             << argName.getValue() << "\" on argument " << i;
-      }
-    }
+  if (failed(verifyArgOrResNameAttrs(
+          getAllArgAttrs(), ARG_NAME_ATTR_NAME, RES_NAME_ATTR_NAME, "argument", "result",
+          emitErrorFunc
+      ))) {
+    return failure();
   }
 
   // Ensure that only valid LLZK types are used for arguments and return. Additionally, the struct

--- a/lib/Dialect/Global/IR/Ops.cpp
+++ b/lib/Dialect/Global/IR/Ops.cpp
@@ -86,7 +86,7 @@ inline InFlightDiagnosticWrapper reportMismatch(
     EmitErrorFn errFn, Type rootType, const Twine &aspect, const Twine &expected, const Twine &found
 ) {
   return errFn().append(
-      "with type ", rootType, " expected ", expected, " ", aspect, " but found ", found
+      "with type ", rootType, " expected ", expected, ' ', aspect, " but found ", found
   );
 }
 

--- a/lib/Dialect/Polymorphic/Transforms/FlatteningPass.cpp
+++ b/lib/Dialect/Polymorphic/Transforms/FlatteningPass.cpp
@@ -1461,7 +1461,7 @@ struct AffineMapFolder {
             // Diagnostic remark: could be removed for release builds if too noisy
             op->emitRemark()
                 .append(
-                    "Cannot fold affine_map for ", aspect, " ", out.paramsOfStructTy.size(),
+                    "Cannot fold affine_map for ", aspect, ' ', out.paramsOfStructTy.size(),
                     " due to divide by 0 or modulus with negative divisor"
                 )
                 .report();
@@ -1471,7 +1471,7 @@ struct AffineMapFolder {
             // Diagnostic remark: could be removed for release builds if too noisy
             op->emitRemark()
                 .append(
-                    "Folding affine_map for ", aspect, " ", out.paramsOfStructTy.size(), " failed"
+                    "Folding affine_map for ", aspect, ' ', out.paramsOfStructTy.size(), " failed"
                 )
                 .report();
             return failure();
@@ -1480,7 +1480,7 @@ struct AffineMapFolder {
             // Diagnostic remark: could be removed for release builds if too noisy
             op->emitRemark()
                 .append(
-                    "Folding affine_map for ", aspect, " ", out.paramsOfStructTy.size(),
+                    "Folding affine_map for ", aspect, ' ', out.paramsOfStructTy.size(),
                     " produced ", result.size(), " results but expected 1"
                 )
                 .report();

--- a/lib/Dialect/SMT/SMTOps.cpp
+++ b/lib/Dialect/SMT/SMTOps.cpp
@@ -268,7 +268,7 @@ ParseResult RepeatOp::parse(OpAsmParser &parser, OperationState &result) {
 }
 
 void RepeatOp::print(OpAsmPrinter &printer) {
-  printer << " " << getCount() << " times " << getInput();
+  printer << ' ' << getCount() << " times " << getInput();
   printer.printOptionalAttrDict((*this)->getAttrs());
   printer << " : " << getInput().getType();
 }
@@ -303,7 +303,7 @@ OpFoldResult IntConstantOp::fold(FoldAdaptor adaptor) {
 }
 
 void IntConstantOp::print(OpAsmPrinter &p) {
-  p << " " << getValue();
+  p << ' ' << getValue();
   p.printOptionalAttrDict((*this)->getAttrs(), /*elidedAttrs=*/ {"value"});
 }
 

--- a/lib/Dialect/Verif/IR/Ops.cpp
+++ b/lib/Dialect/Verif/IR/Ops.cpp
@@ -431,7 +431,7 @@ LogicalResult ContractOp::verify() {
   OwningEmitErrorFn emitErrorFunc = getEmitOpErrFn(this);
 
   if ((*this)->hasAttr(ARG_NAME_ATTR_NAME)) {
-    return emitOpError() << "'" << ARG_NAME_ATTR_NAME << "' is only valid on function arguments";
+    return emitOpError() << '\'' << ARG_NAME_ATTR_NAME << "' is only valid on function arguments";
   }
 
   if (ArrayAttr argAttrs = getAllArgAttrs()) {
@@ -447,15 +447,15 @@ LogicalResult ContractOp::verify() {
       }
       auto argName = llvm::dyn_cast<StringAttr>(argNameAttr);
       if (!argName) {
-        return emitOpError() << "'" << ARG_NAME_ATTR_NAME << "' on argument " << i
+        return emitOpError() << '\'' << ARG_NAME_ATTR_NAME << "' on argument " << i
                              << " must be a string attribute";
       }
       if (!llvm::isa<NoneType>(argName.getType())) {
-        return emitOpError() << "'" << ARG_NAME_ATTR_NAME << "' on argument " << i
+        return emitOpError() << '\'' << ARG_NAME_ATTR_NAME << "' on argument " << i
                              << " must not have an explicit type";
       }
       if (argName.getValue().empty()) {
-        return emitOpError() << "'" << ARG_NAME_ATTR_NAME << "' on argument " << i
+        return emitOpError() << '\'' << ARG_NAME_ATTR_NAME << "' on argument " << i
                              << " must not be empty";
       }
       if (!seenNames.insert(argName).second) {

--- a/lib/Transforms/LLZKComputeConstrainToProductPass.cpp
+++ b/lib/Transforms/LLZKComputeConstrainToProductPass.cpp
@@ -188,7 +188,7 @@ LogicalResult ProductAligner::alignCalls(FuncDefOp product) {
       llvm::outs() << "Asking for equivalence between calls\n"
                    << compute << "\nand\n"
                    << constrain << "\n\n";
-      llvm::outs() << "In block:\n\n" << *compute->getBlock() << "\n";
+      llvm::outs() << "In block:\n\n" << *compute->getBlock() << '\n';
     });
 
     auto computeStruct = getPrefixAsSymbolRefAttr(compute.getCallee());

--- a/tools/llzk-witgen/ExecutionEngineBackend.cpp
+++ b/tools/llzk-witgen/ExecutionEngineBackend.cpp
@@ -347,7 +347,7 @@ static void maybeDumpModule(ModuleOp moduleOp, bool enabled, llvm::StringRef tit
   }
   llvm::errs() << title << ":\n";
   moduleOp.print(llvm::errs());
-  llvm::errs() << "\n";
+  llvm::errs() << '\n';
 }
 
 } // namespace


### PR DESCRIPTION
- avoid duplication in `FuncDefOp::verify()` by adding a helper function
- replace single size-1 strings with equivalent character