### PR TITLE
Restore insert point properly

### DIFF
--- a/changelogs/unreleased/dani__fix-insertion-point-on-edge-bis.yaml
+++ b/changelogs/unreleased/dani__fix-insertion-point-on-edge-bis.yaml
@@ -1,0 +1,3 @@
+fixed:
+  - CAPI:
+    - Insertion point not properly reconstructed when restoring

--- a/lib/CAPI/Builder.cpp
+++ b/lib/CAPI/Builder.cpp
@@ -129,8 +129,15 @@ MlirOpBuilderInsertPoint mlirOpBuilderSaveInsertionPoint(MlirOpBuilder builder) 
 
 /// Restore the insert point to a previously saved point.
 void mlirOpBuilderRestoreInsertionPoint(MlirOpBuilder builder, MlirOpBuilderInsertPoint rawIp) {
-  OpBuilderT::InsertPoint ip(unwrap(rawIp.block), Block::iterator(unwrap(rawIp.point)));
-  unwrap(builder)->restoreInsertionPoint(ip);
+  auto *block = unwrap(rawIp.block);
+  if (!block) {
+    OpBuilderT::InsertPoint ip;
+    unwrap(builder)->restoreInsertionPoint(ip);
+  } else {
+    Block::iterator it = rawIp.point.ptr ? Block::iterator(unwrap(rawIp.point)) : block->end();
+    OpBuilderT::InsertPoint ip(block, it);
+    unwrap(builder)->restoreInsertionPoint(ip);
+  }
 }
 
 /// Reset the insertion point to no location.

--- a/unittests/CAPI/Builder.cpp
+++ b/unittests/CAPI/Builder.cpp
@@ -207,6 +207,33 @@ TEST_F(CAPITest, MlirOpBuilderRestoreInsertionPoint) {
   mlirOperationDestroy(module);
 }
 
+TEST_F(CAPITest, MlirOpBuilderRestoreInsertionPointWithoutOperation) {
+  MlirBlock block;
+  MlirOperation module = createContainerOp(context, &block);
+  MlirOperation first = createIndexOperation();
+  MlirOperation second = createIndexOperation();
+  MlirOperation third = createIndexOperation();
+  mlirBlockAppendOwnedOperation(block, first);
+  mlirBlockAppendOwnedOperation(block, second);
+
+  auto builder = mlirOpBuilderCreate(context);
+
+  mlirOpBuilderSetInsertionPointToEnd(builder, block);
+  MlirOpBuilderInsertPoint saved = mlirOpBuilderSaveInsertionPoint(builder);
+  EXPECT_EQ(saved.block.ptr, block.ptr);
+  EXPECT_EQ(saved.point.ptr, nullptr);
+  mlirOpBuilderSetInsertionPointToStart(builder, block);
+  EXPECT_TRUE(mlirOperationEqual(mlirOpBuilderGetInsertionPoint(builder), first));
+  mlirOpBuilderRestoreInsertionPoint(builder, saved);
+  mlirOpBuilderInsert(builder, third);
+  EXPECT_EQ(mlirOpBuilderGetInsertionBlock(builder).ptr, block.ptr);
+  EXPECT_EQ(mlirOpBuilderGetInsertionPoint(builder).ptr, nullptr);
+  EXPECT_TRUE(mlirOperationEqual(mlirOperationGetNextInBlock(second), third));
+
+  mlirOpBuilderDestroy(builder);
+  mlirOperationDestroy(module);
+}
+
 TEST_F(CAPITest, MlirOpBuilderClearInsertionPoint) {
   MlirBlock block;
   MlirOperation module = createContainerOp(context, &block);


### PR DESCRIPTION
Second round of this because I missed one thing in #521. The CAPI side of the `Block::iterator` needs to be a null pointer, however the value that indicates "the end of the block" is not a null pointer but `Block::end`, that is probably some sort of sentinel value (`llvm::ilist` shenanigans). So this fix reconstructs the insert point properly, using `Block::end` when the CAPI point is a null operation.

I also added a new test that ensures the restoration is good by calling `mlirOpBuilderInsert` since that's the point where it will try use the insert point that was previously restored.
