### PR TITLE
Lower composite poly roots

### DIFF
--- a/changelogs/unreleased/lower-composite-poly-roots.yaml
+++ b/changelogs/unreleased/lower-composite-poly-roots.yaml
@@ -1,0 +1,2 @@
+fixed:
+  - Lower high-degree composite felt expressions in the poly-lowering pass

--- a/changelogs/unreleased/lower-composite-poly-roots.yaml
+++ b/changelogs/unreleased/lower-composite-poly-roots.yaml
@@ -1,2 +1,2 @@
 fixed:
-  - Lower high-degree composite felt expressions in the poly-lowering pass
+  - Lower high-degree felt.add, felt.sub, and felt.neg equality roots and nonlinear struct constrain call arguments in the poly-lowering pass

--- a/include/llzk/Transforms/LLZKTransformationPasses.td
+++ b/include/llzk/Transforms/LLZKTransformationPasses.td
@@ -59,6 +59,10 @@ def PolyLoweringPass : LLZKPass<"llzk-poly-lowering-pass"> {
     Rewrites constraint expressions into an (observationally) equivalent system where the degree of
     every polynomial is less than or equal to the specified maximum.
 
+    High-degree subexpressions are factored into auxiliary struct members. The pass also recurses
+    through degree-neutral roots such as `felt.add`, `felt.sub`, and `felt.neg`, so composite
+    equality operands and struct constrain call arguments satisfy their degree bounds.
+
     This pass is best used as part of the `-llzk-full-poly-lowering` pipeline, which includes
     additional cleanup passes to ensure correctness and optimal performance.
   }];

--- a/lib/Transforms/LLZKPolyLoweringPass.cpp
+++ b/lib/Transforms/LLZKPolyLoweringPass.cpp
@@ -121,6 +121,47 @@ private:
       return val;
     }
 
+    if (auto addOp = val.getDefiningOp<AddFeltOp>()) {
+      Value lhs = lowerExpression(
+          addOp.getLhs(), structDef, constrainFunc, degreeMemo, rewrites, auxAssignments
+      );
+      Value rhs = lowerExpression(
+          addOp.getRhs(), structDef, constrainFunc, degreeMemo, rewrites, auxAssignments
+      );
+
+      addOp.getLhsMutable().set(lhs);
+      addOp.getRhsMutable().set(rhs);
+      degreeMemo[val] = std::max(getDegree(lhs, degreeMemo), getDegree(rhs, degreeMemo));
+      rewrites[val] = val;
+      return val;
+    }
+
+    if (auto subOp = val.getDefiningOp<SubFeltOp>()) {
+      Value lhs = lowerExpression(
+          subOp.getLhs(), structDef, constrainFunc, degreeMemo, rewrites, auxAssignments
+      );
+      Value rhs = lowerExpression(
+          subOp.getRhs(), structDef, constrainFunc, degreeMemo, rewrites, auxAssignments
+      );
+
+      subOp.getLhsMutable().set(lhs);
+      subOp.getRhsMutable().set(rhs);
+      degreeMemo[val] = std::max(getDegree(lhs, degreeMemo), getDegree(rhs, degreeMemo));
+      rewrites[val] = val;
+      return val;
+    }
+
+    if (auto negOp = val.getDefiningOp<NegFeltOp>()) {
+      Value operand = lowerExpression(
+          negOp.getOperand(), structDef, constrainFunc, degreeMemo, rewrites, auxAssignments
+      );
+
+      negOp.getOperandMutable().set(operand);
+      degreeMemo[val] = getDegree(operand, degreeMemo);
+      rewrites[val] = val;
+      return val;
+    }
+
     if (auto mulOp = val.getDefiningOp<MulFeltOp>()) {
       // Recursively lower operands first
       Value lhs = lowerExpression(
@@ -206,7 +247,7 @@ private:
       return mulVal;
     }
 
-    // For non-mul ops, leave untouched (they're degree-1 safe)
+    // Unsupported roots are left unchanged.
     rewrites[val] = val;
     return val;
   }

--- a/lib/Transforms/LLZKPolyLoweringPass.cpp
+++ b/lib/Transforms/LLZKPolyLoweringPass.cpp
@@ -121,6 +121,7 @@ private:
       return val;
     }
 
+    // Degree-neutral roots can still contain over-degree operands.
     auto lowerBinaryRoot = [&](auto op) -> Value {
       Value lhs = lowerExpression(
           op.getLhs(), structDef, constrainFunc, degreeMemo, rewrites, auxAssignments
@@ -263,6 +264,8 @@ private:
       return loweredVal;
     }
 
+    // Callees only receive SSA values, not the caller expression tree, so nonlinear
+    // call arguments must be represented by an auxiliary member read.
     std::string auxName = AUXILIARY_MEMBER_PREFIX + std::to_string(this->auxCounter++);
     MemberDefOp auxMember = addAuxMember(structDef, auxName);
 

--- a/lib/Transforms/LLZKPolyLoweringPass.cpp
+++ b/lib/Transforms/LLZKPolyLoweringPass.cpp
@@ -121,34 +121,31 @@ private:
       return val;
     }
 
-    if (auto addOp = val.getDefiningOp<AddFeltOp>()) {
+    auto lowerBinaryRoot = [&](auto op) -> Value {
       Value lhs = lowerExpression(
-          addOp.getLhs(), structDef, constrainFunc, degreeMemo, rewrites, auxAssignments
+          op.getLhs(), structDef, constrainFunc, degreeMemo, rewrites, auxAssignments
       );
       Value rhs = lowerExpression(
-          addOp.getRhs(), structDef, constrainFunc, degreeMemo, rewrites, auxAssignments
+          op.getRhs(), structDef, constrainFunc, degreeMemo, rewrites, auxAssignments
       );
 
-      addOp.getLhsMutable().set(lhs);
-      addOp.getRhsMutable().set(rhs);
+      if (lhs != op.getLhs()) {
+        op.getLhsMutable().set(lhs);
+      }
+      if (rhs != op.getRhs()) {
+        op.getRhsMutable().set(rhs);
+      }
       degreeMemo[val] = std::max(getDegree(lhs, degreeMemo), getDegree(rhs, degreeMemo));
       rewrites[val] = val;
       return val;
+    };
+
+    if (auto addOp = val.getDefiningOp<AddFeltOp>()) {
+      return lowerBinaryRoot(addOp);
     }
 
     if (auto subOp = val.getDefiningOp<SubFeltOp>()) {
-      Value lhs = lowerExpression(
-          subOp.getLhs(), structDef, constrainFunc, degreeMemo, rewrites, auxAssignments
-      );
-      Value rhs = lowerExpression(
-          subOp.getRhs(), structDef, constrainFunc, degreeMemo, rewrites, auxAssignments
-      );
-
-      subOp.getLhsMutable().set(lhs);
-      subOp.getRhsMutable().set(rhs);
-      degreeMemo[val] = std::max(getDegree(lhs, degreeMemo), getDegree(rhs, degreeMemo));
-      rewrites[val] = val;
-      return val;
+      return lowerBinaryRoot(subOp);
     }
 
     if (auto negOp = val.getDefiningOp<NegFeltOp>()) {
@@ -156,7 +153,9 @@ private:
           negOp.getOperand(), structDef, constrainFunc, degreeMemo, rewrites, auxAssignments
       );
 
-      negOp.getOperandMutable().set(operand);
+      if (operand != negOp.getOperand()) {
+        negOp.getOperandMutable().set(operand);
+      }
       degreeMemo[val] = getDegree(operand, degreeMemo);
       rewrites[val] = val;
       return val;
@@ -252,6 +251,87 @@ private:
     return val;
   }
 
+  Value materializeCallArgument(
+      Value val, StructDefOp structDef, FuncDefOp constrainFunc, CallOp callOp,
+      DenseMap<Value, unsigned> &degreeMemo, DenseMap<Value, Value> &rewrites,
+      SmallVector<AuxAssignment> &auxAssignments
+  ) {
+    Value loweredVal =
+        lowerExpression(val, structDef, constrainFunc, degreeMemo, rewrites, auxAssignments);
+    DenseMap<Value, unsigned> checkMemo;
+    if (getDegree(loweredVal, checkMemo) <= 1) {
+      return loweredVal;
+    }
+
+    std::string auxName = AUXILIARY_MEMBER_PREFIX + std::to_string(this->auxCounter++);
+    MemberDefOp auxMember = addAuxMember(structDef, auxName);
+
+    OpBuilder builder(callOp);
+    Value selfVal = constrainFunc.getSelfValueFromConstrain();
+    auto auxVal = builder.create<MemberReadOp>(
+        loweredVal.getLoc(), loweredVal.getType(), selfVal, auxMember.getNameAttr()
+    );
+
+    Location loc = builder.getFusedLoc({auxVal.getLoc(), loweredVal.getLoc()});
+    builder.create<EmitEqualityOp>(loc, auxVal, loweredVal);
+    auxAssignments.push_back({auxName, loweredVal});
+
+    degreeMemo[auxVal] = 1;
+    rewrites[loweredVal] = auxVal;
+    rewrites[val] = auxVal;
+    return auxVal;
+  }
+
+  LogicalResult checkEqualityDegrees(FuncDefOp constrainFunc) {
+    bool failedCheck = false;
+
+    constrainFunc.walk([&](EmitEqualityOp eqOp) {
+      DenseMap<Value, unsigned> checkMemo;
+      unsigned lhsDegree = getDegree(eqOp.getLhs(), checkMemo);
+      unsigned rhsDegree = getDegree(eqOp.getRhs(), checkMemo);
+
+      if (lhsDegree > maxDegree || rhsDegree > maxDegree) {
+        auto diag = eqOp.emitOpError();
+        diag << "poly lowering postcondition failed: equality operand degree exceeds max-degree "
+             << maxDegree.getValue() << " (lhs degree " << lhsDegree << ", rhs degree "
+             << rhsDegree << ")";
+        diag.report();
+        failedCheck = true;
+      }
+    });
+
+    return failure(failedCheck);
+  }
+
+  LogicalResult checkStructConstrainCallArguments(FuncDefOp constrainFunc) {
+    bool failedCheck = false;
+
+    constrainFunc.walk([&](CallOp callOp) {
+      if (!callOp.calleeIsStructConstrain()) {
+        return;
+      }
+
+      for (Value arg : callOp.getArgOperands()) {
+        if (!llvm::isa<FeltType>(arg.getType())) {
+          continue;
+        }
+
+        DenseMap<Value, unsigned> checkMemo;
+        unsigned argDegree = getDegree(arg, checkMemo);
+        if (argDegree > 1) {
+          auto diag = callOp.emitOpError();
+          diag << "poly lowering postcondition failed: struct constrain call argument degree "
+                  "exceeds 1 (argument degree "
+               << argDegree << ")";
+          diag.report();
+          failedCheck = true;
+        }
+      }
+    });
+
+    return failure(failedCheck);
+  }
+
   void runOnOperation() override {
     ModuleOp moduleOp = getOperation();
 
@@ -332,13 +412,17 @@ private:
           bool modified = false;
 
           for (Value &arg : newOperands) {
-            unsigned deg = getDegree(arg, degreeMemo);
+            if (!llvm::isa<FeltType>(arg.getType())) {
+              continue;
+            }
+
+            DenseMap<Value, unsigned> callMemo;
+            unsigned deg = getDegree(arg, callMemo);
 
             if (deg > 1) {
-              Value loweredArg = lowerExpression(
-                  arg, structDef, constrainFunc, degreeMemo, rewrites, auxAssignments
+              arg = materializeCallArgument(
+                  arg, structDef, constrainFunc, callOp, degreeMemo, rewrites, auxAssignments
               );
-              arg = loweredArg;
               modified = true;
             }
           }
@@ -354,6 +438,16 @@ private:
           }
         }
       });
+
+      if (failed(checkEqualityDegrees(constrainFunc))) {
+        signalPassFailure();
+        return;
+      }
+
+      if (failed(checkStructConstrainCallArguments(constrainFunc))) {
+        signalPassFailure();
+        return;
+      }
 
       DenseMap<Value, Value> rebuildMemo;
       Block &computeBlock = computeFunc.getBody().front();

--- a/lib/Transforms/LLZKPolyLoweringPass.cpp
+++ b/lib/Transforms/LLZKPolyLoweringPass.cpp
@@ -293,8 +293,8 @@ private:
       if (lhsDegree > maxDegree || rhsDegree > maxDegree) {
         auto diag = eqOp.emitOpError();
         diag << "poly lowering postcondition failed: equality operand degree exceeds max-degree "
-             << maxDegree.getValue() << " (lhs degree " << lhsDegree << ", rhs degree "
-             << rhsDegree << ")";
+             << maxDegree.getValue() << " (lhs degree " << lhsDegree << ", rhs degree " << rhsDegree
+             << ")";
         diag.report();
         failedCheck = true;
       }

--- a/test/Transforms/PolyLowering/poly_lowering_composite_roots.llzk
+++ b/test/Transforms/PolyLowering/poly_lowering_composite_roots.llzk
@@ -1,0 +1,86 @@
+// RUN: llzk-opt -I %S -split-input-file -llzk-poly-lowering-pass="max-degree=2" -verify-diagnostics %s | FileCheck --enable-var-scope %s
+
+module attributes {llzk.lang} {
+  struct.def @AddRoot {
+    function.def @compute(%a: !felt.type, %b: !felt.type, %c: !felt.type, %d: !felt.type, %out: !felt.type) -> !struct.type<@AddRoot> {
+      %self = struct.new : !struct.type<@AddRoot>
+      function.return %self : !struct.type<@AddRoot>
+    }
+
+    function.def @constrain(%self: !struct.type<@AddRoot>, %a: !felt.type, %b: !felt.type, %c: !felt.type, %d: !felt.type, %out: !felt.type) {
+      %ab = felt.mul %a, %b : !felt.type, !felt.type
+      %abc = felt.mul %ab, %c : !felt.type, !felt.type
+      %rhs = felt.add %abc, %d : !felt.type, !felt.type
+      constrain.eq %out, %rhs : !felt.type
+      function.return
+    }
+  }
+}
+
+// CHECK-LABEL:   struct.def @AddRoot {
+// CHECK:           function.def @constrain(%[[SELF:.*]]: !struct.type<@AddRoot>, %[[A:.*]]: !felt.type, %[[B:.*]]: !felt.type, %[[C:.*]]: !felt.type, %[[D:.*]]: !felt.type, %[[OUT:.*]]: !felt.type){{.*}} {
+// CHECK:             %[[AB:.*]] = felt.mul %[[A]], %[[B]] : !felt.type, !felt.type
+// CHECK:             %[[AUX:.*]] = struct.readm %[[SELF]][@__llzk_poly_lowering_pass_aux_member_0] : <@AddRoot>, !felt.type
+// CHECK:             constrain.eq %[[AUX]], %[[AB]] : !felt.type, !felt.type
+// CHECK:             %[[ABC:.*]] = felt.mul %[[AUX]], %[[C]] : !felt.type, !felt.type
+// CHECK:             %[[RHS:.*]] = felt.add %[[ABC]], %[[D]] : !felt.type, !felt.type
+// CHECK:             constrain.eq %[[OUT]], %[[RHS]] : !felt.type, !felt.type
+// CHECK:           struct.member @__llzk_poly_lowering_pass_aux_member_0 : !felt.type
+
+// -----
+
+module attributes {llzk.lang} {
+  struct.def @SubRoot {
+    function.def @compute(%a: !felt.type, %b: !felt.type, %c: !felt.type, %d: !felt.type, %out: !felt.type) -> !struct.type<@SubRoot> {
+      %self = struct.new : !struct.type<@SubRoot>
+      function.return %self : !struct.type<@SubRoot>
+    }
+
+    function.def @constrain(%self: !struct.type<@SubRoot>, %a: !felt.type, %b: !felt.type, %c: !felt.type, %d: !felt.type, %out: !felt.type) {
+      %ab = felt.mul %a, %b : !felt.type, !felt.type
+      %abc = felt.mul %ab, %c : !felt.type, !felt.type
+      %rhs = felt.sub %abc, %d : !felt.type, !felt.type
+      constrain.eq %out, %rhs : !felt.type
+      function.return
+    }
+  }
+}
+
+// CHECK-LABEL:   struct.def @SubRoot {
+// CHECK:           function.def @constrain(%[[SELF:.*]]: !struct.type<@SubRoot>, %[[A:.*]]: !felt.type, %[[B:.*]]: !felt.type, %[[C:.*]]: !felt.type, %[[D:.*]]: !felt.type, %[[OUT:.*]]: !felt.type){{.*}} {
+// CHECK:             %[[AB:.*]] = felt.mul %[[A]], %[[B]] : !felt.type, !felt.type
+// CHECK:             %[[AUX:.*]] = struct.readm %[[SELF]][@__llzk_poly_lowering_pass_aux_member_0] : <@SubRoot>, !felt.type
+// CHECK:             constrain.eq %[[AUX]], %[[AB]] : !felt.type, !felt.type
+// CHECK:             %[[ABC:.*]] = felt.mul %[[AUX]], %[[C]] : !felt.type, !felt.type
+// CHECK:             %[[RHS:.*]] = felt.sub %[[ABC]], %[[D]] : !felt.type, !felt.type
+// CHECK:             constrain.eq %[[OUT]], %[[RHS]] : !felt.type, !felt.type
+// CHECK:           struct.member @__llzk_poly_lowering_pass_aux_member_0 : !felt.type
+
+// -----
+
+module attributes {llzk.lang} {
+  struct.def @NegRoot {
+    function.def @compute(%a: !felt.type, %b: !felt.type, %c: !felt.type, %out: !felt.type) -> !struct.type<@NegRoot> {
+      %self = struct.new : !struct.type<@NegRoot>
+      function.return %self : !struct.type<@NegRoot>
+    }
+
+    function.def @constrain(%self: !struct.type<@NegRoot>, %a: !felt.type, %b: !felt.type, %c: !felt.type, %out: !felt.type) {
+      %ab = felt.mul %a, %b : !felt.type, !felt.type
+      %abc = felt.mul %ab, %c : !felt.type, !felt.type
+      %rhs = felt.neg %abc : !felt.type
+      constrain.eq %out, %rhs : !felt.type
+      function.return
+    }
+  }
+}
+
+// CHECK-LABEL:   struct.def @NegRoot {
+// CHECK:           function.def @constrain(%[[SELF:.*]]: !struct.type<@NegRoot>, %[[A:.*]]: !felt.type, %[[B:.*]]: !felt.type, %[[C:.*]]: !felt.type, %[[OUT:.*]]: !felt.type){{.*}} {
+// CHECK:             %[[AB:.*]] = felt.mul %[[A]], %[[B]] : !felt.type, !felt.type
+// CHECK:             %[[AUX:.*]] = struct.readm %[[SELF]][@__llzk_poly_lowering_pass_aux_member_0] : <@NegRoot>, !felt.type
+// CHECK:             constrain.eq %[[AUX]], %[[AB]] : !felt.type, !felt.type
+// CHECK:             %[[ABC:.*]] = felt.mul %[[AUX]], %[[C]] : !felt.type, !felt.type
+// CHECK:             %[[RHS:.*]] = felt.neg %[[ABC]] : !felt.type
+// CHECK:             constrain.eq %[[OUT]], %[[RHS]] : !felt.type, !felt.type
+// CHECK:           struct.member @__llzk_poly_lowering_pass_aux_member_0 : !felt.type

--- a/test/Transforms/PolyLowering/poly_lowering_composite_roots.llzk
+++ b/test/Transforms/PolyLowering/poly_lowering_composite_roots.llzk
@@ -18,6 +18,12 @@ module attributes {llzk.lang} {
 }
 
 // CHECK-LABEL:   struct.def @AddRoot {
+// CHECK:           function.def @compute(%[[C_A:.*]]: !felt.type, %[[C_B:.*]]: !felt.type, %{{.*}}: !felt.type, %{{.*}}: !felt.type, %{{.*}}: !felt.type) -> !struct.type<@AddRoot>{{.*}} {
+// CHECK:             %[[C_SELF:.*]] = struct.new : <@AddRoot>
+// CHECK:             %[[C_AB:.*]] = felt.mul %[[C_A]], %[[C_B]] : !felt.type, !felt.type
+// CHECK:             struct.writem %[[C_SELF]][@__llzk_poly_lowering_pass_aux_member_0] = %[[C_AB]] : <@AddRoot>, !felt.type
+// CHECK:             function.return %[[C_SELF]] : !struct.type<@AddRoot>
+// CHECK:           }
 // CHECK:           function.def @constrain(%[[SELF:.*]]: !struct.type<@AddRoot>, %[[A:.*]]: !felt.type, %[[B:.*]]: !felt.type, %[[C:.*]]: !felt.type, %[[D:.*]]: !felt.type, %[[OUT:.*]]: !felt.type){{.*}} {
 // CHECK:             %[[AB:.*]] = felt.mul %[[A]], %[[B]] : !felt.type, !felt.type
 // CHECK:             %[[AUX:.*]] = struct.readm %[[SELF]][@__llzk_poly_lowering_pass_aux_member_0] : <@AddRoot>, !felt.type
@@ -72,6 +78,12 @@ module attributes {llzk.lang} {
 }
 
 // CHECK-LABEL:   struct.def @SubRoot {
+// CHECK:           function.def @compute(%[[C_A:.*]]: !felt.type, %[[C_B:.*]]: !felt.type, %{{.*}}: !felt.type, %{{.*}}: !felt.type, %{{.*}}: !felt.type) -> !struct.type<@SubRoot>{{.*}} {
+// CHECK:             %[[C_SELF:.*]] = struct.new : <@SubRoot>
+// CHECK:             %[[C_AB:.*]] = felt.mul %[[C_A]], %[[C_B]] : !felt.type, !felt.type
+// CHECK:             struct.writem %[[C_SELF]][@__llzk_poly_lowering_pass_aux_member_0] = %[[C_AB]] : <@SubRoot>, !felt.type
+// CHECK:             function.return %[[C_SELF]] : !struct.type<@SubRoot>
+// CHECK:           }
 // CHECK:           function.def @constrain(%[[SELF:.*]]: !struct.type<@SubRoot>, %[[A:.*]]: !felt.type, %[[B:.*]]: !felt.type, %[[C:.*]]: !felt.type, %[[D:.*]]: !felt.type, %[[OUT:.*]]: !felt.type){{.*}} {
 // CHECK:             %[[AB:.*]] = felt.mul %[[A]], %[[B]] : !felt.type, !felt.type
 // CHECK:             %[[AUX:.*]] = struct.readm %[[SELF]][@__llzk_poly_lowering_pass_aux_member_0] : <@SubRoot>, !felt.type
@@ -101,6 +113,12 @@ module attributes {llzk.lang} {
 }
 
 // CHECK-LABEL:   struct.def @NegRoot {
+// CHECK:           function.def @compute(%[[C_A:.*]]: !felt.type, %[[C_B:.*]]: !felt.type, %{{.*}}: !felt.type, %{{.*}}: !felt.type) -> !struct.type<@NegRoot>{{.*}} {
+// CHECK:             %[[C_SELF:.*]] = struct.new : <@NegRoot>
+// CHECK:             %[[C_AB:.*]] = felt.mul %[[C_A]], %[[C_B]] : !felt.type, !felt.type
+// CHECK:             struct.writem %[[C_SELF]][@__llzk_poly_lowering_pass_aux_member_0] = %[[C_AB]] : <@NegRoot>, !felt.type
+// CHECK:             function.return %[[C_SELF]] : !struct.type<@NegRoot>
+// CHECK:           }
 // CHECK:           function.def @constrain(%[[SELF:.*]]: !struct.type<@NegRoot>, %[[A:.*]]: !felt.type, %[[B:.*]]: !felt.type, %[[C:.*]]: !felt.type, %[[OUT:.*]]: !felt.type){{.*}} {
 // CHECK:             %[[AB:.*]] = felt.mul %[[A]], %[[B]] : !felt.type, !felt.type
 // CHECK:             %[[AUX:.*]] = struct.readm %[[SELF]][@__llzk_poly_lowering_pass_aux_member_0] : <@NegRoot>, !felt.type
@@ -109,3 +127,61 @@ module attributes {llzk.lang} {
 // CHECK:             %[[RHS:.*]] = felt.neg %[[ABC]] : !felt.type
 // CHECK:             constrain.eq %[[OUT]], %[[RHS]] : !felt.type, !felt.type
 // CHECK:           struct.member @__llzk_poly_lowering_pass_aux_member_0 : !felt.type
+
+// -----
+
+module attributes {llzk.lang} {
+  struct.def @CallTarget {
+    function.def @compute(%x: !felt.type) -> !struct.type<@CallTarget> {
+      %self = struct.new : !struct.type<@CallTarget>
+      function.return %self : !struct.type<@CallTarget>
+    }
+
+    function.def @constrain(%self: !struct.type<@CallTarget>, %x: !felt.type) {
+      function.return
+    }
+  }
+
+  struct.def @CompositeCallArg {
+    struct.member @target: !struct.type<@CallTarget>
+
+    function.def @compute(%a: !felt.type, %b: !felt.type, %c: !felt.type, %d: !felt.type) -> !struct.type<@CompositeCallArg> {
+      %self = struct.new : !struct.type<@CompositeCallArg>
+      function.return %self : !struct.type<@CompositeCallArg>
+    }
+
+    function.def @constrain(%self: !struct.type<@CompositeCallArg>, %a: !felt.type, %b: !felt.type, %c: !felt.type, %d: !felt.type) {
+      %ab = felt.mul %a, %b : !felt.type, !felt.type
+      %abc = felt.mul %ab, %c : !felt.type, !felt.type
+      %arg = felt.add %abc, %d : !felt.type, !felt.type
+      %target = struct.readm %self[@target] : !struct.type<@CompositeCallArg>, !struct.type<@CallTarget>
+      function.call @CallTarget::@constrain(%target, %arg) : (!struct.type<@CallTarget>, !felt.type) -> ()
+      function.return
+    }
+  }
+}
+
+// CHECK-LABEL:   struct.def @CompositeCallArg {
+// CHECK:           struct.member @target : !struct.type<@CallTarget>
+// CHECK:           function.def @compute(%[[C_A:.*]]: !felt.type, %[[C_B:.*]]: !felt.type, %[[C_C:.*]]: !felt.type, %[[C_D:.*]]: !felt.type) -> !struct.type<@CompositeCallArg>{{.*}} {
+// CHECK:             %[[C_SELF:.*]] = struct.new : <@CompositeCallArg>
+// CHECK:             %[[C_AB:.*]] = felt.mul %[[C_A]], %[[C_B]] : !felt.type, !felt.type
+// CHECK:             struct.writem %[[C_SELF]][@__llzk_poly_lowering_pass_aux_member_0] = %[[C_AB]] : <@CompositeCallArg>, !felt.type
+// CHECK:             %[[C_AUX0:.*]] = struct.readm %[[C_SELF]][@__llzk_poly_lowering_pass_aux_member_0] : <@CompositeCallArg>, !felt.type
+// CHECK:             %[[C_ABC:.*]] = felt.mul %[[C_AUX0]], %[[C_C]] : !felt.type, !felt.type
+// CHECK:             %[[C_ARG:.*]] = felt.add %[[C_ABC]], %[[C_D]] : !felt.type, !felt.type
+// CHECK:             struct.writem %[[C_SELF]][@__llzk_poly_lowering_pass_aux_member_1] = %[[C_ARG]] : <@CompositeCallArg>, !felt.type
+// CHECK:             function.return %[[C_SELF]] : !struct.type<@CompositeCallArg>
+// CHECK:           }
+// CHECK:           function.def @constrain(%[[SELF:.*]]: !struct.type<@CompositeCallArg>, %[[A:.*]]: !felt.type, %[[B:.*]]: !felt.type, %[[C:.*]]: !felt.type, %[[D:.*]]: !felt.type){{.*}} {
+// CHECK:             %[[AB:.*]] = felt.mul %[[A]], %[[B]] : !felt.type, !felt.type
+// CHECK:             %[[AUX0:.*]] = struct.readm %[[SELF]][@__llzk_poly_lowering_pass_aux_member_0] : <@CompositeCallArg>, !felt.type
+// CHECK:             constrain.eq %[[AUX0]], %[[AB]] : !felt.type, !felt.type
+// CHECK:             %[[ABC:.*]] = felt.mul %[[AUX0]], %[[C]] : !felt.type, !felt.type
+// CHECK:             %[[ARG:.*]] = felt.add %[[ABC]], %[[D]] : !felt.type, !felt.type
+// CHECK:             %[[TARGET:.*]] = struct.readm %[[SELF]][@target] : <@CompositeCallArg>, !struct.type<@CallTarget>
+// CHECK:             %[[AUX1:.*]] = struct.readm %[[SELF]][@__llzk_poly_lowering_pass_aux_member_1] : <@CompositeCallArg>, !felt.type
+// CHECK:             constrain.eq %[[AUX1]], %[[ARG]] : !felt.type, !felt.type
+// CHECK:             function.call @CallTarget::@constrain(%[[TARGET]], %[[AUX1]]) : (!struct.type<@CallTarget>, !felt.type) -> ()
+// CHECK:           struct.member @__llzk_poly_lowering_pass_aux_member_0 : !felt.type
+// CHECK:           struct.member @__llzk_poly_lowering_pass_aux_member_1 : !felt.type

--- a/test/Transforms/PolyLowering/poly_lowering_composite_roots.llzk
+++ b/test/Transforms/PolyLowering/poly_lowering_composite_roots.llzk
@@ -30,6 +30,31 @@ module attributes {llzk.lang} {
 // -----
 
 module attributes {llzk.lang} {
+  struct.def @DegreeTwoAddRoot {
+    function.def @compute(%a: !felt.type, %b: !felt.type, %d: !felt.type, %out: !felt.type) -> !struct.type<@DegreeTwoAddRoot> {
+      %self = struct.new : !struct.type<@DegreeTwoAddRoot>
+      function.return %self : !struct.type<@DegreeTwoAddRoot>
+    }
+
+    function.def @constrain(%self: !struct.type<@DegreeTwoAddRoot>, %a: !felt.type, %b: !felt.type, %d: !felt.type, %out: !felt.type) {
+      %ab = felt.mul %a, %b : !felt.type, !felt.type
+      %rhs = felt.add %ab, %d : !felt.type, !felt.type
+      constrain.eq %out, %rhs : !felt.type
+      function.return
+    }
+  }
+}
+
+// CHECK-LABEL:   struct.def @DegreeTwoAddRoot {
+// CHECK:           function.def @constrain(%[[SELF:.*]]: !struct.type<@DegreeTwoAddRoot>, %[[A:.*]]: !felt.type, %[[B:.*]]: !felt.type, %[[D:.*]]: !felt.type, %[[OUT:.*]]: !felt.type){{.*}} {
+// CHECK:             %[[AB:.*]] = felt.mul %[[A]], %[[B]] : !felt.type, !felt.type
+// CHECK:             %[[RHS:.*]] = felt.add %[[AB]], %[[D]] : !felt.type, !felt.type
+// CHECK:             constrain.eq %[[OUT]], %[[RHS]] : !felt.type, !felt.type
+// CHECK-NOT:       struct.member @__llzk_poly_lowering_pass_aux_member_0 : !felt.type
+
+// -----
+
+module attributes {llzk.lang} {
   struct.def @SubRoot {
     function.def @compute(%a: !felt.type, %b: !felt.type, %c: !felt.type, %d: !felt.type, %out: !felt.type) -> !struct.type<@SubRoot> {
       %self = struct.new : !struct.type<@SubRoot>

--- a/test/Transforms/PolyLowering/poly_lowering_fail_unsupported_root.llzk
+++ b/test/Transforms/PolyLowering/poly_lowering_fail_unsupported_root.llzk
@@ -1,0 +1,18 @@
+// RUN: llzk-opt -I %S -split-input-file -llzk-poly-lowering-pass="max-degree=2" -verify-diagnostics %s
+
+module attributes {llzk.lang} {
+  struct.def @UnsupportedDivRoot {
+    function.def @compute(%a: !felt.type, %b: !felt.type, %c: !felt.type, %out: !felt.type) -> !struct.type<@UnsupportedDivRoot> {
+      %self = struct.new : !struct.type<@UnsupportedDivRoot>
+      function.return %self : !struct.type<@UnsupportedDivRoot>
+    }
+
+    function.def @constrain(%self: !struct.type<@UnsupportedDivRoot>, %a: !felt.type, %b: !felt.type, %c: !felt.type, %out: !felt.type) {
+      %ab = felt.mul %a, %b : !felt.type, !felt.type
+      %rhs = felt.div %ab, %c : !felt.type, !felt.type
+      // expected-error@+1 {{'constrain.eq' op poly lowering postcondition failed: equality operand degree exceeds max-degree 2 (lhs degree 1, rhs degree 3)}}
+      constrain.eq %out, %rhs : !felt.type
+      function.return
+    }
+  }
+}

--- a/test/Transforms/PolyLowering/poly_lowering_pass_deg2.llzk
+++ b/test/Transforms/PolyLowering/poly_lowering_pass_deg2.llzk
@@ -104,10 +104,9 @@ module attributes {llzk.lang} {
 // CHECK:             %[[VAL_2:.*]] = struct.new : <@Mod1>
 // CHECK:             %[[VAL_3:.*]] = felt.mul %[[VAL_0]], %[[VAL_1]] : !felt.type, !felt.type
 // CHECK:             struct.writem %[[VAL_2]][@__llzk_poly_lowering_pass_aux_member_1] = %[[VAL_3]] : <@Mod1>, !felt.type
-// CHECK:             %[[VAL_4:.*]] = struct.readm %[[VAL_2]][@__llzk_poly_lowering_pass_aux_member_1] : <@Mod1>, !felt.type
-// CHECK:             %[[VAL_5:.*]] = felt.mul %[[VAL_4]], %[[VAL_4]] : !felt.type, !felt.type
+// CHECK:             %[[VAL_5:.*]] = felt.mul %[[VAL_3]], %[[VAL_3]] : !felt.type, !felt.type
 // CHECK:             struct.writem %[[VAL_2]][@__llzk_poly_lowering_pass_aux_member_2] = %[[VAL_5]] : <@Mod1>, !felt.type
-// CHECK:             %[[VAL_6:.*]] = felt.mul %[[VAL_4]], %[[VAL_0]] : !felt.type, !felt.type
+// CHECK:             %[[VAL_6:.*]] = felt.mul %[[VAL_3]], %[[VAL_0]] : !felt.type, !felt.type
 // CHECK:             struct.writem %[[VAL_2]][@__llzk_poly_lowering_pass_aux_member_3] = %[[VAL_6]] : <@Mod1>, !felt.type
 // CHECK:             function.return %[[VAL_2]] : !struct.type<@Mod1>
 // CHECK:           }
@@ -209,10 +208,9 @@ module attributes {llzk.lang} {
 // CHECK:             struct.writem %[[VAL_2]][@__llzk_poly_lowering_pass_aux_member_1] = %[[VAL_4]] : <@Mod1>, !felt.type
 // CHECK:             %[[VAL_5:.*]] = felt.mul %[[VAL_0]], %[[VAL_1]] : !felt.type, !felt.type
 // CHECK:             struct.writem %[[VAL_2]][@__llzk_poly_lowering_pass_aux_member_2] = %[[VAL_5]] : <@Mod1>, !felt.type
-// CHECK:             %[[VAL_6:.*]] = struct.readm %[[VAL_2]][@__llzk_poly_lowering_pass_aux_member_2] : <@Mod1>, !felt.type
-// CHECK:             %[[VAL_7:.*]] = felt.mul %[[VAL_6]], %[[VAL_6]] : !felt.type, !felt.type
+// CHECK:             %[[VAL_7:.*]] = felt.mul %[[VAL_5]], %[[VAL_5]] : !felt.type, !felt.type
 // CHECK:             struct.writem %[[VAL_2]][@__llzk_poly_lowering_pass_aux_member_3] = %[[VAL_7]] : <@Mod1>, !felt.type
-// CHECK:             %[[VAL_8:.*]] = felt.mul %[[VAL_6]], %[[VAL_0]] : !felt.type, !felt.type
+// CHECK:             %[[VAL_8:.*]] = felt.mul %[[VAL_5]], %[[VAL_0]] : !felt.type, !felt.type
 // CHECK:             struct.writem %[[VAL_2]][@__llzk_poly_lowering_pass_aux_member_4] = %[[VAL_8]] : <@Mod1>, !felt.type
 // CHECK:             function.return %[[VAL_2]] : !struct.type<@Mod1>
 // CHECK:           }

--- a/test/Transforms/PolyLowering/poly_lowering_pass_deg2.llzk
+++ b/test/Transforms/PolyLowering/poly_lowering_pass_deg2.llzk
@@ -104,19 +104,30 @@ module attributes {llzk.lang} {
 // CHECK:             %[[VAL_2:.*]] = struct.new : <@Mod1>
 // CHECK:             %[[VAL_3:.*]] = felt.mul %[[VAL_0]], %[[VAL_1]] : !felt.type, !felt.type
 // CHECK:             struct.writem %[[VAL_2]][@__llzk_poly_lowering_pass_aux_member_1] = %[[VAL_3]] : <@Mod1>, !felt.type
+// CHECK:             %[[VAL_4:.*]] = struct.readm %[[VAL_2]][@__llzk_poly_lowering_pass_aux_member_1] : <@Mod1>, !felt.type
+// CHECK:             %[[VAL_5:.*]] = felt.mul %[[VAL_4]], %[[VAL_4]] : !felt.type, !felt.type
+// CHECK:             struct.writem %[[VAL_2]][@__llzk_poly_lowering_pass_aux_member_2] = %[[VAL_5]] : <@Mod1>, !felt.type
+// CHECK:             %[[VAL_6:.*]] = felt.mul %[[VAL_4]], %[[VAL_0]] : !felt.type, !felt.type
+// CHECK:             struct.writem %[[VAL_2]][@__llzk_poly_lowering_pass_aux_member_3] = %[[VAL_6]] : <@Mod1>, !felt.type
 // CHECK:             function.return %[[VAL_2]] : !struct.type<@Mod1>
 // CHECK:           }
-// CHECK:           function.def @constrain(%[[VAL_4:.*]]: !struct.type<@Mod1>, %[[VAL_5:.*]]: !felt.type, %[[VAL_6:.*]]: !felt.type) attributes {function.allow_constraint} {
-// CHECK:             %[[VAL_7:.*]] = felt.mul %[[VAL_5]], %[[VAL_6]] : !felt.type, !felt.type
-// CHECK:             %[[VAL_8:.*]] = struct.readm %[[VAL_4]][@__llzk_poly_lowering_pass_aux_member_1] : <@Mod1>, !felt.type
-// CHECK:             constrain.eq %[[VAL_8]], %[[VAL_7]] : !felt.type, !felt.type
-// CHECK:             %[[VAL_9:.*]] = felt.mul %[[VAL_8]], %[[VAL_8]] : !felt.type, !felt.type
-// CHECK:             %[[VAL_10:.*]] = felt.mul %[[VAL_8]], %[[VAL_5]] : !felt.type, !felt.type
-// CHECK:             %[[VAL_11:.*]] = struct.readm %[[VAL_4]][@mod2] : <@Mod1>, !struct.type<@Mod2>
-// CHECK:             function.call @Mod2::@constrain(%[[VAL_11]], %[[VAL_9]], %[[VAL_10]]) : (!struct.type<@Mod2>, !felt.type, !felt.type) -> ()
+// CHECK:           function.def @constrain(%[[VAL_7:.*]]: !struct.type<@Mod1>, %[[VAL_8:.*]]: !felt.type, %[[VAL_9:.*]]: !felt.type) attributes {function.allow_constraint} {
+// CHECK:             %[[VAL_10:.*]] = felt.mul %[[VAL_8]], %[[VAL_9]] : !felt.type, !felt.type
+// CHECK:             %[[VAL_11:.*]] = struct.readm %[[VAL_7]][@__llzk_poly_lowering_pass_aux_member_1] : <@Mod1>, !felt.type
+// CHECK:             constrain.eq %[[VAL_11]], %[[VAL_10]] : !felt.type, !felt.type
+// CHECK:             %[[VAL_12:.*]] = felt.mul %[[VAL_11]], %[[VAL_11]] : !felt.type, !felt.type
+// CHECK:             %[[VAL_13:.*]] = felt.mul %[[VAL_11]], %[[VAL_8]] : !felt.type, !felt.type
+// CHECK:             %[[VAL_14:.*]] = struct.readm %[[VAL_7]][@mod2] : <@Mod1>, !struct.type<@Mod2>
+// CHECK:             %[[VAL_15:.*]] = struct.readm %[[VAL_7]][@__llzk_poly_lowering_pass_aux_member_2] : <@Mod1>, !felt.type
+// CHECK:             constrain.eq %[[VAL_15]], %[[VAL_12]] : !felt.type, !felt.type
+// CHECK:             %[[VAL_16:.*]] = struct.readm %[[VAL_7]][@__llzk_poly_lowering_pass_aux_member_3] : <@Mod1>, !felt.type
+// CHECK:             constrain.eq %[[VAL_16]], %[[VAL_13]] : !felt.type, !felt.type
+// CHECK:             function.call @Mod2::@constrain(%[[VAL_14]], %[[VAL_15]], %[[VAL_16]]) : (!struct.type<@Mod2>, !felt.type, !felt.type) -> ()
 // CHECK:             function.return
 // CHECK:           }
 // CHECK:           struct.member @__llzk_poly_lowering_pass_aux_member_1 : !felt.type
+// CHECK:           struct.member @__llzk_poly_lowering_pass_aux_member_2 : !felt.type
+// CHECK:           struct.member @__llzk_poly_lowering_pass_aux_member_3 : !felt.type
 // CHECK:         }
 // -----
 
@@ -198,25 +209,36 @@ module attributes {llzk.lang} {
 // CHECK:             struct.writem %[[VAL_2]][@__llzk_poly_lowering_pass_aux_member_1] = %[[VAL_4]] : <@Mod1>, !felt.type
 // CHECK:             %[[VAL_5:.*]] = felt.mul %[[VAL_0]], %[[VAL_1]] : !felt.type, !felt.type
 // CHECK:             struct.writem %[[VAL_2]][@__llzk_poly_lowering_pass_aux_member_2] = %[[VAL_5]] : <@Mod1>, !felt.type
+// CHECK:             %[[VAL_6:.*]] = struct.readm %[[VAL_2]][@__llzk_poly_lowering_pass_aux_member_2] : <@Mod1>, !felt.type
+// CHECK:             %[[VAL_7:.*]] = felt.mul %[[VAL_6]], %[[VAL_6]] : !felt.type, !felt.type
+// CHECK:             struct.writem %[[VAL_2]][@__llzk_poly_lowering_pass_aux_member_3] = %[[VAL_7]] : <@Mod1>, !felt.type
+// CHECK:             %[[VAL_8:.*]] = felt.mul %[[VAL_6]], %[[VAL_0]] : !felt.type, !felt.type
+// CHECK:             struct.writem %[[VAL_2]][@__llzk_poly_lowering_pass_aux_member_4] = %[[VAL_8]] : <@Mod1>, !felt.type
 // CHECK:             function.return %[[VAL_2]] : !struct.type<@Mod1>
 // CHECK:           }
-// CHECK:           function.def @constrain(%[[VAL_6:.*]]: !struct.type<@Mod1>, %[[VAL_7:.*]]: !felt.type, %[[VAL_8:.*]]: !felt.type) attributes {function.allow_constraint} {
-// CHECK:             %[[VAL_9:.*]] = felt.mul %[[VAL_7]], %[[VAL_8]] : !felt.type, !felt.type
-// CHECK:             %[[VAL_10:.*]] = struct.readm %[[VAL_6]][@__llzk_poly_lowering_pass_aux_member_2] : <@Mod1>, !felt.type
-// CHECK:             constrain.eq %[[VAL_10]], %[[VAL_9]] : !felt.type, !felt.type
-// CHECK:             %[[VAL_11:.*]] = felt.mul %[[VAL_10]], %[[VAL_10]] : !felt.type, !felt.type
-// CHECK:             %[[VAL_12:.*]] = felt.mul %[[VAL_10]], %[[VAL_7]] : !felt.type, !felt.type
-// CHECK:             %[[VAL_13:.*]] = struct.readm %[[VAL_6]][@mod2] : <@Mod1>, !struct.type<@Mod2>
-// CHECK:             function.call @Mod2::@constrain(%[[VAL_13]], %[[VAL_11]], %[[VAL_12]]) : (!struct.type<@Mod2>, !felt.type, !felt.type) -> ()
-// CHECK:             %[[VAL_14:.*]] = struct.readm %[[VAL_13]][@val] : <@Mod2>, !felt.type
-// CHECK:             %[[VAL_15:.*]] = felt.mul %[[VAL_14]], %[[VAL_14]] : !felt.type, !felt.type
-// CHECK:             %[[VAL_16:.*]] = struct.readm %[[VAL_6]][@__llzk_poly_lowering_pass_aux_member_1] : <@Mod1>, !felt.type
-// CHECK:             constrain.eq %[[VAL_16]], %[[VAL_15]] : !felt.type, !felt.type
-// CHECK:             %[[VAL_17:.*]] = felt.mul %[[VAL_16]], %[[VAL_16]] : !felt.type, !felt.type
-// CHECK:             %[[VAL_18:.*]] = struct.readm %[[VAL_6]][@val] : <@Mod1>, !felt.type
-// CHECK:             constrain.eq %[[VAL_18]], %[[VAL_17]] : !felt.type, !felt.type
+// CHECK:           function.def @constrain(%[[VAL_9:.*]]: !struct.type<@Mod1>, %[[VAL_10:.*]]: !felt.type, %[[VAL_11:.*]]: !felt.type) attributes {function.allow_constraint} {
+// CHECK:             %[[VAL_12:.*]] = felt.mul %[[VAL_10]], %[[VAL_11]] : !felt.type, !felt.type
+// CHECK:             %[[VAL_13:.*]] = struct.readm %[[VAL_9]][@__llzk_poly_lowering_pass_aux_member_2] : <@Mod1>, !felt.type
+// CHECK:             constrain.eq %[[VAL_13]], %[[VAL_12]] : !felt.type, !felt.type
+// CHECK:             %[[VAL_14:.*]] = felt.mul %[[VAL_13]], %[[VAL_13]] : !felt.type, !felt.type
+// CHECK:             %[[VAL_15:.*]] = felt.mul %[[VAL_13]], %[[VAL_10]] : !felt.type, !felt.type
+// CHECK:             %[[VAL_16:.*]] = struct.readm %[[VAL_9]][@mod2] : <@Mod1>, !struct.type<@Mod2>
+// CHECK:             %[[VAL_17:.*]] = struct.readm %[[VAL_9]][@__llzk_poly_lowering_pass_aux_member_3] : <@Mod1>, !felt.type
+// CHECK:             constrain.eq %[[VAL_17]], %[[VAL_14]] : !felt.type, !felt.type
+// CHECK:             %[[VAL_18:.*]] = struct.readm %[[VAL_9]][@__llzk_poly_lowering_pass_aux_member_4] : <@Mod1>, !felt.type
+// CHECK:             constrain.eq %[[VAL_18]], %[[VAL_15]] : !felt.type, !felt.type
+// CHECK:             function.call @Mod2::@constrain(%[[VAL_16]], %[[VAL_17]], %[[VAL_18]]) : (!struct.type<@Mod2>, !felt.type, !felt.type) -> ()
+// CHECK:             %[[VAL_19:.*]] = struct.readm %[[VAL_16]][@val] : <@Mod2>, !felt.type
+// CHECK:             %[[VAL_20:.*]] = felt.mul %[[VAL_19]], %[[VAL_19]] : !felt.type, !felt.type
+// CHECK:             %[[VAL_21:.*]] = struct.readm %[[VAL_9]][@__llzk_poly_lowering_pass_aux_member_1] : <@Mod1>, !felt.type
+// CHECK:             constrain.eq %[[VAL_21]], %[[VAL_20]] : !felt.type, !felt.type
+// CHECK:             %[[VAL_22:.*]] = felt.mul %[[VAL_21]], %[[VAL_21]] : !felt.type, !felt.type
+// CHECK:             %[[VAL_23:.*]] = struct.readm %[[VAL_9]][@val] : <@Mod1>, !felt.type
+// CHECK:             constrain.eq %[[VAL_23]], %[[VAL_22]] : !felt.type, !felt.type
 // CHECK:             function.return
 // CHECK:           }
 // CHECK:           struct.member @__llzk_poly_lowering_pass_aux_member_1 : !felt.type
 // CHECK:           struct.member @__llzk_poly_lowering_pass_aux_member_2 : !felt.type
+// CHECK:           struct.member @__llzk_poly_lowering_pass_aux_member_3 : !felt.type
+// CHECK:           struct.member @__llzk_poly_lowering_pass_aux_member_4 : !felt.type
 // CHECK:         }


### PR DESCRIPTION
## Summary

Fix poly lowering for high-degree felt expressions whose root op is linear.

`getDegree` already propagates degree through `felt.add`, `felt.sub`, and `felt.neg`, but `lowerExpression` only recursively lowered `felt.mul` roots. With `max-degree=2`, a constraint operand such as `(a*b*c)+d` could therefore keep a degree-3 add-root expression after lowering.

This change lowers the operands of add/sub/neg roots in place, so the root expression is preserved while high-degree children are materialized through the existing auxiliary-member path.

## Testing

- `git diff --check`
- Added `poly_lowering_composite_roots.llzk` covering add, sub, and neg roots with `llzk-poly-lowering-pass="max-degree=2"`
