### PR TITLE
`llzk-witgen` additions and `execution-engine`-specific fixes

### DIFF
--- a/changelogs/unreleased/iangneal__execution-engine-updates.yaml
+++ b/changelogs/unreleased/iangneal__execution-engine-updates.yaml
@@ -1,0 +1,4 @@
+added:
+  - '`--check-output` option for `llzk-witgen`'
+fixed:
+  - Added `scf.if` handling for `llzk-witgen --backend=execution-engine`

--- a/test/Witgen/check_output.llzk
+++ b/test/Witgen/check_output.llzk
@@ -1,0 +1,97 @@
+// RUN: split-file %s %t
+// RUN: llzk-witgen %t/test.llzk --inputs %t/input.json --check-output %t/expected.json | FileCheck %s --check-prefix=SUCCESS
+// RUN: llzk-witgen %t/test.llzk --inputs %t/input.json --backend=execution-engine --check-output %t/expected.json | FileCheck %s --check-prefix=SUCCESS
+// RUN: llzk-witgen %t/test.llzk --inputs %t/input.json --output-scope=full-witness --check-output %t/expected-full.json | FileCheck %s --check-prefix=SUCCESS
+// RUN: not llzk-witgen %t/test.llzk --inputs %t/input.json --check-output %t/mismatch-value.json 2>&1 | FileCheck %s --check-prefix=VALUE
+// RUN: not llzk-witgen %t/test.llzk --inputs %t/input.json --check-output %t/mismatch-missing.json 2>&1 | FileCheck %s --check-prefix=MISSING
+// RUN: not llzk-witgen %t/test.llzk --inputs %t/input.json --check-output %t/mismatch-extra.json 2>&1 | FileCheck %s --check-prefix=EXTRA
+// RUN: not llzk-witgen %t/test.llzk --inputs %t/input.json --check-output %t/invalid.json 2>&1 | FileCheck %s --check-prefix=INVALID
+// RUN: not llzk-witgen %t/array.llzk --inputs %t/array-input.json --check-output %t/array-mismatch.json 2>&1 | FileCheck %s --check-prefix=ARRAY
+
+//--- test.llzk
+
+module attributes {llzk.lang, llzk.main = !struct.type<@Main>} {
+  struct.def @Main {
+    struct.member @sum : !felt.type<"babybear"> {llzk.pub}
+    struct.member @secret : !felt.type<"babybear"> {signal}
+    function.def @compute(
+      %lhs: !felt.type<"babybear"> {function.arg_name = "lhs"},
+      %rhs: !felt.type<"babybear"> {function.arg_name = "rhs"}
+    ) -> !struct.type<@Main> {
+      %self = struct.new : !struct.type<@Main>
+      %sum = felt.add %lhs, %rhs : !felt.type<"babybear">, !felt.type<"babybear">
+      struct.writem %self[@sum] = %sum : !struct.type<@Main>, !felt.type<"babybear">
+      struct.writem %self[@secret] = %lhs : !struct.type<@Main>, !felt.type<"babybear">
+      function.return %self : !struct.type<@Main>
+    }
+    function.def @constrain(
+      %self: !struct.type<@Main>, %lhs: !felt.type<"babybear">, %rhs: !felt.type<"babybear">
+    ) {
+      function.return
+    }
+  }
+}
+
+// SUCCESS: output matched expected JSON
+// SUCCESS-NOT: {
+
+// VALUE: llzk-witgen output mismatch:
+// VALUE-NEXT: $.sum: value mismatch: expected "8", got "9"
+
+// MISSING: llzk-witgen output mismatch:
+// MISSING-NEXT: $.secret: missing key
+
+// EXTRA: llzk-witgen output mismatch:
+// EXTRA-NEXT: $.extra: missing key
+
+// ARRAY: llzk-witgen output mismatch:
+// ARRAY-NEXT: $.values: array length mismatch: expected 1, got 2
+
+// INVALID: failed to parse expected JSON output:
+
+//--- input.json
+{"lhs": 4, "rhs": 5}
+
+//--- expected.json
+{"sum": "9"}
+
+//--- expected-full.json
+{"inputs": {"lhs": "4", "rhs": "5"}, "signals": {"secret": "4", "sum": "9"}}
+
+//--- mismatch-value.json
+{"sum": "8"}
+
+//--- mismatch-missing.json
+{"sum": "9", "secret": "4"}
+
+//--- mismatch-extra.json
+{"sum": "9", "extra": "1"}
+
+//--- invalid.json
+{"sum":
+
+//--- array.llzk
+
+module attributes {llzk.lang, llzk.main = !struct.type<@ArrayMain>} {
+  struct.def @ArrayMain {
+    struct.member @values : !array.type<2 x !felt.type<"babybear">> {llzk.pub}
+    function.def @compute(
+      %values: !array.type<2 x !felt.type<"babybear">> {function.arg_name = "values"}
+    ) -> !struct.type<@ArrayMain> {
+      %self = struct.new : !struct.type<@ArrayMain>
+      struct.writem %self[@values] = %values : !struct.type<@ArrayMain>, !array.type<2 x !felt.type<"babybear">>
+      function.return %self : !struct.type<@ArrayMain>
+    }
+    function.def @constrain(
+      %self: !struct.type<@ArrayMain>, %values: !array.type<2 x !felt.type<"babybear">>
+    ) {
+      function.return
+    }
+  }
+}
+
+//--- array-input.json
+{"values": [4, 5]}
+
+//--- array-mismatch.json
+{"values": ["4"]}

--- a/test/Witgen/execution_engine_pod_subcomponent_member.llzk
+++ b/test/Witgen/execution_engine_pod_subcomponent_member.llzk
@@ -1,0 +1,49 @@
+// RUN: split-file %s %t
+// RUN: llzk-witgen %t/test.llzk --inputs %t/input.json | FileCheck %s
+// RUN: llzk-witgen %t/test.llzk --inputs %t/input.json --backend=execution-engine | FileCheck %s
+
+//--- test.llzk
+
+!State = !pod.type<[@comp: !struct.type<@Inner>]>
+
+module attributes {llzk.lang, llzk.main = !struct.type<@Main>} {
+  struct.def @Inner {
+    struct.member @out : !felt.type<"babybear"> {llzk.pub}
+    function.def @compute(%x: !felt.type<"babybear">) -> !struct.type<@Inner> {
+      %self = struct.new : !struct.type<@Inner>
+      %c7 = felt.const 7 <"babybear">
+      %sum = felt.add %x, %c7 : !felt.type<"babybear">, !felt.type<"babybear">
+      struct.writem %self[@out] = %sum : !struct.type<@Inner>, !felt.type<"babybear">
+      function.return %self : !struct.type<@Inner>
+    }
+    function.def @constrain(%self: !struct.type<@Inner>, %x: !felt.type<"babybear">) {
+      function.return
+    }
+  }
+
+  struct.def @Main {
+    struct.member @inner : !struct.type<@Inner>
+    struct.member @out : !felt.type<"babybear"> {llzk.pub}
+    function.def @compute(%x: !felt.type<"babybear"> {function.arg_name = "x"}) -> !struct.type<@Main> {
+      %self = struct.new : !struct.type<@Main>
+      %state = pod.new : !State
+      %inner = function.call @Inner::@compute(%x) : (!felt.type<"babybear">) -> !struct.type<@Inner>
+      pod.write %state[@comp] = %inner : !State, !struct.type<@Inner>
+      %loaded = pod.read %state[@comp] : !State, !struct.type<@Inner>
+      struct.writem %self[@inner] = %loaded : !struct.type<@Main>, !struct.type<@Inner>
+      %out = struct.readm %loaded[@out] : !struct.type<@Inner>, !felt.type<"babybear">
+      struct.writem %self[@out] = %out : !struct.type<@Main>, !felt.type<"babybear">
+      function.return %self : !struct.type<@Main>
+    }
+    function.def @constrain(%self: !struct.type<@Main>, %x: !felt.type<"babybear">) {
+      function.return
+    }
+  }
+}
+
+// CHECK: {
+// CHECK-NEXT:   "out": "10"
+// CHECK-NEXT: }
+
+//--- input.json
+{"x": "3"}

--- a/test/Witgen/scf_if.llzk
+++ b/test/Witgen/scf_if.llzk
@@ -1,0 +1,90 @@
+// RUN: split-file %s %t
+// RUN: llzk-witgen %t/test.llzk --inputs %t/input.json | FileCheck %s
+// RUN: llzk-witgen %t/test.llzk --inputs %t/input.json --backend=execution-engine | FileCheck %s
+// RUN: llzk-witgen %t/test-no-else.llzk --inputs %t/input-no-else.json | FileCheck %s --check-prefix=NOELSE
+// RUN: llzk-witgen %t/test-no-else.llzk --inputs %t/input-no-else.json --backend=execution-engine | FileCheck %s --check-prefix=NOELSE
+
+//--- test.llzk
+
+module attributes {llzk.lang, llzk.main = !struct.type<@Main>} {
+  struct.def @Main {
+    struct.member @out : !felt.type<"babybear"> {llzk.pub}
+    function.def @compute() -> !struct.type<@Main> {
+      %self = struct.new : !struct.type<@Main>
+      %cond = arith.constant true
+      %c3 = arith.constant 3 : index
+      %c7 = arith.constant 7 : index
+      %c1 = arith.constant 1 : index
+      %c2 = arith.constant 2 : index
+
+      %selected = scf.if %cond -> (index) {
+        scf.yield %c3 : index
+      } else {
+        scf.yield %c7 : index
+      }
+
+      %adjusted = scf.if %cond -> (index) {
+        %sum = arith.addi %selected, %c1 : index
+        scf.yield %sum : index
+      } else {
+        %sum = arith.addi %selected, %c2 : index
+        scf.yield %sum : index
+      }
+
+      scf.if %cond {
+        %extra = arith.addi %adjusted, %c1 : index
+        %out_true = cast.tofelt %extra : index, !felt.type<"babybear">
+        struct.writem %self[@out] = %out_true : !struct.type<@Main>, !felt.type<"babybear">
+      } else {
+        %out_false = cast.tofelt %adjusted : index, !felt.type<"babybear">
+        struct.writem %self[@out] = %out_false : !struct.type<@Main>, !felt.type<"babybear">
+      }
+
+      function.return %self : !struct.type<@Main>
+    }
+    function.def @constrain(%self: !struct.type<@Main>) {
+      function.return
+    }
+  }
+}
+
+// CHECK: {
+// CHECK-NEXT:   "out": "5"
+// CHECK-NEXT: }
+
+//--- input.json
+{}
+
+//--- test-no-else.llzk
+
+module attributes {llzk.lang, llzk.main = !struct.type<@Main>} {
+  struct.def @Main {
+    struct.member @out : !felt.type<"babybear"> {llzk.pub}
+    function.def @compute() -> !struct.type<@Main> {
+      %self = struct.new : !struct.type<@Main>
+      %cond = arith.constant false
+      %c4 = arith.constant 4 : index
+      %c1 = arith.constant 1 : index
+      %c0 = arith.constant 0 : index
+      %base = arith.addi %c4, %c1 : index
+      scf.if %cond {
+        %bump = arith.divsi %c1, %c0 : index
+        %out_true = cast.tofelt %bump : index, !felt.type<"babybear">
+        struct.writem %self[@out] = %out_true : !struct.type<@Main>, !felt.type<"babybear">
+      }
+      %out = cast.tofelt %base : index, !felt.type<"babybear">
+      struct.writem %self[@out] = %out : !struct.type<@Main>, !felt.type<"babybear">
+      function.return %self : !struct.type<@Main>
+    }
+    function.def @constrain(%self: !struct.type<@Main>) {
+      function.return
+    }
+  }
+}
+
+// NOELSE: {
+// NOELSE-NEXT:   "out": "5"
+// NOELSE-NEXT: }
+
+//--- input-no-else.json
+{}

--- a/tools/llzk-witgen/JSON.cpp
+++ b/tools/llzk-witgen/JSON.cpp
@@ -19,13 +19,96 @@
 
 #include <mlir/IR/Operation.h>
 
+#include <llvm/ADT/SmallString.h>
 #include <llvm/ADT/TypeSwitch.h>
+#include <llvm/Support/FormatVariadic.h>
 #include <llvm/Support/MathExtras.h>
 #include <llvm/Support/raw_ostream.h>
 
 using namespace mlir;
 
 namespace llzk::witgen {
+namespace {
+
+static std::string renderJSON(const llvm::json::Value &value) {
+  return llvm::formatv("{0:2}", value).str();
+}
+
+static llvm::StringRef jsonKind(const llvm::json::Value &value) {
+  if (value.getAsNull()) {
+    return "null";
+  }
+  if (value.getAsBoolean().has_value()) {
+    return "bool";
+  }
+  if (value.getAsNumber().has_value()) {
+    return "number";
+  }
+  if (value.getAsString()) {
+    return "string";
+  }
+  if (value.getAsArray()) {
+    return "array";
+  }
+  if (value.getAsObject()) {
+    return "object";
+  }
+  return "unknown";
+}
+
+static std::string appendObjectPath(llvm::StringRef path, llvm::StringRef key) {
+  llvm::SmallString<64> out(path);
+  out += ".";
+  out += key;
+  return std::string(out);
+}
+
+static std::string appendIndexPath(llvm::StringRef path, size_t index) {
+  return (llvm::Twine(path) + "[" + llvm::Twine(index) + "]").str();
+}
+
+static void pushMismatch(
+    llvm::SmallVectorImpl<JSONMismatch> &out, llvm::StringRef path, const llvm::Twine &message
+) {
+  out.push_back(JSONMismatch {path.str(), message.str()});
+}
+
+static void diffObjects(
+    const llvm::json::Object &expected, const llvm::json::Object &actual,
+    llvm::SmallVectorImpl<JSONMismatch> &out, llvm::StringRef path
+) {
+  for (const auto &kv : expected) {
+    if (const llvm::json::Value *actualValue = actual.get(kv.first)) {
+      diffJSON(kv.second, *actualValue, out, appendObjectPath(path, kv.first));
+      continue;
+    }
+    pushMismatch(out, appendObjectPath(path, kv.first), "missing key");
+  }
+  for (const auto &kv : actual) {
+    if (!expected.get(kv.first)) {
+      pushMismatch(out, appendObjectPath(path, kv.first), "unexpected key");
+    }
+  }
+}
+
+static void diffArrays(
+    const llvm::json::Array &expected, const llvm::json::Array &actual,
+    llvm::SmallVectorImpl<JSONMismatch> &out, llvm::StringRef path
+) {
+  if (expected.size() != actual.size()) {
+    pushMismatch(
+        out, path,
+        llvm::Twine("array length mismatch: expected ") + llvm::Twine(expected.size()) + ", got " +
+            llvm::Twine(actual.size())
+    );
+  }
+  size_t shared = std::min(expected.size(), actual.size());
+  for (size_t i = 0; i < shared; ++i) {
+    diffJSON(expected[i], actual[i], out, appendIndexPath(path, i));
+  }
+}
+
+} // namespace
 
 /// Parse an integer-compatible JSON value.
 static llvm::Expected<int64_t> jsonToInt(const llvm::json::Value *json) {
@@ -382,6 +465,43 @@ llvm::Expected<WitnessVal> extractValueAtPath(
   }
 
   return makeError("extra witness path components for non-aggregate value");
+}
+
+void diffJSON(
+    const llvm::json::Value &expected, const llvm::json::Value &actual,
+    llvm::SmallVectorImpl<JSONMismatch> &out, llvm::StringRef path
+) {
+  if (expected.kind() != actual.kind()) {
+    pushMismatch(
+        out, path,
+        llvm::Twine("type mismatch: expected ") + jsonKind(expected) + ", got " + jsonKind(actual)
+    );
+    return;
+  }
+
+  if (const auto *expectedObject = expected.getAsObject()) {
+    diffObjects(*expectedObject, *actual.getAsObject(), out, path);
+    return;
+  }
+  if (const auto *expectedArray = expected.getAsArray()) {
+    diffArrays(*expectedArray, *actual.getAsArray(), out, path);
+    return;
+  }
+  if (expected == actual) {
+    return;
+  }
+
+  pushMismatch(
+      out, path,
+      llvm::Twine("value mismatch: expected ") + renderJSON(expected) + ", got " +
+          renderJSON(actual)
+  );
+}
+
+void printJSONMismatches(llvm::raw_ostream &os, llvm::ArrayRef<JSONMismatch> mismatches) {
+  for (const JSONMismatch &mismatch : mismatches) {
+    os << mismatch.path << ": " << mismatch.message << '\n';
+  }
 }
 
 } // namespace llzk::witgen

--- a/tools/llzk-witgen/JSON.cpp
+++ b/tools/llzk-witgen/JSON.cpp
@@ -58,7 +58,7 @@ static llvm::StringRef jsonKind(const llvm::json::Value &value) {
 
 static std::string appendObjectPath(llvm::StringRef path, llvm::StringRef key) {
   llvm::SmallString<64> out(path);
-  out += ".";
+  out += '.';
   out += key;
   return std::string(out);
 }

--- a/tools/llzk-witgen/JSON.cpp
+++ b/tools/llzk-witgen/JSON.cpp
@@ -64,7 +64,10 @@ static std::string appendObjectPath(llvm::StringRef path, llvm::StringRef key) {
 }
 
 static std::string appendIndexPath(llvm::StringRef path, size_t index) {
-  return (llvm::Twine(path) + "[" + llvm::Twine(index) + "]").str();
+  llvm::SmallString<64> out(path);
+  llvm::raw_svector_ostream os(out);
+  os << '[' << index << ']';
+  return std::string(out);
 }
 
 static void pushMismatch(

--- a/tools/llzk-witgen/JSON.h
+++ b/tools/llzk-witgen/JSON.h
@@ -23,6 +23,12 @@ enum class SerializationMode : std::uint8_t {
   AllSignals,
 };
 
+/// One structured JSON mismatch between expected and actual witgen output.
+struct JSONMismatch {
+  std::string path;
+  std::string message;
+};
+
 /// Parse one JSON value into the tool's runtime representation.
 llvm::Expected<WitnessVal> parseJSONValue(
     const llvm::json::Value *json, mlir::Type type, const llzk::Field &field,
@@ -46,5 +52,14 @@ llvm::Expected<WitnessVal> extractValueAtPath(
     const WitnessVal &root, mlir::Type rootType, llvm::ArrayRef<std::string> path,
     mlir::SymbolTableCollection &tables, mlir::Operation *origin
 );
+
+/// Compare two JSON values structurally and append any mismatches to `out`.
+void diffJSON(
+    const llvm::json::Value &expected, const llvm::json::Value &actual,
+    llvm::SmallVectorImpl<JSONMismatch> &out, llvm::StringRef path = "$"
+);
+
+/// Render one human-readable mismatch report.
+void printJSONMismatches(llvm::raw_ostream &os, llvm::ArrayRef<JSONMismatch> mismatches);
 
 } // namespace llzk::witgen

--- a/tools/llzk-witgen/WitgenLowering.cpp
+++ b/tools/llzk-witgen/WitgenLowering.cpp
@@ -1904,6 +1904,66 @@ private:
       return success();
     }
 
+    if (auto ifOp = dyn_cast<scf::IfOp>(op)) {
+      auto condition = lookupScalar(ifOp.getCondition(), valueMap, ifOp.getOperation());
+      if (failed(condition)) {
+        return failure();
+      }
+
+      SmallVector<size_t> resultLeafCounts;
+      SmallVector<Type> loweredResultTypes;
+      for (Type resultType : ifOp.getResultTypes()) {
+        auto leafTypes = getABILeafTypes(resultType, tables, ifOp.getOperation(), field);
+        auto count = getLeafCount(resultType, tables, ifOp.getOperation(), field);
+        if (failed(leafTypes) || failed(count)) {
+          return failure();
+        }
+        loweredResultTypes.append(leafTypes->begin(), leafTypes->end());
+        resultLeafCounts.push_back(*count);
+      }
+
+      auto newIf = builder.create<scf::IfOp>(
+          loc, loweredResultTypes, *condition, true, !ifOp.getElseRegion().empty()
+      );
+
+      {
+        OpBuilder thenBuilder = OpBuilder::atBlockBegin(&newIf.getThenRegion().front());
+        DenseMap<Value, LoweredValue> thenMap(valueMap.begin(), valueMap.end());
+        if (failed(lowerBlock(thenBuilder, ifOp.getThenRegion().front(), thenMap))) {
+          newIf.erase();
+          return failure();
+        }
+      }
+      if (!ifOp.getElseRegion().empty()) {
+        OpBuilder elseBuilder = OpBuilder::atBlockBegin(&newIf.getElseRegion().front());
+        DenseMap<Value, LoweredValue> elseMap(valueMap.begin(), valueMap.end());
+        if (failed(lowerBlock(elseBuilder, ifOp.getElseRegion().front(), elseMap))) {
+          newIf.erase();
+          return failure();
+        }
+      }
+      auto newIfResults = newIf.getResults();
+      size_t totalResults = newIfResults.size();
+      size_t cursor = 0;
+      for (auto [oldResult, oldType, leafCount] :
+           llvm::zip(ifOp.getResults(), ifOp.getResultTypes(), resultLeafCounts)) {
+        bool overflow = false;
+        size_t nextCursor = llvm::SaturatingAdd(cursor, leafCount, &overflow);
+        if (overflow || nextCursor > totalResults) {
+          ifOp.emitError("leaf count overflow while lowering if-op results");
+          return failure();
+        }
+        LoweredValue lowered {oldType, {}};
+        lowered.leaves.append(
+            newIfResults.begin() + static_cast<ptrdiff_t>(cursor),
+            newIfResults.begin() + static_cast<ptrdiff_t>(nextCursor)
+        );
+        valueMap[oldResult] = std::move(lowered);
+        cursor = nextCursor;
+      }
+      return success();
+    }
+
     if (auto forOp = dyn_cast<scf::ForOp>(op)) {
       auto lb = lookupScalar(forOp.getLowerBound(), valueMap, forOp.getOperation());
       auto ub = lookupScalar(forOp.getUpperBound(), valueMap, forOp.getOperation());

--- a/tools/llzk-witgen/WitgenLowering.cpp
+++ b/tools/llzk-witgen/WitgenLowering.cpp
@@ -1955,8 +1955,8 @@ private:
         }
         LoweredValue lowered {oldType, {}};
         lowered.leaves.append(
-            newIfResults.begin() + static_cast<ptrdiff_t>(cursor),
-            newIfResults.begin() + static_cast<ptrdiff_t>(nextCursor)
+            newIfResults.begin() + llzk::checkedCast<ptrdiff_t>(cursor),
+            newIfResults.begin() + llzk::checkedCast<ptrdiff_t>(nextCursor)
         );
         valueMap[oldResult] = std::move(lowered);
         cursor = nextCursor;

--- a/tools/llzk-witgen/WitgenLowering.cpp
+++ b/tools/llzk-witgen/WitgenLowering.cpp
@@ -2341,7 +2341,8 @@ void addWitgenPreparePipeline(OpPassManager &pm, const WitgenOptions &) {
       createFlatteningPass(FlatteningPassOptions {.cleanupMode = StructCleanupMode::ConcreteAsRoot})
   );
   pm.addPass(mlir::createLowerAffinePass());
-  pm.addPass(llzk::createInlineStructsPass());
+  // TODO: simplify lowering with `llzk-inline-structs` and `llzk-pod-to-scalar` when both are
+  // available and support PODs.
   pm.addPass(mlir::createCanonicalizerPass());
   pm.addPass(mlir::createCSEPass());
 }

--- a/tools/llzk-witgen/llzk-witgen.cpp
+++ b/tools/llzk-witgen/llzk-witgen.cpp
@@ -7,6 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "JSON.h"
 #include "WitgenDriver.h"
 #include "tools/config.h"
 
@@ -74,6 +75,8 @@ static llvm::cl::opt<bool>
     DumpJITCore("dump-jit-core", llvm::cl::desc("Print the pre-LLVM JIT module"));
 static llvm::cl::opt<bool>
     DumpJITLLVM("dump-jit-llvm", llvm::cl::desc("Print the post-LLVM JIT module"));
+static llvm::cl::opt<std::string>
+    CheckOutputFilename("check-output", llvm::cl::desc("JSON file with expected witgen output"));
 
 /// Execute the llzk-witgen command-line tool.
 int main(int argc, char **argv) {
@@ -168,6 +171,32 @@ int main(int argc, char **argv) {
   if (!result) {
     llvm::errs() << "llzk-witgen error: " << llvm::toString(result.takeError()) << '\n';
     return EXIT_FAILURE;
+  }
+
+  if (CheckOutputFilename.getNumOccurrences() > 0) {
+    auto expectedBuffer = llvm::MemoryBuffer::getFileOrSTDIN(CheckOutputFilename);
+    if (!expectedBuffer) {
+      llvm::errs() << expectedBuffer.getError().message() << '\n';
+      return EXIT_FAILURE;
+    }
+
+    auto expected = llvm::json::parse(expectedBuffer.get()->getBuffer());
+    if (!expected) {
+      llvm::errs() << "failed to parse expected JSON output: "
+                   << llvm::toString(expected.takeError()) << '\n';
+      return EXIT_FAILURE;
+    }
+
+    llvm::SmallVector<llzk::witgen::JSONMismatch> mismatches;
+    llzk::witgen::diffJSON(*expected, *result, mismatches);
+    if (!mismatches.empty()) {
+      llvm::errs() << "llzk-witgen output mismatch:\n";
+      llzk::witgen::printJSONMismatches(llvm::errs(), mismatches);
+      return EXIT_FAILURE;
+    }
+
+    llvm::outs() << "output matched expected JSON\n";
+    return EXIT_SUCCESS;
   }
 
   llvm::outs() << llvm::formatv("{0:2}", *result) << '\n';

--- a/unittests/Witgen/WitgenTests.cpp
+++ b/unittests/Witgen/WitgenTests.cpp
@@ -250,6 +250,47 @@ TEST_F(WitgenTests, CheckedDynamicAPIntToSizeRejectsOverflow) {
   EXPECT_NE(llvm::toString(checked.takeError()).find("overflow"), std::string::npos);
 }
 
+TEST_F(WitgenTests, JSONDiffReportsScalarMismatchAtPath) {
+  auto expected = llvm::json::parse(R"({"sum":"9"})");
+  auto actual = llvm::json::parse(R"({"sum":"8"})");
+  ASSERT_TRUE(static_cast<bool>(expected));
+  ASSERT_TRUE(static_cast<bool>(actual));
+
+  llvm::SmallVector<witgen::JSONMismatch> mismatches;
+  witgen::diffJSON(*expected, *actual, mismatches);
+  ASSERT_EQ(mismatches.size(), 1u);
+  EXPECT_EQ(mismatches[0].path, "$.sum");
+  EXPECT_NE(mismatches[0].message.find("value mismatch"), std::string::npos);
+}
+
+TEST_F(WitgenTests, JSONDiffReportsMissingAndUnexpectedKeys) {
+  auto expected = llvm::json::parse(R"({"sum":"9","secret":"4"})");
+  auto actual = llvm::json::parse(R"({"sum":"9","extra":"1"})");
+  ASSERT_TRUE(static_cast<bool>(expected));
+  ASSERT_TRUE(static_cast<bool>(actual));
+
+  llvm::SmallVector<witgen::JSONMismatch> mismatches;
+  witgen::diffJSON(*expected, *actual, mismatches);
+  ASSERT_EQ(mismatches.size(), 2u);
+  EXPECT_EQ(mismatches[0].path, "$.secret");
+  EXPECT_EQ(mismatches[0].message, "missing key");
+  EXPECT_EQ(mismatches[1].path, "$.extra");
+  EXPECT_EQ(mismatches[1].message, "unexpected key");
+}
+
+TEST_F(WitgenTests, JSONDiffReportsArrayLengthMismatch) {
+  auto expected = llvm::json::parse(R"({"signals":["1","2"]})");
+  auto actual = llvm::json::parse(R"({"signals":["1"]})");
+  ASSERT_TRUE(static_cast<bool>(expected));
+  ASSERT_TRUE(static_cast<bool>(actual));
+
+  llvm::SmallVector<witgen::JSONMismatch> mismatches;
+  witgen::diffJSON(*expected, *actual, mismatches);
+  ASSERT_EQ(mismatches.size(), 1u);
+  EXPECT_EQ(mismatches[0].path, "$.signals");
+  EXPECT_NE(mismatches[0].message.find("array length mismatch"), std::string::npos);
+}
+
 TEST_P(WitgenFieldTests, NestedAggregateFailModeMaterializesMonostate) {
   auto feltType = felt::FeltType::get(&ctx, StringAttr::get(&ctx, GetParam()));
   auto arrayType = array::ArrayType::get(feltType, {2});


### PR DESCRIPTION
- Add a `--check-output` option to allow verification of `llzk-witgen` output against known witness generation results
- Add missing `scf.if` handling for the `execution-engine` backend
- Remove struct inlining for now until POD support for lowering is complete