### PR TITLE
Add destructuring and promotable interfaces to pod ops/types

### DIFF
--- a/changelogs/unreleased/th__pod_op_interfaces.yaml
+++ b/changelogs/unreleased/th__pod_op_interfaces.yaml
@@ -1,0 +1,3 @@
+added:
+  - PodRefOpInterface and PodAccessOpInterface for ops that reference or access pods
+  - Destructurable*Interface and Promotable*Interface to pod ops/types

--- a/include/llzk/Dialect/POD/IR/CMakeLists.txt
+++ b/include/llzk/Dialect/POD/IR/CMakeLists.txt
@@ -19,6 +19,10 @@ llzk_tablegen(Types.capi.h.inc -gen-type-capi-header -prefix=llzk -dialect=pod)
 llzk_tablegen(Types.capi.cpp.inc -gen-type-capi-impl -prefix=llzk -dialect=pod)
 llzk_tablegen(Types.capi.test.cpp.inc -gen-type-capi-tests -prefix=llzk -dialect=pod)
 
+set(LLVM_TARGET_DEFINITIONS "OpInterfaces.td")
+mlir_tablegen(OpInterfaces.h.inc --gen-op-interface-decls)
+mlir_tablegen(OpInterfaces.cpp.inc --gen-op-interface-defs)
+
 set(LLVM_TARGET_DEFINITIONS "Ops.td")
 mlir_tablegen(Ops.h.inc -gen-op-decls -dialect=pod)
 mlir_tablegen(Ops.cpp.inc -gen-op-defs -dialect=pod)

--- a/include/llzk/Dialect/POD/IR/OpInterfaces.td
+++ b/include/llzk/Dialect/POD/IR/OpInterfaces.td
@@ -1,0 +1,77 @@
+//===-- OpInterfaces.td ------------------------------------*- tablegen -*-===//
+//
+// Part of the LLZK Project, under the Apache License v2.0.
+// See LICENSE.txt for license information.
+// Copyright 2026 Project LLZK
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLZK_POD_OP_INTERFACES
+#define LLZK_POD_OP_INTERFACES
+
+include "llzk/Dialect/POD/IR/Types.td"
+
+include "mlir/IR/Interfaces.td"
+include "mlir/Interfaces/MemorySlotInterfaces.td"
+include "mlir/Interfaces/SideEffectInterfaces.td"
+
+def PodRefOpInterface : OpInterface<"PodRefOpInterface"> {
+  let description = [{
+    Common interface for operations that reference a plain-old-data struct value.
+  }];
+  let cppNamespace = "::llzk::pod";
+
+  let methods = [
+      // Requires implementors to have a '$pod_ref' argument.
+      InterfaceMethod<[{Gets the SSA Value for the referenced pod.}],
+                      "::mlir::TypedValue<::llzk::pod::PodType>", "getPodRef",
+                      (ins)>,
+      InterfaceMethod<
+          [{Gets the mutable operand slot holding the SSA Value for the referenced pod.}],
+          "::mlir::OpOperand &", "getPodRefMutable", (ins)>,
+  ];
+
+  let extraClassDeclaration = [{
+    /// Gets the type of the referenced pod.
+    inline ::llzk::pod::PodType getPodRefType() { return getPodRef().getType(); }
+  }];
+}
+
+def PodAccessOpInterface
+    : OpInterface<"PodAccessOpInterface", [PodRefOpInterface]> {
+  let description = [{
+    Common interface for operations that read or write from a pod record.
+  }];
+  let cppNamespace = "::llzk::pod";
+
+  let methods = [
+      // Requires implementors to have a '$record_name' attribute.
+      InterfaceMethod<
+          [{Gets the record name attribute from the pod access op.}],
+          "::mlir::FlatSymbolRefAttr", "getRecordNameAttr", (ins)>,
+      InterfaceMethod<
+          [{Return `true` if the op is a read, `false` if it's a write.}],
+          "bool", "isRead", (ins)>,
+  ];
+
+  let extraClassDeclaration = [{
+    /// Gets the record name as an attribute suitable for destructuring indices.
+    inline ::mlir::StringAttr getRecordNameAsStringAttr() {
+      return getRecordNameAttr().getLeafReference();
+    }
+
+    /// Required by companion interface DestructurableAccessorOpInterface / SROA pass
+    bool canRewire(const ::mlir::DestructurableMemorySlot &slot,
+            ::llvm::SmallPtrSetImpl<::mlir::Attribute> &usedIndices,
+            ::mlir::SmallVectorImpl<::mlir::MemorySlot> &mustBeSafelyUsed,
+            const ::mlir::DataLayout &dataLayout);
+
+    /// Required by companion interface DestructurableAccessorOpInterface / SROA pass
+    ::mlir::DeletionKind rewire(const ::mlir::DestructurableMemorySlot &slot,
+            ::llvm::DenseMap<::mlir::Attribute, ::mlir::MemorySlot> &subslots,
+            ::mlir::OpBuilder &builder, const ::mlir::DataLayout &dataLayout);
+  }];
+}
+
+#endif // LLZK_POD_OP_INTERFACES

--- a/include/llzk/Dialect/POD/IR/Ops.h
+++ b/include/llzk/Dialect/POD/IR/Ops.h
@@ -16,6 +16,10 @@
 #include <mlir/IR/BuiltinAttributes.h>
 #include <mlir/IR/OpImplementation.h>
 #include <mlir/IR/Value.h>
+#include <mlir/Interfaces/MemorySlotInterfaces.h>
+
+// Include TableGen'd declarations
+#include "llzk/Dialect/POD/IR/OpInterfaces.h.inc"
 
 // Include TableGen'd declarations
 #define GET_OP_CLASSES

--- a/include/llzk/Dialect/POD/IR/Ops.td
+++ b/include/llzk/Dialect/POD/IR/Ops.td
@@ -11,6 +11,7 @@
 #define LLZK_POD_OPS
 
 include "llzk/Dialect/POD/IR/Dialect.td"
+include "llzk/Dialect/POD/IR/OpInterfaces.td"
 include "llzk/Dialect/POD/IR/Types.td"
 include "llzk/Dialect/Shared/OpTraits.td"
 
@@ -22,11 +23,99 @@ include "mlir/Interfaces/SideEffectInterfaces.td"
 class PODDialectOp<string mnemonic, list<Trait> traits = []>
     : Op<PODDialect, mnemonic, traits>;
 
+class PODAccessOpBase<string mnemonic, list<Trait> traits = []>
+    : PODDialectOp<mnemonic,
+                   traits#[DeclareOpInterfaceMethods<PodAccessOpInterface>]> {
+  let extraClassDeclaration = [{
+    /// Gets the type of the referenced pod.
+    inline ::llzk::pod::PodType getPodRefType() {
+      return ::llvm::cast<PodAccessOpInterface>(getOperation()).getPodRefType();
+    }
+  }];
+}
+
+// isRead: read(1) vs write(0) ops
+class ScalarPODAccessOp<string mnemonic, bit isRead, list<Trait> traits = []>
+    : PODAccessOpBase<
+          mnemonic,
+          traits#[DeclareOpInterfaceMethods<DestructurableAccessorOpInterface>,
+                  DeclareOpInterfaceMethods<PromotableMemOpInterface>]> {
+  let extraClassDefinition = [{
+    /// Required by DestructurableAllocationOpInterface / SROA pass
+    bool $cppClass::canRewire(const ::mlir::DestructurableMemorySlot &slot,
+                ::llvm::SmallPtrSetImpl<::mlir::Attribute> &usedIndices,
+                ::mlir::SmallVectorImpl<::mlir::MemorySlot> &mustBeSafelyUsed,
+                const ::mlir::DataLayout &dataLayout) {
+      return ::llvm::cast<PodAccessOpInterface>(getOperation())
+                .canRewire(slot, usedIndices, mustBeSafelyUsed, dataLayout);
+    }
+
+    /// Required by DestructurableAllocationOpInterface / SROA pass
+    ::mlir::DeletionKind $cppClass::rewire(const ::mlir::DestructurableMemorySlot &slot,
+                ::llvm::DenseMap<::mlir::Attribute, ::mlir::MemorySlot> &subslots,
+                ::mlir::OpBuilder &builder, const ::mlir::DataLayout &dataLayout) {
+      return ::llvm::cast<PodAccessOpInterface>(getOperation())
+                .rewire(slot, subslots, builder, dataLayout);
+    }
+
+    /// Required by PromotableMemOpInterface / mem2reg pass
+    bool $cppClass::loadsFrom(const ::mlir::MemorySlot &slot) {
+      return }]#!if(isRead, "getPodRef() == slot.ptr", "false")#[{;
+    }
+
+    /// Required by PromotableMemOpInterface / mem2reg pass
+    bool $cppClass::storesTo(const ::mlir::MemorySlot &slot) {
+      return }]#!if(isRead, "false", "getPodRef() == slot.ptr")#[{;
+    }
+
+    /// Required by PromotableAllocationOpInterface / mem2reg pass
+    ::mlir::Value $cppClass::getStored(const ::mlir::MemorySlot &, ::mlir::OpBuilder &,
+                                       ::mlir::Value, const ::mlir::DataLayout &) {
+      }]#!if(
+      isRead,
+      "llvm_unreachable(\"getStored() should not be called on $cppClass\")",
+      "return getValue()")#[{;
+    }
+
+    /// Required by PromotableMemOpInterface / mem2reg pass
+    bool $cppClass::canUsesBeRemoved(
+        const ::mlir::MemorySlot &slot,
+        const ::llvm::SmallPtrSetImpl<::mlir::OpOperand *> &blockingUses,
+        ::llvm::SmallVectorImpl<::mlir::OpOperand *> & /*newBlockingUses*/,
+        const ::mlir::DataLayout & /*datalayout*/) {
+      if (blockingUses.size() != 1) {
+        return false;
+      }
+      ::mlir::Value blockingUse = (*blockingUses.begin())->get();
+      return blockingUse == slot.ptr && getPodRef() == slot.ptr &&
+      }]#!if(isRead, "getResult().getType() == slot.elemType",
+             "getValue() != slot.ptr && getValue().getType() == slot.elemType")#[{;
+    }
+
+    /// Required by PromotableMemOpInterface / mem2reg pass
+    ::mlir::DeletionKind $cppClass::removeBlockingUses(
+        const ::mlir::MemorySlot &, const ::llvm::SmallPtrSetImpl<::mlir::OpOperand *> &,
+        ::mlir::OpBuilder &, ::mlir::Value reachingDefinition, const ::mlir::DataLayout &) {
+      }]#!if(isRead, "getResult().replaceAllUsesWith(reachingDefinition)",
+             "")#[{;
+      return ::mlir::DeletionKind::Delete;
+    }
+
+    /// Return `true` if the op is a read, `false` if it's a write.
+    bool $cppClass::isRead() {
+      return }]#!if(isRead, "true", "false")#[{;
+    }
+  }];
+}
+
 def LLZK_NewPodOp
-    : PODDialectOp<"new", [Pure, AttrSizedOperandSegments,
-                           VerifySizesForMultiAffineOps<1>,
-                           DeclareOpInterfaceMethods<
-                               OpAsmOpInterface, ["getAsmResultNames"]>]> {
+    : PODDialectOp<
+          "new",
+          [Pure, AttrSizedOperandSegments, VerifySizesForMultiAffineOps<1>,
+           DeclareOpInterfaceMethods<PromotableAllocationOpInterface>,
+           DeclareOpInterfaceMethods<DestructurableAllocationOpInterface>,
+           DeclareOpInterfaceMethods<
+               OpAsmOpInterface, ["getAsmResultNames"]>]> {
   let summary = "create a new plain-old-data struct";
   let description = [{
     Creates a new, uninitialized, pod instance. Optionally, the user can pass a list of record names and values
@@ -113,7 +202,7 @@ def LLZK_NewPodOp
   }];
 }
 
-def LLZK_ReadPodOp : PODDialectOp<"read"> {
+def LLZK_ReadPodOp : ScalarPODAccessOp<"read", 1> {
   let summary = "reads the contents of a plain-old-data struct record";
   let description = [{
     Reads the current value of a named record from a pod instance.
@@ -137,7 +226,7 @@ def LLZK_ReadPodOp : PODDialectOp<"read"> {
   let hasVerifier = 1;
 }
 
-def LLZK_WritePodOp : PODDialectOp<"write"> {
+def LLZK_WritePodOp : ScalarPODAccessOp<"write", 0> {
   let summary = "writes content into a plain-old-data struct record";
   let description = [{
     Writes a value into a named record of a pod instance. This operation has no result values.

--- a/include/llzk/Dialect/POD/IR/Types.h
+++ b/include/llzk/Dialect/POD/IR/Types.h
@@ -12,6 +12,8 @@
 #include "llzk/Dialect/POD/IR/Attrs.h"
 #include "llzk/Dialect/POD/IR/Dialect.h"
 
+#include <mlir/Interfaces/MemorySlotInterfaces.h>
+
 namespace llzk::pod {
 
 struct RecordValue {

--- a/include/llzk/Dialect/POD/IR/Types.td
+++ b/include/llzk/Dialect/POD/IR/Types.td
@@ -24,7 +24,10 @@ class PODDialectType<string name, string typeMnemonic, list<Trait> traits = []>
   let mnemonic = typeMnemonic;
 }
 
-def LLZK_PODType : PODDialectType<"Pod", "type"> {
+def LLZK_PODType
+    : PODDialectType<
+          "Pod",
+          "type", [DeclareTypeInterfaceMethods<DestructurableTypeInterface>]> {
   let summary = "plain-old-data struct";
   let description = [{
     Contains a list of `RecordAttr` defining structure of a pod.
@@ -71,6 +74,9 @@ def LLZK_PODType : PODDialectType<"Pod", "type"> {
     /// If you plan to make several queries to this type, it's better to generate the map
     /// once via `getRecordMap()` and query it instead of repeatedly calling `getRecord()`.
     ::llvm::StringMap<::mlir::Type> getRecordMap() const;
+
+    /// Creates a PodType containing only the requested record.
+    ::mlir::Type getSingleRecordType(::mlir::StringAttr name) const;
   }];
 }
 

--- a/lib/Dialect/POD/IR/Ops.cpp
+++ b/lib/Dialect/POD/IR/Ops.cpp
@@ -10,6 +10,7 @@
 #include "llzk/Dialect/POD/IR/Ops.h"
 
 #include "llzk/Dialect/Array/IR/Types.h"
+#include "llzk/Dialect/LLZK/IR/Ops.h"
 #include "llzk/Dialect/POD/IR/Types.h"
 #include "llzk/Dialect/Struct/IR/Types.h"
 #include "llzk/Util/TypeHelper.h"
@@ -29,6 +30,10 @@
 #include <llvm/Support/Debug.h>
 
 #include <cstdint>
+#include <optional>
+
+// TableGen'd implementation files
+#include "llzk/Dialect/POD/IR/OpInterfaces.cpp.inc"
 
 // TableGen'd implementation files
 #define GET_OP_CLASSES
@@ -82,6 +87,109 @@ void NewPodOp::build(
 
 void NewPodOp::getAsmResultNames(llvm::function_ref<void(Value, StringRef)> setNameFn) {
   setNameFn(getResult(), "pod");
+}
+
+/// Required by DestructurableAllocationOpInterface / SROA pass
+SmallVector<DestructurableMemorySlot> NewPodOp::getDestructurableSlots() {
+  PodType podType = getType();
+  if (podType.getRecords().size() <= 1 || !getMapOperands().empty()) {
+    return {};
+  }
+  if (auto destructured = podType.getSubelementIndexMap()) {
+    return {DestructurableMemorySlot {{getResult(), podType}, std::move(*destructured)}};
+  }
+  return {};
+}
+
+/// Required by DestructurableAllocationOpInterface / SROA pass
+DenseMap<Attribute, MemorySlot> NewPodOp::destructure(
+    const DestructurableMemorySlot &slot, const SmallPtrSetImpl<Attribute> &usedIndices,
+    OpBuilder &builder, SmallVectorImpl<DestructurableAllocationOpInterface> &newAllocators
+) {
+  assert(slot.ptr == getResult());
+  assert(slot.elemType == getType());
+
+  builder.setInsertionPointAfter(*this);
+
+  SmallVector<RecordValue> initializedRecords = getInitializedRecordValues();
+  DenseMap<Attribute, MemorySlot> slotMap;
+  for (Attribute index : usedIndices) {
+    auto recordName = llvm::dyn_cast<StringAttr>(index);
+    assert(recordName && "expected StringAttr");
+
+    Type destructAs = getType().getTypeAtIndex(recordName);
+    assert(destructAs == slot.subelementTypes.lookup(recordName));
+
+    auto destructAsPodTy = llvm::dyn_cast<PodType>(destructAs);
+    assert(destructAsPodTy && "expected PodType");
+
+    SmallVector<RecordValue, 1> initialValue;
+    for (RecordValue record : initializedRecords) {
+      if (record.name == recordName.getValue()) {
+        initialValue.push_back(record);
+        break;
+      }
+    }
+
+    auto subNew = builder.create<NewPodOp>(getLoc(), destructAsPodTy, initialValue);
+    newAllocators.push_back(subNew);
+    slotMap.try_emplace<MemorySlot>(index, {subNew.getResult(), destructAs});
+  }
+
+  return slotMap;
+}
+
+/// Required by DestructurableAllocationOpInterface / SROA pass
+std::optional<DestructurableAllocationOpInterface> NewPodOp::handleDestructuringComplete(
+    const DestructurableMemorySlot &slot, OpBuilder & /*builder*/
+) {
+  assert(slot.ptr == getResult());
+  this->erase();
+  return std::nullopt;
+}
+
+/// Required by PromotableAllocationOpInterface / mem2reg pass
+SmallVector<MemorySlot> NewPodOp::getPromotableSlots() {
+  ArrayRef<RecordAttr> records = getType().getRecords();
+  if (records.size() != 1) {
+    return {};
+  }
+  return {MemorySlot {getResult(), records.front().getType()}};
+}
+
+/// Required by PromotableAllocationOpInterface / mem2reg pass
+Value NewPodOp::getDefaultValue(const MemorySlot &slot, OpBuilder &builder) {
+  assert(slot.ptr == getResult());
+  ArrayRef<RecordAttr> records = getType().getRecords();
+  assert(records.size() == 1 && "only single-record pods are promotable");
+  assert(records.front().getType() == slot.elemType);
+
+  StringRef recordName = records.front().getName().getValue();
+  for (RecordValue record : getInitializedRecordValues()) {
+    if (record.name == recordName) {
+      return record.value;
+    }
+  }
+  return builder.create<llzk::NonDetOp>(getLoc(), slot.elemType);
+}
+
+/// Required by PromotableAllocationOpInterface / mem2reg pass
+void NewPodOp::handleBlockArgument(const MemorySlot &, BlockArgument, OpBuilder &) {}
+
+/// Required by PromotableAllocationOpInterface / mem2reg pass
+std::optional<PromotableAllocationOpInterface> NewPodOp::handlePromotionComplete(
+    const MemorySlot &slot, Value defaultValue, OpBuilder & /*builder*/
+) {
+  assert(slot.ptr == getResult());
+  if (defaultValue && defaultValue.use_empty()) {
+    if (Operation *defOp = defaultValue.getDefiningOp()) {
+      if (llvm::isa<llzk::NonDetOp>(defOp)) {
+        defOp->erase();
+      }
+    }
+  }
+  this->erase();
+  return std::nullopt;
 }
 
 namespace {
@@ -347,6 +455,43 @@ getInitializedRecordValues(ValueRange initialValues, ArrayAttr initializedRecord
 
 SmallVector<RecordValue> NewPodOp::getInitializedRecordValues() {
   return llzk::pod::getInitializedRecordValues(getInitialValues(), getInitializedRecords());
+}
+
+//===----------------------------------------------------------------------===//
+// PodAccessOpInterface
+//===----------------------------------------------------------------------===//
+
+/// Required by DestructurableAllocationOpInterface / SROA pass
+bool PodAccessOpInterface::canRewire(
+    const DestructurableMemorySlot &slot, SmallPtrSetImpl<Attribute> &usedIndices,
+    SmallVectorImpl<MemorySlot> & /*mustBeSafelyUsed*/, const DataLayout & /*dataLayout*/
+) {
+  if (slot.ptr != getPodRef()) {
+    return false;
+  }
+
+  StringAttr recordName = getRecordNameAsStringAttr();
+  if (!slot.subelementTypes.contains(recordName)) {
+    return false;
+  }
+
+  usedIndices.insert(recordName);
+  return true;
+}
+
+/// Required by DestructurableAllocationOpInterface / SROA pass
+DeletionKind PodAccessOpInterface::rewire(
+    const DestructurableMemorySlot &slot, DenseMap<Attribute, MemorySlot> &subslots,
+    OpBuilder & /*builder*/, const DataLayout & /*dataLayout*/
+) {
+  assert(slot.ptr == getPodRef());
+  assert(slot.elemType == getPodRefType());
+
+  StringAttr recordName = getRecordNameAsStringAttr();
+  const MemorySlot &memorySlot = subslots.at(recordName);
+  getPodRefMutable().set(memorySlot.ptr);
+
+  return DeletionKind::Keep;
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/POD/IR/Types.cpp
+++ b/lib/Dialect/POD/IR/Types.cpp
@@ -64,6 +64,30 @@ llvm::StringMap<Type> PodType::getRecordMap() const {
   return map;
 }
 
+Type PodType::getSingleRecordType(StringAttr recordName) const {
+  for (RecordAttr record : getRecords()) {
+    if (record.getName() == recordName.getValue()) {
+      return PodType::get(getContext(), {record});
+    }
+  }
+  return nullptr;
+}
+
+/// Required by DestructurableTypeInterface / SROA pass
+std::optional<DenseMap<Attribute, Type>> PodType::getSubelementIndexMap() const {
+  DenseMap<Attribute, Type> ret;
+  for (RecordAttr record : getRecords()) {
+    ret[record.getName()] = PodType::get(getContext(), {record});
+  }
+  return ret;
+}
+
+/// Required by DestructurableTypeInterface / SROA pass
+Type PodType::getTypeAtIndex(Attribute index) const {
+  auto recordName = llvm::dyn_cast<StringAttr>(index);
+  return recordName ? getSingleRecordType(recordName) : nullptr;
+}
+
 ParseResult parsePodType(AsmParser &parser, SmallVector<RecordAttr> &records) {
   return parser.parseCommaSeparatedList(AsmParser::Delimiter::Square, [&records, &parser]() {
     StringAttr name;


### PR DESCRIPTION
Preparation for pod-to-scalar pass which will utilize SROA and mem2reg which require these interfaces.