### PR TITLE
add op-restricted SROA and mem2reg passes

### DIFF
--- a/changelogs/unreleased/th__sandbox_array_destructuring.yaml
+++ b/changelogs/unreleased/th__sandbox_array_destructuring.yaml
@@ -1,0 +1,5 @@
+added:
+  - "`SpecializedSROA` and `SpecializedMem2Reg` passes"
+
+changed:
+  - Update ArrayToScalarPass to use these new passes instead of the builtin ones

--- a/include/llzk/Transforms/SpecializedMemoryPasses.h
+++ b/include/llzk/Transforms/SpecializedMemoryPasses.h
@@ -1,0 +1,130 @@
+//===-- SpecializedMemoryPasses.h - Targeted SROA / mem2reg -----*- C++ -*-===//
+//
+// Part of the LLZK Project, under the Apache License v2.0.
+// See LICENSE.txt for license information.
+// Copyright 2026 Project LLZK
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Provides `SpecializedSROA<AllocOpTy>` and `SpecializedMem2Reg<AllocOpTy>`:
+/// pass templates that replicate the bodies of the MLIR `sroa` and `mem2reg`
+/// passes but restrict the allocation-op walk to a single concrete op type rather
+/// than collecting every op that implements the corresponding allocation interface.
+///
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <mlir/Analysis/DataLayoutAnalysis.h>
+#include <mlir/IR/Builders.h>
+#include <mlir/IR/Dominance.h>
+#include <mlir/Interfaces/MemorySlotInterfaces.h>
+#include <mlir/Pass/Pass.h>
+#include <mlir/Transforms/Mem2Reg.h>
+#include <mlir/Transforms/SROA.h>
+
+#include <llvm/ADT/SmallVector.h>
+
+namespace llzk {
+
+/// A variant of the MLIR `sroa` pass that only destructures memory slots belonging to allocators
+/// of type \p AllocOpTy (which must implement `mlir::DestructurableAllocationOpInterface`). All
+/// other allocator ops are ignored. The rest of the pass body is identical to the upstream pass.
+template <typename AllocOpTy>
+struct SpecializedSROA : mlir::PassWrapper<SpecializedSROA<AllocOpTy>, mlir::OperationPass<>> {
+
+  mlir::StringRef getArgument() const override { return "llzk-specialized-sroa"; }
+
+  mlir::StringRef getDescription() const override {
+    return "Scalar replacement of aggregates for a specific allocator op type";
+  }
+
+  void runOnOperation() override {
+    mlir::Operation *scopeOp = this->getOperation();
+
+    auto &dataLayoutAnalysis = this->template getAnalysis<mlir::DataLayoutAnalysis>();
+    const mlir::DataLayout &dataLayout = dataLayoutAnalysis.getAtOrAbove(scopeOp);
+
+    bool changed = false;
+
+    for (mlir::Region &region : scopeOp->getRegions()) {
+      if (region.getBlocks().empty()) {
+        continue;
+      }
+
+      mlir::OpBuilder builder(&region.front(), region.front().begin());
+
+      mlir::SmallVector<mlir::DestructurableAllocationOpInterface> allocators;
+      region.walk([&](AllocOpTy allocator) { allocators.emplace_back(allocator); });
+
+      if (mlir::succeeded(mlir::tryToDestructureMemorySlots(allocators, builder, dataLayout))) {
+        changed = true;
+      }
+    }
+
+    if (!changed) {
+      this->markAllAnalysesPreserved();
+    }
+  }
+};
+
+// Pass factory for `SpecializedSROA`.
+template <typename AllocOpTy>
+std::unique_ptr<SpecializedSROA<AllocOpTy>> createSpecializedSROAPass() {
+  return std::make_unique<SpecializedSROA<AllocOpTy>>();
+}
+
+/// A variant of the MLIR `mem2reg` pass that only promotes memory slots belonging to allocators
+/// of type \p AllocOpTy (which must implement `mlir::PromotableAllocationOpInterface`). All
+/// other allocator ops are ignored. The rest of the pass body is identical to the upstream pass.
+template <typename AllocOpTy>
+struct SpecializedMem2Reg
+    : mlir::PassWrapper<SpecializedMem2Reg<AllocOpTy>, mlir::OperationPass<>> {
+
+  mlir::StringRef getArgument() const override { return "llzk-specialized-mem2reg"; }
+
+  mlir::StringRef getDescription() const override {
+    return "Promotes memory slots of a specific allocator op type into values";
+  }
+
+  void runOnOperation() override {
+    mlir::Operation *scopeOp = this->getOperation();
+
+    auto &dataLayoutAnalysis = this->template getAnalysis<mlir::DataLayoutAnalysis>();
+    const mlir::DataLayout &dataLayout = dataLayoutAnalysis.getAtOrAbove(scopeOp);
+    auto &dominance = this->template getAnalysis<mlir::DominanceInfo>();
+
+    bool changed = false;
+
+    for (mlir::Region &region : scopeOp->getRegions()) {
+      if (region.getBlocks().empty()) {
+        continue;
+      }
+
+      mlir::OpBuilder builder(&region.front(), region.front().begin());
+
+      mlir::SmallVector<mlir::PromotableAllocationOpInterface> allocators;
+      region.walk([&](AllocOpTy allocator) { allocators.emplace_back(allocator); });
+
+      if (mlir::succeeded(
+              mlir::tryToPromoteMemorySlots(allocators, builder, dataLayout, dominance)
+          )) {
+        changed = true;
+      }
+    }
+
+    if (!changed) {
+      this->markAllAnalysesPreserved();
+    }
+  }
+};
+
+// Pass factory for `SpecializedMem2Reg`.
+template <typename AllocOpTy>
+std::unique_ptr<SpecializedMem2Reg<AllocOpTy>> createSpecializedMem2RegPass() {
+  return std::make_unique<SpecializedMem2Reg<AllocOpTy>>();
+}
+
+} // namespace llzk

--- a/lib/Dialect/Array/Transforms/ArrayToScalarPass.cpp
+++ b/lib/Dialect/Array/Transforms/ArrayToScalarPass.cpp
@@ -66,6 +66,7 @@
 #include "llzk/Dialect/Include/IR/Dialect.h"
 #include "llzk/Dialect/LLZK/IR/Ops.h"
 #include "llzk/Transforms/LLZKConversionUtils.h"
+#include "llzk/Transforms/SpecializedMemoryPasses.h"
 #include "llzk/Util/Compare.h"
 #include "llzk/Util/Concepts.h"
 
@@ -996,9 +997,9 @@ class ArrayToScalarPass : public llzk::array::impl::ArrayToScalarPassBase<ArrayT
     // Use SROA (Destructurable* interfaces) to split each array with linear size N into N arrays of
     // size 1. This is necessary because the mem2reg pass cannot deal with indexing and splitting up
     // memory, i.e., it can only convert scalar memory access into SSA values.
-    nestedPM.addPass(createSROA());
+    nestedPM.addPass(createSpecializedSROAPass<CreateArrayOp>());
     // The mem2reg pass converts all of the size 1 array allocation and access into SSA values.
-    nestedPM.addPass(createMem2Reg());
+    nestedPM.addPass(createSpecializedMem2RegPass<CreateArrayOp>());
     // Cleanup SSA values made dead by the transformations
     nestedPM.addPass(createRemoveDeadValuesPass());
     if (failed(runPipeline(nestedPM, module))) {


### PR DESCRIPTION
In preparation for adding the interfaces for these passes to `pod` dialect ops (which would cause a single run of the builtin passes to process all ops with the pass-related interface), create op-restricted SROA and mem2reg passes. This allows `array` destructuring and `pod` destructuring to be run as independent passes (likewise for `pod` when that is updated).