### PR TITLE
Fix llzk-flatten cleanup for templated free functions

### DIFF
--- a/changelogs/unreleased/codex__github-mention-llzk-flatten-does-not-support-cleanup-for.yaml
+++ b/changelogs/unreleased/codex__github-mention-llzk-flatten-does-not-support-cleanup-for.yaml
@@ -1,0 +1,2 @@
+changed:
+  - Apply `llzk-flatten` cleanup option to free functions, not just structs

--- a/include/llzk/Dialect/Polymorphic/Transforms/TransformationPasses.td
+++ b/include/llzk/Dialect/Polymorphic/Transforms/TransformationPasses.td
@@ -13,15 +13,15 @@
 include "llzk/Pass/PassBase.td"
 include "mlir/IR/EnumAttr.td"
 
-def StructCleanupModeDescription {
+def FlatteningCleanupModeDescription {
   string r =
       "Specifies the extent to which unused parameterized definitions (i.e. "
       "structs or free functions within a `poly.template`) are removed during "
       "the flattening pass.";
 }
 
-def StructCleanupMode
-    : I32EnumAttr<"StructCleanupMode", StructCleanupModeDescription.r,
+def FlatteningCleanupMode
+    : I32EnumAttr<"FlatteningCleanupMode", FlatteningCleanupModeDescription.r,
                   [
                       // Disabled: No definitions are deleted.
                       I32EnumAttrCase<"Disabled", 0, "disabled">,
@@ -63,30 +63,30 @@ def FlatteningPass : LLZKPass<"llzk-flatten"> {
   }];
   let constructor = "llzk::polymorphic::createFlatteningPass()";
 
-  let options = [Option<
-                     "iterationLimit", "max-iter", "unsigned",
-                     /* default */ "1000",
-                     "Maximum number of times the pass will run if a fixpoint "
-                     "is not reached earlier. Unrolling loops can provide more "
-                     "opportunities for instantiating structs but the converse "
-                     "is true as well. Thus, the pass will run multiple times "
-                     "until no further changes can be made or the upper limit "
-                     "provided in this option is reached.">,
-                 Option<"cleanupMode", "cleanup",
-                        "::llzk::polymorphic::StructCleanupMode",
-                        /* default */
-                        "::llzk::polymorphic::StructCleanupMode::Preimage",
-                        StructCleanupModeDescription.r, [{::llvm::cl::values(
-                clEnumValN(::llzk::polymorphic::StructCleanupMode::Disabled,
-                           stringifyStructCleanupMode(::llzk::polymorphic::StructCleanupMode::Disabled), "No definitions are deleted."),
-                clEnumValN(::llzk::polymorphic::StructCleanupMode::Preimage,
-                           stringifyStructCleanupMode(::llzk::polymorphic::StructCleanupMode::Preimage),
+  let options =
+      [Option<"iterationLimit", "max-iter", "unsigned",
+              /* default */ "1000",
+              "Maximum number of times the pass will run if a fixpoint "
+              "is not reached earlier. Unrolling loops can provide more "
+              "opportunities for instantiating structs but the converse "
+              "is true as well. Thus, the pass will run multiple times "
+              "until no further changes can be made or the upper limit "
+              "provided in this option is reached.">,
+       Option<"cleanupMode", "cleanup",
+              "::llzk::polymorphic::FlatteningCleanupMode",
+              /* default */
+              "::llzk::polymorphic::FlatteningCleanupMode::Preimage",
+              FlatteningCleanupModeDescription.r, [{::llvm::cl::values(
+                clEnumValN(::llzk::polymorphic::FlatteningCleanupMode::Disabled,
+                           stringifyFlatteningCleanupMode(::llzk::polymorphic::FlatteningCleanupMode::Disabled), "No definitions are deleted."),
+                clEnumValN(::llzk::polymorphic::FlatteningCleanupMode::Preimage,
+                           stringifyFlatteningCleanupMode(::llzk::polymorphic::FlatteningCleanupMode::Preimage),
                            "Only definitions that were replaced with concrete instantiations are deleted."),
-                clEnumValN(::llzk::polymorphic::StructCleanupMode::ConcreteAsRoot,
-                           stringifyStructCleanupMode(::llzk::polymorphic::StructCleanupMode::ConcreteAsRoot),
+                clEnumValN(::llzk::polymorphic::FlatteningCleanupMode::ConcreteAsRoot,
+                           stringifyFlatteningCleanupMode(::llzk::polymorphic::FlatteningCleanupMode::ConcreteAsRoot),
                            "All definitions that cannot be reached by a use-def chain from some concrete definition are deleted."),
-                clEnumValN(::llzk::polymorphic::StructCleanupMode::MainAsRoot,
-                           stringifyStructCleanupMode(::llzk::polymorphic::StructCleanupMode::MainAsRoot),
+                clEnumValN(::llzk::polymorphic::FlatteningCleanupMode::MainAsRoot,
+                           stringifyFlatteningCleanupMode(::llzk::polymorphic::FlatteningCleanupMode::MainAsRoot),
                            "All definitions that cannot be reached by a use-def chain from the \"Main\" struct are deleted.")
           )}]>,
   ];

--- a/include/llzk/Dialect/Polymorphic/Transforms/TransformationPasses.td
+++ b/include/llzk/Dialect/Polymorphic/Transforms/TransformationPasses.td
@@ -14,9 +14,10 @@ include "llzk/Pass/PassBase.td"
 include "mlir/IR/EnumAttr.td"
 
 def StructCleanupModeDescription {
-  string r = "Specifies the extent to which unused parameterized definitions (i.e. "
-             "structs or free functions within a `poly.template`) are removed during the "
-             "flattening pass.";
+  string r =
+      "Specifies the extent to which unused parameterized definitions (i.e. "
+      "structs or free functions within a `poly.template`) are removed during "
+      "the flattening pass.";
 }
 
 def StructCleanupMode
@@ -24,11 +25,12 @@ def StructCleanupMode
                   [
                       // Disabled: No definitions are deleted.
                       I32EnumAttrCase<"Disabled", 0, "disabled">,
-                      // Preimage: Only definitions that were replaced with concrete
-                      // instantiations are deleted.
+                      // Preimage: Only definitions that were replaced with
+                      // concrete instantiations are deleted.
                       I32EnumAttrCase<"Preimage", 1, "preimage">,
-                      // ConcreteAsRoot: All definitions that cannot be reached by a
-                      // use-def chain from some concrete definition are deleted.
+                      // ConcreteAsRoot: All definitions that cannot be reached
+                      // by a use-def chain from some concrete definition are
+                      // deleted.
                       I32EnumAttrCase<"ConcreteAsRoot", 2, "concrete-as-root">,
                       // MainAsRoot: All definitions that cannot be reached by a
                       // use-def chain from the main struct are deleted.

--- a/include/llzk/Dialect/Polymorphic/Transforms/TransformationPasses.td
+++ b/include/llzk/Dialect/Polymorphic/Transforms/TransformationPasses.td
@@ -14,23 +14,23 @@ include "llzk/Pass/PassBase.td"
 include "mlir/IR/EnumAttr.td"
 
 def StructCleanupModeDescription {
-  string r = "Specifies the extent to which unused parameterized structs (i.e. "
-             "structs within a `poly.template`) are removed during the "
+  string r = "Specifies the extent to which unused parameterized definitions (i.e. "
+             "structs or free functions within a `poly.template`) are removed during the "
              "flattening pass.";
 }
 
 def StructCleanupMode
     : I32EnumAttr<"StructCleanupMode", StructCleanupModeDescription.r,
                   [
-                      // Disabled: No structs are deleted.
+                      // Disabled: No definitions are deleted.
                       I32EnumAttrCase<"Disabled", 0, "disabled">,
-                      // Preimage: Only structs that were replaced with concrete
+                      // Preimage: Only definitions that were replaced with concrete
                       // instantiations are deleted.
                       I32EnumAttrCase<"Preimage", 1, "preimage">,
-                      // ConcreteAsRoot: All structs that cannot be reached by a
-                      // use-def chain from some concrete struct are deleted.
+                      // ConcreteAsRoot: All definitions that cannot be reached by a
+                      // use-def chain from some concrete definition are deleted.
                       I32EnumAttrCase<"ConcreteAsRoot", 2, "concrete-as-root">,
-                      // MainAsRoot: All structs that cannot be reached by a
+                      // MainAsRoot: All definitions that cannot be reached by a
                       // use-def chain from the main struct are deleted.
                       I32EnumAttrCase<"MainAsRoot", 3, "main-as-root">,
 ]> {
@@ -76,16 +76,16 @@ def FlatteningPass : LLZKPass<"llzk-flatten"> {
                         "::llzk::polymorphic::StructCleanupMode::Preimage",
                         StructCleanupModeDescription.r, [{::llvm::cl::values(
                 clEnumValN(::llzk::polymorphic::StructCleanupMode::Disabled,
-                           stringifyStructCleanupMode(::llzk::polymorphic::StructCleanupMode::Disabled), "No structs are deleted."),
+                           stringifyStructCleanupMode(::llzk::polymorphic::StructCleanupMode::Disabled), "No definitions are deleted."),
                 clEnumValN(::llzk::polymorphic::StructCleanupMode::Preimage,
                            stringifyStructCleanupMode(::llzk::polymorphic::StructCleanupMode::Preimage),
-                           "Only structs that were replaced with concrete instantiations are deleted."),
+                           "Only definitions that were replaced with concrete instantiations are deleted."),
                 clEnumValN(::llzk::polymorphic::StructCleanupMode::ConcreteAsRoot,
                            stringifyStructCleanupMode(::llzk::polymorphic::StructCleanupMode::ConcreteAsRoot),
-                           "All structs that cannot be reached by a use-def chain from some concrete struct are deleted."),
+                           "All definitions that cannot be reached by a use-def chain from some concrete definition are deleted."),
                 clEnumValN(::llzk::polymorphic::StructCleanupMode::MainAsRoot,
                            stringifyStructCleanupMode(::llzk::polymorphic::StructCleanupMode::MainAsRoot),
-                           "All structs that cannot be reached by a use-def chain from the \"Main\" struct are deleted.")
+                           "All definitions that cannot be reached by a use-def chain from the \"Main\" struct are deleted.")
           )}]>,
   ];
 }

--- a/lib/Dialect/Polymorphic/Transforms/FlatteningPass.cpp
+++ b/lib/Dialect/Polymorphic/Transforms/FlatteningPass.cpp
@@ -2430,7 +2430,7 @@ private:
     // initial pass to remove things that are not reachable (as an optimization) because creating
     // an instantiated version of a struct will not cause something to become reachable that was
     // not already reachable in parameterized form.
-    if (cleanupMode == StructCleanupMode::MainAsRoot) {
+    if (cleanupMode == FlatteningCleanupMode::MainAsRoot) {
       if (failed(eraseUnreachableFromMainStruct(modOp))) {
         return failure();
       }
@@ -2529,13 +2529,13 @@ private:
   LogicalResult cleanupSwitch(ModuleOp modOp, const ConversionTracker &tracker) {
     LLVM_DEBUG({ llvm::dbgs() << "[FlatteningPass] Running step 5: cleanup "; });
     switch (cleanupMode) {
-    case StructCleanupMode::MainAsRoot:
+    case FlatteningCleanupMode::MainAsRoot:
       LLVM_DEBUG(llvm::dbgs() << "(main as root mode)\n");
       return eraseUnreachableFromMainStruct(modOp, false);
-    case StructCleanupMode::ConcreteAsRoot:
+    case FlatteningCleanupMode::ConcreteAsRoot:
       LLVM_DEBUG(llvm::dbgs() << "(concrete definitions mode)\n");
       return eraseUnreachableFromConcreteDefinitions(modOp);
-    case StructCleanupMode::Preimage:
+    case FlatteningCleanupMode::Preimage:
       LLVM_DEBUG(llvm::dbgs() << "(preimage mode)\n");
       return erasePreimageOfInstantiations(modOp, tracker);
     default:
@@ -2610,7 +2610,7 @@ private:
       rootMod.emitWarning()
           .append(
               "using option '", cleanupMode.getArgStr(), '=',
-              stringifyStructCleanupMode(StructCleanupMode::MainAsRoot), "' with no \"",
+              stringifyFlatteningCleanupMode(FlatteningCleanupMode::MainAsRoot), "' with no \"",
               MAIN_ATTR_NAME,
               "\" attribute on the top-level module may remove all cleanup-candidate definitions!"
           )

--- a/lib/Dialect/Polymorphic/Transforms/FlatteningPass.cpp
+++ b/lib/Dialect/Polymorphic/Transforms/FlatteningPass.cpp
@@ -2223,8 +2223,7 @@ struct FromKeepSet : public CleanupBase {
                 (void)insertRes; // tell compiler it's intentionally unused in release builds
                 LLVM_DEBUG({
                   if (insertRes) {
-                    llvm::dbgs() << "[EraseUnreachable]  found another root: " << asSymbol
-                                 << '\n';
+                    llvm::dbgs() << "[EraseUnreachable]  found another root: " << asSymbol << '\n';
                   }
                 });
               }
@@ -2612,7 +2611,8 @@ private:
           .append(
               "using option '", cleanupMode.getArgStr(), '=',
               stringifyStructCleanupMode(StructCleanupMode::MainAsRoot), "' with no \"",
-              MAIN_ATTR_NAME, "\" attribute on the top-level module may remove all cleanup-candidate definitions!"
+              MAIN_ATTR_NAME,
+              "\" attribute on the top-level module may remove all cleanup-candidate definitions!"
           )
           .report();
     }

--- a/lib/Dialect/Polymorphic/Transforms/FlatteningPass.cpp
+++ b/lib/Dialect/Polymorphic/Transforms/FlatteningPass.cpp
@@ -103,6 +103,8 @@ class ConversionTracker {
   DenseMap<StructType, StructType> structInstantiations;
   /// Contains the reverse of mappings in `structInstantiations` for use in legal conversion check.
   DenseMap<StructType, StructType> reverseInstantiations;
+  /// Tracks original free function definitions for which instantiated clones were created.
+  DenseSet<SymbolRefAttr> funcInstantiations;
   /// Maps new remote type (i.e., the values in 'structInstantiations') to a list of Diagnostic
   /// to report at the location(s) of the compute() that causes the instantiation to the StructType.
   DenseMap<StructType, SmallVector<Diagnostic>> delayedDiagnostics;
@@ -141,9 +143,15 @@ public:
     return std::nullopt;
   }
 
-  /// Collect the fully-qualified names of all structs that were instantiated.
-  DenseSet<SymbolRefAttr> getInstantiatedStructNames() const {
-    DenseSet<SymbolRefAttr> instantiatedNames;
+  /// Record that the given free function was instantiated.
+  void recordInstantiation(SymbolRefAttr funcName) {
+    funcInstantiations.insert(funcName);
+    modified = true;
+  }
+
+  /// Collect the fully-qualified names of all structs and free functions that were instantiated.
+  DenseSet<SymbolRefAttr> getInstantiatedDefinitionNames() const {
+    DenseSet<SymbolRefAttr> instantiatedNames = funcInstantiations;
     for (const auto &[origRemoteTy, _] : structInstantiations) {
       instantiatedNames.insert(origRemoteTy.getNameRef());
     }
@@ -1214,6 +1222,7 @@ public:
 
     SmallVector<FlatSymbolRefAttr> symPieces = getPieces(op.getCalleeAttr());
     assert(symPieces.size() >= 2 && "callee must include at least template and function names");
+    SymbolRefAttr originalCalleeAttr = asSymbolRefAttr(symPieces);
     if (remainingNames.empty()) {
       // FULL INSTANTIATION: place the cloned function directly in the parent module.
       // New function name encodes all parameter values, e.g., "TemplateName_8_12_funcName".
@@ -1317,6 +1326,8 @@ public:
       symPieces.push_back(FlatSymbolRefAttr::get(newTemplate.getSymNameAttr()));
       symPieces.push_back(FlatSymbolRefAttr::get(callTgt.getSymNameAttr()));
     }
+
+    tracker_.recordInstantiation(originalCalleeAttr);
 
     // Update the CallOp to point to the instantiated function and mark the module as modified.
     rewriter.modifyOpInPlace(op, [&op, &symPieces]() {
@@ -2130,22 +2141,39 @@ protected:
 struct FromKeepSet : public CleanupBase {
   using CleanupBase::CleanupBase;
 
-  /// Erase all StructDefOp that are not reachable (via calls, types, or symbol usage) from one of
-  /// the StructDefOp given or from some global def or free function (since this pass does not
-  /// remove either of those, any symbols reachable from them must not be removed).
-  LogicalResult eraseUnreachableFrom(ArrayRef<StructDefOp> keep) {
-    // Initialize roots from the given StructDefOp instances
-    SetVector<SymbolOpInterface> roots(keep.begin(), keep.end());
-    // Add GlobalDefOp and "free functions" to the set of roots
-    rootMod.walk([&roots](Operation *op) {
-      if (global::GlobalDefOp gdef = llvm::dyn_cast<global::GlobalDefOp>(op)) {
-        roots.insert(gdef);
-      } else if (function::FuncDefOp fdef = llvm::dyn_cast<function::FuncDefOp>(op)) {
-        if (!fdef.isInStruct()) {
-          roots.insert(fdef);
-        }
+  /// Return `true` iff the given free function or struct definition still has unresolved template
+  /// symbol bindings.
+  static bool hasTemplateSymbolBindings(Operation *op) {
+    if (StructDefOp sdef = llvm::dyn_cast<StructDefOp>(op)) {
+      return sdef.hasTemplateSymbolBindings();
+    }
+    if (llvm::isa<function::FuncDefOp>(op)) {
+      if (TemplateOp parent = getParentOfType<TemplateOp>(op)) {
+        return parent.hasConstOps<TemplateSymbolBindingOpInterface>();
       }
-    });
+    }
+    return false;
+  }
+
+  /// Return `true` iff `op` is a cleanup candidate.
+  static bool isErasableDefinition(Operation *op) {
+    if (llvm::isa<StructDefOp>(op)) {
+      return true;
+    }
+    if (function::FuncDefOp fdef = llvm::dyn_cast<function::FuncDefOp>(op)) {
+      return !fdef.isInStruct();
+    }
+    return false;
+  }
+
+  /// Erase all cleanup-candidate definitions that are not reachable (via calls, types, or symbol
+  /// usage) from one of the given roots or from some global def (since this pass does not remove
+  /// global definitions, any symbols reachable from them must not be removed).
+  LogicalResult eraseUnreachableFrom(ArrayRef<SymbolOpInterface> keep) {
+    // Initialize roots from the given symbol definitions.
+    SetVector<SymbolOpInterface> roots(keep.begin(), keep.end());
+    // Add GlobalDefOp to the set of roots.
+    rootMod.walk([&roots](global::GlobalDefOp gdef) { roots.insert(gdef); });
 
     // Use a SymbolDefTree to find all Symbol defs reachable from one of the root nodes. Then
     // collect all Symbol uses reachable from those def nodes. These are the symbols that should
@@ -2155,7 +2183,7 @@ struct FromKeepSet : public CleanupBase {
       SymbolOpInterface keepRoot = roots[i];
       LLVM_DEBUG({ llvm::dbgs() << "[EraseUnreachable] root: " << keepRoot << '\n'; });
       const SymbolDefTreeNode *keepRootNode = defTree.lookupNode(keepRoot);
-      assert(keepRootNode && "every struct def must be in the def tree");
+      assert(keepRootNode && "every symbol def must be in the def tree");
       for (const SymbolDefTreeNode *reachableDefNode : llvm::depth_first(keepRootNode)) {
         LLVM_DEBUG({
           llvm::dbgs() << "[EraseUnreachable] can reach: " << reachableDefNode->getOp() << '\n';
@@ -2163,8 +2191,8 @@ struct FromKeepSet : public CleanupBase {
         if (SymbolOpInterface reachableDef = reachableDefNode->getOp()) {
           // Use 'depth_first_ext()' to get all symbol uses reachable from the current Symbol def
           // node. There are no uses if the node is not in the graph. Within the loop that populates
-          // 'depth_first_ext()', also check if the symbol is a StructDefOp and ensure it is in
-          // 'roots' so the outer loop will ensure that all symbols reachable from it are preserved.
+          // 'depth_first_ext()', also check if the symbol is an erasable definition and ensure it
+          // is in 'roots' so the outer loop preserves all symbols reachable from it.
           if (const SymbolUseGraphNode *useGraphNodeForDef = useGraph.lookupNode(reachableDef)) {
             for (const SymbolUseGraphNode *usedSymbolNode :
                  depth_first_ext(useGraphNodeForDef, symbolsToKeep)) {
@@ -2177,7 +2205,8 @@ struct FromKeepSet : public CleanupBase {
               if (usedSymbolNode->isTemplateSymbolBinding()) {
                 continue;
               }
-              // If `usedSymbolNode` references a StructDefOp, ensure it's considered in the roots.
+              // If `usedSymbolNode` references an erasable definition, ensure it's considered in
+              // the roots so symbols reachable from its body are preserved too.
               auto lookupRes = usedSymbolNode->lookupSymbol(tables);
               if (failed(lookupRes)) {
                 LLVM_DEBUG(useGraph.dumpToDotFile());
@@ -2187,12 +2216,15 @@ struct FromKeepSet : public CleanupBase {
               if (lookupRes->viaInclude()) {
                 continue;
               }
-              if (StructDefOp asStruct = llvm::dyn_cast<StructDefOp>(lookupRes->get())) {
-                bool insertRes = roots.insert(asStruct);
+              Operation *usedOp = lookupRes->get();
+              if (isErasableDefinition(usedOp)) {
+                SymbolOpInterface asSymbol = llvm::cast<SymbolOpInterface>(usedOp);
+                bool insertRes = roots.insert(asSymbol);
                 (void)insertRes; // tell compiler it's intentionally unused in release builds
                 LLVM_DEBUG({
                   if (insertRes) {
-                    llvm::dbgs() << "[EraseUnreachable]  found another root: " << asStruct << '\n';
+                    llvm::dbgs() << "[EraseUnreachable]  found another root: " << asSymbol
+                                 << '\n';
                   }
                 });
               }
@@ -2202,16 +2234,22 @@ struct FromKeepSet : public CleanupBase {
       }
     }
 
-    rootMod.walk([this, &symbolsToKeep](StructDefOp op) {
-      const SymbolUseGraphNode *n = this->useGraph.lookupNode(op);
+    SmallVector<SymbolOpInterface> toErase;
+    rootMod.walk([this, &symbolsToKeep, &toErase](Operation *op) {
+      if (!isErasableDefinition(op)) {
+        return;
+      }
+      SymbolOpInterface symOp = llvm::cast<SymbolOpInterface>(op);
+      const SymbolUseGraphNode *n = this->useGraph.lookupNode(symOp);
       assert(n);
       if (!symbolsToKeep.contains(n)) {
-        LLVM_DEBUG(llvm::dbgs() << "[EraseUnreachable] removing: " << op.getSymName() << '\n');
-        op.erase();
+        LLVM_DEBUG(llvm::dbgs() << "[EraseUnreachable] removing: " << symOp.getNameAttr() << '\n');
+        toErase.push_back(symOp);
       }
-
-      return WalkResult::skip(); // StructDefOp cannot be nested
     });
+    for (SymbolOpInterface symOp : toErase) {
+      symOp.erase();
+    }
 
     return success();
   }
@@ -2225,14 +2263,15 @@ struct FromEraseSet : public CleanupBase {
       DenseSet<SymbolRefAttr> &&tryToErasePaths
   )
       : CleanupBase(root, symDefTree, symUseGraph) {
-    // Convert the set of paths targeted for erasure into a set of the StructDefOp
+    // Convert the set of paths targeted for erasure into a set of cleanup-candidate definitions.
     for (SymbolRefAttr path : tryToErasePaths) {
       LLVM_DEBUG(llvm::dbgs() << "[FromEraseSet] path to erase: " << path << '\n';);
       Operation *lookupFrom = rootMod.getOperation();
-      auto res = lookupSymbolIn<StructDefOp>(tables, path, lookupFrom, lookupFrom);
-      assert(succeeded(res) && "inputs must be valid StructDefOp references");
+      auto res = lookupSymbolIn(tables, path, Within(), lookupFrom);
+      assert(succeeded(res) && "inputs must be valid symbol references");
+      assert(FromKeepSet::isErasableDefinition(res->get()) && "inputs must be cleanup candidates");
       if (!res->viaInclude()) { // do not remove if it's from another source file
-        auto op = res->get();
+        SymbolOpInterface op = llvm::cast<SymbolOpInterface>(res->get());
         LLVM_DEBUG(llvm::dbgs() << "[FromEraseSet]   added op to the erase set: " << op << '\n';);
         tryToErase.insert(op);
       } else {
@@ -2244,17 +2283,16 @@ struct FromEraseSet : public CleanupBase {
     }
   }
 
-  LogicalResult eraseUnusedStructs() {
+  LogicalResult eraseUnusedDefinitions() {
     // Collect the subset of 'tryToErase' that has no remaining uses.
-    for (StructDefOp sd : tryToErase) {
-      collectSafeToErase(sd);
+    for (SymbolOpInterface sym : tryToErase) {
+      collectSafeToErase(sym);
     }
-    // The `visitedPlusSafetyResult` will contain FuncDefOp w/in the StructDefOp so just a single
-    // loop to `dyn_cast` and `erase()` will cause `use-after-free` errors w/in the `dyn_cast`.
-    // Instead, reduce the map to only those that should be erased and erase in a separate loop.
-    for (auto it = visitedPlusSafetyResult.begin(); it != visitedPlusSafetyResult.end(); ++it) {
-      if (!it->second || !llvm::isa<StructDefOp>(it->first.getOperation())) {
-        visitedPlusSafetyResult.erase(it);
+    // The `visitedPlusSafetyResult` may contain child FuncDefOp within an erased StructDefOp, so
+    // reduce the map to only top-level erase targets before erasing in a separate loop.
+    for (auto &it : llvm::make_early_inc_range(visitedPlusSafetyResult)) {
+      if (!it.second || !tryToErase.contains(it.first)) {
+        visitedPlusSafetyResult.erase(it.first);
       }
     }
     for (auto &[sym, _] : visitedPlusSafetyResult) {
@@ -2264,11 +2302,11 @@ struct FromEraseSet : public CleanupBase {
     return success();
   }
 
-  const DenseSet<StructDefOp> &getTryToEraseSet() const { return tryToErase; }
+  const DenseSet<SymbolOpInterface> &getTryToEraseSet() const { return tryToErase; }
 
 private:
-  /// The initial set of structs that this should try to erase (if there are no other uses).
-  DenseSet<StructDefOp> tryToErase;
+  /// The initial set of definitions that this should try to erase (if there are no other uses).
+  DenseSet<SymbolOpInterface> tryToErase;
   /// Track visited nodes to avoid cycles (for example, a struct has its functions as children in
   /// the def graph but the opposite direction edges exist in the use graph) and map if they were
   /// determined safe to remove or not.
@@ -2287,12 +2325,10 @@ private:
       return visited->second;
     }
 
-    // If it's a StructDefOp that is not in `tryToErase` then it cannot be erased.
-    if (StructDefOp sd = llvm::dyn_cast<StructDefOp>(check.getOperation())) {
-      if (!tryToErase.contains(sd)) {
-        visitedPlusSafetyResult[check] = false;
-        return false;
-      }
+    // If it's an erasable definition that is not in `tryToErase` then it cannot be erased.
+    if (FromKeepSet::isErasableDefinition(check.getOperation()) && !tryToErase.contains(check)) {
+      visitedPlusSafetyResult[check] = false;
+      return false;
     }
 
     // Otherwise, temporarily mark as safe b/c a node cannot keep itself live (and this prevents
@@ -2498,8 +2534,8 @@ private:
       LLVM_DEBUG(llvm::dbgs() << "(main as root mode)\n");
       return eraseUnreachableFromMainStruct(modOp, false);
     case StructCleanupMode::ConcreteAsRoot:
-      LLVM_DEBUG(llvm::dbgs() << "(concrete structs mode)\n");
-      return eraseUnreachableFromConcreteStructs(modOp);
+      LLVM_DEBUG(llvm::dbgs() << "(concrete definitions mode)\n");
+      return eraseUnreachableFromConcreteDefinitions(modOp);
     case StructCleanupMode::Preimage:
       LLVM_DEBUG(llvm::dbgs() << "(preimage mode)\n");
       return erasePreimageOfInstantiations(modOp, tracker);
@@ -2509,33 +2545,34 @@ private:
     }
   }
 
-  // Erase parameterized structs that were replaced with concrete instantiations.
+  // Erase parameterized definitions that were replaced with concrete instantiations.
   LogicalResult erasePreimageOfInstantiations(ModuleOp rootMod, const ConversionTracker &tracker) {
-    // TODO: The names from getInstantiatedStructNames() are NOT guaranteed to be paths from the
+    // TODO: The names from getInstantiatedDefinitionNames() are NOT guaranteed to be paths from the
     // "top root" and they also do not indicate a root module so there could be ambiguity. This is a
     // broader problem in the FlatteningPass itself so let's just assume, for now, that these are
     // paths from the "top root". See [LLZK-286].
     Step5_Cleanup::FromEraseSet cleaner(
         rootMod, getAnalysis<SymbolDefTree>(), getAnalysis<SymbolUseGraph>(),
-        tracker.getInstantiatedStructNames()
+        tracker.getInstantiatedDefinitionNames()
     );
-    LogicalResult res = cleaner.eraseUnusedStructs();
+    LogicalResult res = cleaner.eraseUnusedDefinitions();
     if (succeeded(res)) {
       LLVM_DEBUG(llvm::dbgs() << "[Cleanup(preimage)] success\n";);
-      // Warn about any structs that were instantiated but still have uses elsewhere.
+      // Warn about any definitions that were instantiated but still have uses elsewhere.
       const SymbolUseGraph *useGraph = nullptr;
-      rootMod->walk([this, &cleaner, &useGraph](StructDefOp op) {
-        if (cleaner.getTryToEraseSet().contains(op)) {
-          // If needed, rebuild use graph to reflect deletions.
-          if (!useGraph) {
-            useGraph = &getAnalysis<SymbolUseGraph>();
-          }
-          // If the op has any users, report the warning.
-          if (useGraph->lookupNode(op)->hasPredecessor()) {
-            op.emitWarning("Parameterized struct still has uses!").report();
-          }
+      rootMod->walk([this, &cleaner, &useGraph](Operation *walkedOp) {
+        SymbolOpInterface op = llvm::dyn_cast<SymbolOpInterface>(walkedOp);
+        if (!op || !cleaner.getTryToEraseSet().contains(op)) {
+          return;
         }
-        return WalkResult::skip(); // StructDefOp cannot be nested
+        // If needed, rebuild use graph to reflect deletions.
+        if (!useGraph) {
+          useGraph = &getAnalysis<SymbolUseGraph>();
+        }
+        // If the op has any users, report the warning.
+        if (useGraph->lookupNode(op)->hasPredecessor()) {
+          op.emitWarning("Parameterized definition still has uses!").report();
+        }
       });
     } else {
       LLVM_DEBUG(llvm::dbgs() << "[Cleanup(preimage)] failed\n";);
@@ -2543,13 +2580,13 @@ private:
     return res;
   }
 
-  LogicalResult eraseUnreachableFromConcreteStructs(ModuleOp rootMod) {
-    SmallVector<StructDefOp> roots;
-    rootMod.walk([&roots](StructDefOp op) {
-      if (!op.hasTemplateSymbolBindings()) {
-        roots.push_back(op);
+  LogicalResult eraseUnreachableFromConcreteDefinitions(ModuleOp rootMod) {
+    SmallVector<SymbolOpInterface> roots;
+    rootMod.walk([&roots](Operation *op) {
+      if (Step5_Cleanup::FromKeepSet::isErasableDefinition(op) &&
+          !Step5_Cleanup::FromKeepSet::hasTemplateSymbolBindings(op)) {
+        roots.push_back(llvm::cast<SymbolOpInterface>(op));
       }
-      return WalkResult::skip(); // StructDefOp cannot be nested
     });
 
     Step5_Cleanup::FromKeepSet cleaner(
@@ -2569,20 +2606,21 @@ private:
     }
     SymbolLookupResult<StructDefOp> main = mainOpt.value();
     if (emitWarning && !main) {
-      // Emit warning if there is no main specified because all structs may be removed (only
-      // structs that are reachable from a global def or free function will be preserved since
-      // those constructs are not candidate for removal in this pass).
+      // Emit warning if there is no main specified because all cleanup-candidate definitions not
+      // reachable from global defs may be removed.
       rootMod.emitWarning()
           .append(
               "using option '", cleanupMode.getArgStr(), '=',
               stringifyStructCleanupMode(StructCleanupMode::MainAsRoot), "' with no \"",
-              MAIN_ATTR_NAME, "\" attribute on the top-level module may remove all structs!"
+              MAIN_ATTR_NAME, "\" attribute on the top-level module may remove all cleanup-candidate definitions!"
           )
           .report();
     }
-    return cleaner.eraseUnreachableFrom(
-        main ? ArrayRef<StructDefOp> {*main} : ArrayRef<StructDefOp> {}
-    );
+    SmallVector<SymbolOpInterface> roots;
+    if (main) {
+      roots.push_back(*main);
+    }
+    return cleaner.eraseUnreachableFrom(roots);
   }
 };
 

--- a/lib/Dialect/Polymorphic/Transforms/FlatteningPass.cpp
+++ b/lib/Dialect/Polymorphic/Transforms/FlatteningPass.cpp
@@ -2178,6 +2178,7 @@ struct FromKeepSet : public CleanupBase {
     // Use a SymbolDefTree to find all Symbol defs reachable from one of the root nodes. Then
     // collect all Symbol uses reachable from those def nodes. These are the symbols that should
     // be preserved. All other symbol defs should be removed.
+    DenseSet<Operation *> defsToKeep;
     llvm::df_iterator_default_set<const SymbolUseGraphNode *> symbolsToKeep;
     for (size_t i = 0; i < roots.size(); ++i) { // iterate for safe insertion
       SymbolOpInterface keepRoot = roots[i];
@@ -2189,6 +2190,9 @@ struct FromKeepSet : public CleanupBase {
           llvm::dbgs() << "[EraseUnreachable] can reach: " << reachableDefNode->getOp() << '\n';
         });
         if (SymbolOpInterface reachableDef = reachableDefNode->getOp()) {
+          if (isErasableDefinition(reachableDef.getOperation())) {
+            defsToKeep.insert(reachableDef.getOperation());
+          }
           // Use 'depth_first_ext()' to get all symbol uses reachable from the current Symbol def
           // node. There are no uses if the node is not in the graph. Within the loop that populates
           // 'depth_first_ext()', also check if the symbol is an erasable definition and ensure it
@@ -2234,14 +2238,13 @@ struct FromKeepSet : public CleanupBase {
     }
 
     SmallVector<SymbolOpInterface> toErase;
-    rootMod.walk([this, &symbolsToKeep, &toErase](Operation *op) {
-      if (!isErasableDefinition(op)) {
+    rootMod.walk([this, &defsToKeep, &symbolsToKeep, &toErase](Operation *op) {
+      if (!isErasableDefinition(op) || defsToKeep.contains(op)) {
         return;
       }
       SymbolOpInterface symOp = llvm::cast<SymbolOpInterface>(op);
       const SymbolUseGraphNode *n = this->useGraph.lookupNode(symOp);
-      assert(n);
-      if (!symbolsToKeep.contains(n)) {
+      if (!n || !symbolsToKeep.contains(n)) {
         LLVM_DEBUG(llvm::dbgs() << "[EraseUnreachable] removing: " << symOp.getNameAttr() << '\n');
         toErase.push_back(symOp);
       }

--- a/test/Transforms/Flattening/cleanup_concreteAsRoot.llzk
+++ b/test/Transforms/Flattening/cleanup_concreteAsRoot.llzk
@@ -1,9 +1,9 @@
 // RUN: llzk-opt -split-input-file -verify-diagnostics --pass-pipeline='builtin.module(llzk-flatten{cleanup=concrete-as-root})' %s | FileCheck --enable-var-scope %s
 
-// TEST: With "cleanup=concrete-as-root", all structs without parameters are preserved. Structs
-// that are reachable from one of these "concrete" structs or reachable from a global def or
-// free function (since those are not subject to removal during this pass) are also preserved.
-// All other structs are removed.
+// TEST: With "cleanup=concrete-as-root", all structs and free functions without parameters
+// are preserved. Structs and free functions that are reachable from one of these "concrete"
+// definitions or reachable from a global def are also preserved. All other structs and free
+// functions are removed.
 
 module attributes {llzk.lang} {
   global.def @g : !struct.type<@HasUseFromGlobal>
@@ -574,3 +574,26 @@ module attributes {llzk.lang} {
 // CHECK-NOT: poly.template @TNoUse {
 // CHECK:     struct.def @TransitiveUseFromMain {
 // CHECK-NOT: poly.template @TNoUse {
+
+// -----
+
+module attributes {llzk.lang} {
+  function.def @concrete(%inp: !array.type<4 x !felt.type>) -> !felt.type {
+    %c0 = arith.constant 0 : index
+    %r = array.read %inp[%c0] : !array.type<4 x !felt.type>, !felt.type
+    function.return %r : !felt.type
+  }
+
+  poly.template @TNoUseFunc {
+    poly.param @N : index
+
+    function.def @no_use(%inp: !array.type<@N x !felt.type>) -> !felt.type {
+      %c0 = arith.constant 0 : index
+      %r = array.read %inp[%c0] : !array.type<@N x !felt.type>, !felt.type
+      function.return %r : !felt.type
+    }
+  }
+}
+// CHECK-NOT: poly.template @TNoUseFunc {
+// CHECK:     function.def @concrete
+// CHECK-NOT: poly.template @TNoUseFunc {

--- a/test/Transforms/Flattening/cleanup_mainAsRoot.llzk
+++ b/test/Transforms/Flattening/cleanup_mainAsRoot.llzk
@@ -1,8 +1,8 @@
 // RUN: llzk-opt -split-input-file -verify-diagnostics --pass-pipeline='builtin.module(llzk-flatten{cleanup=main-as-root})' %s | FileCheck --enable-var-scope %s
 
-// TEST: With "cleanup=main-as-root", all structs reachable from the main struct are preserved.
-// If there is no main struct, all structs are removed (except those that have a reference from
-// a global def or from a free function since those are not subject to removal during this pass).
+// TEST: With "cleanup=main-as-root", all structs and free functions reachable from the main
+// struct are preserved. If there is no main struct, all cleanup-candidate definitions are removed
+// except those that have a reference from a global def.
 
 module attributes {llzk.main = !struct.type<@Main>, llzk.lang} {
   global.def @g : !struct.type<@HasUseFromGlobal>
@@ -45,7 +45,7 @@ module attributes {llzk.main = !struct.type<@Main>, llzk.lang} {
     }
   }
 
-  // preserved
+  // removed
   struct.def @HasUseFromFreeFunc {
     function.def @compute() -> !struct.type<@HasUseFromFreeFunc> {
       %self = struct.new : !struct.type<@HasUseFromFreeFunc>
@@ -77,12 +77,12 @@ module attributes {llzk.main = !struct.type<@Main>, llzk.lang} {
 // CHECK:     struct.def @HasUseFromGlobal {
 // CHECK-NOT: poly.template @TNoUse {
 // CHECK:     struct.def @HasUseFromMain {
-// CHECK-NOT: poly.template @TNoUse {
-// CHECK:     struct.def @HasUseFromFreeFunc {
+// CHECK-NOT: struct.def @HasUseFromFreeFunc {
+// CHECK-NOT: function.def @free
 // CHECK-NOT: poly.template @TNoUse {
 // -----
 
-// expected-warning@+1 {{using option 'cleanup=main-as-root' with no "llzk.main" attribute on the top-level module may remove all structs!}}
+// expected-warning@+1 {{using option 'cleanup=main-as-root' with no "llzk.main" attribute on the top-level module may remove all cleanup-candidate definitions!}}
 module attributes {llzk.lang} {
   global.def @g : !struct.type<@HasUse>
 
@@ -121,7 +121,7 @@ module attributes {llzk.lang} {
 // CHECK-NOT: poly.template @TNoUse {
 // -----
 
-// expected-warning@+1 {{using option 'cleanup=main-as-root' with no "llzk.main" attribute on the top-level module may remove all structs!}}
+// expected-warning@+1 {{using option 'cleanup=main-as-root' with no "llzk.main" attribute on the top-level module may remove all cleanup-candidate definitions!}}
 module attributes {llzk.lang} {
   global.def @a : !struct.type<@StructsWithinNestedModule::@THasUse::@HasUse<[i1]>>
 
@@ -165,7 +165,7 @@ module attributes {llzk.lang} {
 // CHECK-NOT:   poly.template @THasUse {
 // -----
 
-// expected-warning@+1 {{using option 'cleanup=main-as-root' with no "llzk.main" attribute on the top-level module may remove all structs!}}
+// expected-warning@+1 {{using option 'cleanup=main-as-root' with no "llzk.main" attribute on the top-level module may remove all cleanup-candidate definitions!}}
 module attributes {llzk.lang} {
   module @GlobalWithinNestedModule {
     global.def @a : !struct.type<@THasUse::@HasUse<[!felt.type]>>
@@ -207,7 +207,7 @@ module attributes {llzk.lang} {
 // CHECK-NOT: poly.template @THasUse {
 // -----
 
-// expected-warning@+1 {{using option 'cleanup=main-as-root' with no "llzk.main" attribute on the top-level module may remove all structs!}}
+// expected-warning@+1 {{using option 'cleanup=main-as-root' with no "llzk.main" attribute on the top-level module may remove all cleanup-candidate definitions!}}
 module attributes {llzk.lang} {
   module @FreeFuncInModule {
     function.def @struct_param(%a: !struct.type<@DefsInDifferentModule::@THasUse::@HasUse<[!felt.type]>>) -> !felt.type {
@@ -245,16 +245,13 @@ module attributes {llzk.lang} {
   }
 }
 // CHECK-LABEL: module @FreeFuncInModule
-// CHECK:       function.def @struct_param
+// CHECK-NOT:   function.def @struct_param
 // CHECK-LABEL: module @DefsInDifferentModule
-// CHECK-NOT:   struct.def @NoUse {
-// CHECK-NOT:   poly.template @THasUse {
-// CHECK:       struct.def @THasUse_f_HasUse {
 // CHECK-NOT:   struct.def @NoUse {
 // CHECK-NOT:   poly.template @THasUse {
 // -----
 
-// expected-warning@+1 {{using option 'cleanup=main-as-root' with no "llzk.main" attribute on the top-level module may remove all structs!}}
+// expected-warning@+1 {{using option 'cleanup=main-as-root' with no "llzk.main" attribute on the top-level module may remove all cleanup-candidate definitions!}}
 module attributes {llzk.lang} {
   module @GlobalsWithinNestedModule {
     global.def @a : !struct.type<@THasUse::@HasUse<[!felt.type]>>
@@ -309,7 +306,7 @@ module attributes {llzk.lang} {
 // CHECK-NOT: poly.template @THasUse {
 // -----
 
-// expected-warning@+1 {{using option 'cleanup=main-as-root' with no "llzk.main" attribute on the top-level module may remove all structs!}}
+// expected-warning@+1 {{using option 'cleanup=main-as-root' with no "llzk.main" attribute on the top-level module may remove all cleanup-candidate definitions!}}
 module attributes {llzk.lang} {
   module @FreeFuncModule {
     module @Level2A {
@@ -361,13 +358,9 @@ module attributes {llzk.lang} {
   }
 }
 // CHECK-LABEL: module @FreeFuncModule
-// CHECK:       function.def @struct_param
-// CHECK:       function.def @struct_param
+// CHECK-NOT:   function.def @struct_param
 // CHECK-LABEL: module @StructModule
 // CHECK-LABEL: module @MoreNested
-// CHECK-NOT:   struct.def @NoUse {
-// CHECK-NOT:   poly.template @THasUse {
-// CHECK:       struct.def @THasUse_f_HasUse {
 // CHECK-NOT:   struct.def @NoUse {
 // CHECK-NOT:   poly.template @THasUse {
 // -----

--- a/test/Transforms/Flattening/cleanup_mainAsRoot.llzk
+++ b/test/Transforms/Flattening/cleanup_mainAsRoot.llzk
@@ -210,6 +210,7 @@ module attributes {llzk.lang} {
 // expected-warning@+1 {{using option 'cleanup=main-as-root' with no "llzk.main" attribute on the top-level module may remove all cleanup-candidate definitions!}}
 module attributes {llzk.lang} {
   module @FreeFuncInModule {
+    // removed
     function.def @struct_param(%a: !struct.type<@DefsInDifferentModule::@THasUse::@HasUse<[!felt.type]>>) -> !felt.type {
       %b = felt.const 42
       function.return %b: !felt.type
@@ -217,7 +218,7 @@ module attributes {llzk.lang} {
   }
 
   module @DefsInDifferentModule {
-    // preserved instantiated version
+    // removed
     poly.template @THasUse {
       poly.param @T
 
@@ -244,11 +245,9 @@ module attributes {llzk.lang} {
     }
   }
 }
-// CHECK-LABEL: module @FreeFuncInModule
 // CHECK-NOT:   function.def @struct_param
-// CHECK-LABEL: module @DefsInDifferentModule
-// CHECK-NOT:   struct.def @NoUse {
-// CHECK-NOT:   poly.template @THasUse {
+// CHECK-NOT:   poly.template @THasUse
+// CHECK-NOT:   struct.def @NoUse
 // -----
 
 // expected-warning@+1 {{using option 'cleanup=main-as-root' with no "llzk.main" attribute on the top-level module may remove all cleanup-candidate definitions!}}
@@ -311,6 +310,7 @@ module attributes {llzk.lang} {
   module @FreeFuncModule {
     module @Level2A {
       module @Level3 {
+        // removed
         function.def @struct_param(%a: !struct.type<@StructModule::@MoreNested::@THasUse::@HasUse<[!felt.type]>>) -> !felt.type {
           %b = felt.const 42
           function.return %b: !felt.type
@@ -319,6 +319,7 @@ module attributes {llzk.lang} {
     }
     module @Level2B {
       module @Level3 {
+        // removed
         function.def @struct_param(%a: !struct.type<@StructModule::@MoreNested::@THasUse::@HasUse<[!felt.type]>>) -> !felt.type {
           %b = felt.const 42
           function.return %b: !felt.type
@@ -329,7 +330,7 @@ module attributes {llzk.lang} {
 
   module @StructModule {
     module @MoreNested {
-      // preserved instantiated version
+      // removed
       poly.template @THasUse {
         poly.param @T
 
@@ -357,12 +358,9 @@ module attributes {llzk.lang} {
     }
   }
 }
-// CHECK-LABEL: module @FreeFuncModule
 // CHECK-NOT:   function.def @struct_param
-// CHECK-LABEL: module @StructModule
-// CHECK-LABEL: module @MoreNested
-// CHECK-NOT:   struct.def @NoUse {
-// CHECK-NOT:   poly.template @THasUse {
+// CHECK-NOT:   poly.template @THasUse
+// CHECK-NOT:   struct.def @NoUse
 // -----
 
 module attributes {llzk.main = !struct.type<@Main>, llzk.lang} {

--- a/test/Transforms/Flattening/cleanup_preimage.llzk
+++ b/test/Transforms/Flattening/cleanup_preimage.llzk
@@ -1,8 +1,8 @@
 // RUN: llzk-opt -split-input-file -verify-diagnostics --pass-pipeline='builtin.module(llzk-flatten{cleanup=preimage})' %s | FileCheck --enable-var-scope %s
 
-// TEST: With "cleanup=preimage", the only structs and free functions subject to removal are
-// those with parameters that had at least one "concrete" clone created. If such a definition has
-// no remaining uses, it is removed. For example, `@MakeGuess<[@PEGS]>` has a concrete instantiation `@MakeGuess_4` and
+// TEST: With "cleanup=preimage", the only structs and free functions subject to removal are those with
+// parameters that had at least one "concrete" clone created. If such a definition has no remaining uses,
+// it is removed. For example, `@MakeGuess<[@PEGS]>` has a concrete instantiation `@MakeGuess_4` and
 // there are no remaining uses of `@MakeGuess<[@PEGS]>` so it is removed.
 
 module attributes {llzk.lang} {

--- a/test/Transforms/Flattening/cleanup_preimage.llzk
+++ b/test/Transforms/Flattening/cleanup_preimage.llzk
@@ -1,8 +1,8 @@
 // RUN: llzk-opt -split-input-file -verify-diagnostics --pass-pipeline='builtin.module(llzk-flatten{cleanup=preimage})' %s | FileCheck --enable-var-scope %s
 
-// TEST: With "cleanup=preimage", the only structs subject to removal are those with parameters
-// that had at least one "concrete" clone created. If such a struct has no remaining uses, it is
-// removed. For example, `@MakeGuess<[@PEGS]>` has a concrete instantiation `@MakeGuess_4` and
+// TEST: With "cleanup=preimage", the only structs and free functions subject to removal are
+// those with parameters that had at least one "concrete" clone created. If such a definition has
+// no remaining uses, it is removed. For example, `@MakeGuess<[@PEGS]>` has a concrete instantiation `@MakeGuess_4` and
 // there are no remaining uses of `@MakeGuess<[@PEGS]>` so it is removed.
 
 module attributes {llzk.lang} {
@@ -92,3 +92,39 @@ module attributes {llzk.lang} {
 // CHECK-NOT:   poly.template @TMakeGuess {
 // CHECK:       struct.def @TMakeGuess_4_MakeGuess {
 // CHECK-NOT:   poly.template @TMakeGuess {
+// -----
+
+module attributes {llzk.lang} {
+  poly.template @TFn {
+    poly.param @N : index
+
+    function.def @used(%inp: !array.type<@N x !felt.type>) -> !felt.type {
+      %c0 = arith.constant 0 : index
+      %r = array.read %inp[%c0] : !array.type<@N x !felt.type>, !felt.type
+      function.return %r : !felt.type
+    }
+
+    function.def @unused(%inp: !array.type<@N x !felt.type>) -> !felt.type {
+      %c0 = arith.constant 0 : index
+      %r = array.read %inp[%c0] : !array.type<@N x !felt.type>, !felt.type
+      function.return %r : !felt.type
+    }
+  }
+
+  struct.def @Main {
+    function.def @compute(%inp: !array.type<4 x !felt.type>) -> !struct.type<@Main> {
+      %self = struct.new : !struct.type<@Main>
+      %r = function.call @TFn::@used(%inp) : (!array.type<4 x !felt.type>) -> !felt.type
+      function.return %self : !struct.type<@Main>
+    }
+    function.def @constrain(%self: !struct.type<@Main>, %inp: !array.type<4 x !felt.type>) {
+      function.return
+    }
+  }
+}
+// CHECK-LABEL: function.def @TFn_4_used(
+// CHECK-LABEL: poly.template @TFn {
+// CHECK-NOT:     function.def @used
+// CHECK:         function.def @unused
+// CHECK-NOT:     function.def @used
+// CHECK-LABEL: struct.def @Main {

--- a/test/Transforms/Flattening/instantiate_funcs_pass.llzk
+++ b/test/Transforms/Flattening/instantiate_funcs_pass.llzk
@@ -214,37 +214,10 @@ module attributes {llzk.lang} {
 // CHECK-NEXT:    function.return %[[VAL_2]] : !felt.type
 // CHECK-NEXT:  }
 //
-// CHECK-LABEL: poly.template @"template_k1_8_\1A" {
-// CHECK-NEXT:    poly.param @B : index
-// CHECK-NEXT:    function.def @f(%[[VAL_3:[0-9a-zA-Z_\.]+]]: !array.type<8,@B x !felt.type>) -> !felt.type {
-// CHECK-NEXT:      %[[VAL_4:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:      %[[VAL_5:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_3]]{{\[}}%[[VAL_4]], %[[VAL_4]]] : <8,@B x !felt.type>, !felt.type
-// CHECK-NEXT:      function.return %[[VAL_5]] : !felt.type
-// CHECK-NEXT:    }
-// CHECK-NEXT:  }
-//
-// CHECK-LABEL: poly.template @template_k1 {
-// CHECK-NEXT:    poly.param @A : index
-// CHECK-NEXT:    poly.param @B : index
-// CHECK-NEXT:    function.def @f(%[[VAL_6:[0-9a-zA-Z_\.]+]]: !array.type<@A,@B x !felt.type>) -> !felt.type {
-// CHECK-NEXT:      %[[VAL_7:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:      %[[VAL_8:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_6]]{{\[}}%[[VAL_7]], %[[VAL_7]]] : <@A,@B x !felt.type>, !felt.type
-// CHECK-NEXT:      function.return %[[VAL_8]] : !felt.type
-// CHECK-NEXT:    }
-// CHECK-NEXT:  }
-//
 // CHECK-LABEL: function.def @template_k2_5_g(
 // CHECK-SAME:  %[[VAL_9:[0-9a-zA-Z_\.]+]]: !array.type<8,5 x !felt.type>) -> !felt.type {
 // CHECK-NEXT:    %[[VAL_10:[0-9a-zA-Z_\.]+]] = function.call @template_k1_8_5_f(%[[VAL_9]]) : (!array.type<8,5 x !felt.type>) -> !felt.type
 // CHECK-NEXT:    function.return %[[VAL_10]] : !felt.type
-// CHECK-NEXT:  }
-//
-// CHECK-LABEL: poly.template @template_k2 {
-// CHECK-NEXT:    poly.param @N : index
-// CHECK-NEXT:    function.def @g(%[[VAL_11:[0-9a-zA-Z_\.]+]]: !array.type<8,@N x !felt.type>) -> !felt.type {
-// CHECK-NEXT:      %[[VAL_12:[0-9a-zA-Z_\.]+]] = function.call @"template_k1_8_\1A"::@f(%[[VAL_11]]) : (!array.type<8,@N x !felt.type>) -> !felt.type
-// CHECK-NEXT:      function.return %[[VAL_12]] : !felt.type
-// CHECK-NEXT:    }
 // CHECK-NEXT:  }
 //
 // CHECK-LABEL: struct.def @Main {

--- a/test/Transforms/Flattening/instantiate_structs_pass_1.llzk
+++ b/test/Transforms/Flattening/instantiate_structs_pass_1.llzk
@@ -545,12 +545,12 @@ module attributes {llzk.lang} {
 // CHECK-NEXT:  }
 // -----
 
-/// Test "Parameterized struct still has uses!" warning
+/// Test "Parameterized definition still has uses!" warning
 module attributes {llzk.lang} {
   poly.template @TComponent07A {
     poly.param @C
 
-    // expected-warning@+1 {{Parameterized struct still has uses!}}
+    // expected-warning@+1 {{Parameterized definition still has uses!}}
     struct.def @Component07A {
       struct.member @f1 : !poly.tvar<@C>
 

--- a/tools/llzk-witgen/WitgenLowering.cpp
+++ b/tools/llzk-witgen/WitgenLowering.cpp
@@ -2277,9 +2277,9 @@ private:
 
 void addWitgenPreparePipeline(OpPassManager &pm, const WitgenOptions &) {
   using namespace llzk::polymorphic;
-  pm.addPass(
-      createFlatteningPass(FlatteningPassOptions {.cleanupMode = StructCleanupMode::ConcreteAsRoot})
-  );
+  pm.addPass(createFlatteningPass(
+      FlatteningPassOptions {.cleanupMode = FlatteningCleanupMode::ConcreteAsRoot}
+  ));
   pm.addPass(mlir::createLowerAffinePass());
   pm.addPass(llzk::createInlineStructsPass());
   pm.addPass(mlir::createCanonicalizerPass());


### PR DESCRIPTION
Fixes #457 

### Motivation

- The `-llzk-flatten` pass only cleaned up parameterized structs, leaving original templated free-function definitions (preimages) behind when functions were instantiated.  
- Cleanup behavior should be unified so a single `cleanup` option controls removal of both structs and free (non-struct) function preimages under the same modes.

### Description

- Add tracking of instantiated free-function symbols to `ConversionTracker` via a new `funcInstantiations` set and `recordInstantiation(SymbolRefAttr)` helper.  
- Record original callee symbols when function instantiations are created and expose a combined `getInstantiatedDefinitionNames()` that returns both struct and free-function preimages for cleanup.  
- Generalize cleanup logic to operate on cleanup-candidate definitions (structs and non-struct free functions) by introducing `FromKeepSet::isErasableDefinition`, converting `FromEraseSet`/erase helpers to operate on `SymbolOpInterface` targets, and renaming `eraseUnusedStructs`/`eraseUnreachableFromConcreteStructs` to `eraseUnusedDefinitions`/`eraseUnreachableFromConcreteDefinitions`.  
- Update pass option/help text in `TransformationPasses.td` from “structs” to “definitions” and extend/adjust lit `FileCheck` tests to cover templated free-function cleanup in `preimage`, `concrete-as-root`, and `main-as-root` scenarios.

### Testing

- Ran `git diff --check` to validate there are no whitespace or trivial diff issues and it passed.  
- Searched relevant codepaths with `rg` to verify updated symbols and help text and the searches succeeded.  
- Inspected `generate-test-checks.py` usage via `python scripts/generate-test-checks.py --help` to confirm test helper availability and it succeeded.  
- Full lit/unit build tests (`nix develop --command bash -c "cmake --build build --target check-lit"` / `nix build -L`) and `cmake --build build --target llzk-opt` were not run in this environment due to missing `nix` and missing configured `build/` directory.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a233a54768483209c7def76c4062707)