### PR TITLE
Reject dynamically scoped scalar polynomial auxiliaries

### DIFF
--- a/backends/r1cs/include/r1cs/Transforms/TransformationPasses.td
+++ b/backends/r1cs/include/r1cs/Transforms/TransformationPasses.td
@@ -18,7 +18,8 @@ def R1CSLoweringPass : LLZKPass<"llzk-r1cs-lowering"> {
   let description = [{
     Transforms LLZK constraints into an equivalent set of R1CS constraints expressed in the r1cs dialect.
     The pass expects already-flattened, straight-line `constrain` bodies. Run `llzk-flatten` or
-    another control-flow lowering pass before this pass.
+    another control-flow lowering pass before this pass; nested-region, successor-bearing, or
+    multi-block constraints are rejected before R1CS normalization.
     This pass is best used on already-flattened input as part of the `-llzk-full-r1cs-lowering`
     pipeline which includes a degree lowering pass and clean up passes to ensure correctness and
     performance.

--- a/backends/r1cs/include/r1cs/Transforms/TransformationPasses.td
+++ b/backends/r1cs/include/r1cs/Transforms/TransformationPasses.td
@@ -17,8 +17,11 @@ def R1CSLoweringPass : LLZKPass<"llzk-r1cs-lowering"> {
                 "i.e a*b - c = 0";
   let description = [{
     Transforms LLZK constraints into an equivalent set of R1CS constraints expressed in the r1cs dialect.
-    This pass is best used as part of the `-llzk-full-r1cs-lowering` pipeline which includes
-    a degree lowering pass and clean up passes to ensure correctness and performance.
+    The pass expects already-flattened, straight-line `constrain` bodies. Run `llzk-flatten` or
+    another control-flow lowering pass before this pass.
+    This pass is best used on already-flattened input as part of the `-llzk-full-r1cs-lowering`
+    pipeline which includes a degree lowering pass and clean up passes to ensure correctness and
+    performance.
   }];
 }
 

--- a/backends/r1cs/lib/r1cs/Transforms/R1CSLoweringPass.cpp
+++ b/backends/r1cs/lib/r1cs/Transforms/R1CSLoweringPass.cpp
@@ -648,6 +648,11 @@ class PassImpl : public r1cs::impl::R1CSLoweringPassBase<PassImpl> {
         return;
       }
 
+      if (failed(checkConstrainBodyIsStraightLine(constrainFunc, "R1CS lowering"))) {
+        signalPassFailure();
+        return;
+      }
+
       DenseMap<Value, unsigned> degreeMemo;
       DenseMap<Value, Value> rewrites;
       SmallVector<AuxAssignment> auxAssignments;

--- a/backends/r1cs/lib/r1cs/Transforms/TransformationPassPipelines.cpp
+++ b/backends/r1cs/lib/r1cs/Transforms/TransformationPassPipelines.cpp
@@ -26,7 +26,8 @@ namespace r1cs {
 
 void registerTransformationPassPipelines() {
   PassPipelineRegistration<>(
-      "llzk-full-r1cs-lowering", "Lower all polynomial constraints to r1cs", [](OpPassManager &pm) {
+      "llzk-full-r1cs-lowering", "Lower already-flattened polynomial constraints to r1cs",
+      [](OpPassManager &pm) {
     // 1. Degree lowering
     pm.addPass(llzk::createPolyLoweringPass(llzk::PolyLoweringPassOptions {.maxDegree = 2}));
 

--- a/changelogs/unreleased/poly-dynamic-aux-scope.yaml
+++ b/changelogs/unreleased/poly-dynamic-aux-scope.yaml
@@ -1,2 +1,2 @@
 fixed:
-  - Reject polynomial and R1CS lowering on nested-region constrain bodies instead of materializing component-scope auxiliaries inside control flow
+  - Reject polynomial and R1CS lowering on non-straight-line constrain bodies instead of materializing component-scope auxiliaries inside control flow

--- a/changelogs/unreleased/poly-dynamic-aux-scope.yaml
+++ b/changelogs/unreleased/poly-dynamic-aux-scope.yaml
@@ -1,0 +1,2 @@
+fixed:
+  - Reject polynomial and R1CS lowering on nested-region constrain bodies instead of materializing component-scope auxiliaries inside control flow

--- a/include/llzk/Transforms/LLZKLoweringUtils.h
+++ b/include/llzk/Transforms/LLZKLoweringUtils.h
@@ -34,7 +34,8 @@ checkForAuxMemberConflicts(component::StructDefOp structDef, llvm::StringRef aux
 
 /// Rejects control flow under `constrainFunc`; polynomial and R1CS auxiliary
 /// materialization assumes control flow has already been flattened or otherwise
-/// lowered away.
+/// lowered away. The region check catches multi-block function bodies before
+/// the operation walk rejects nested regions or successor-bearing operations.
 mlir::LogicalResult
 checkConstrainBodyIsStraightLine(function::FuncDefOp constrainFunc, llvm::StringRef passName);
 

--- a/include/llzk/Transforms/LLZKLoweringUtils.h
+++ b/include/llzk/Transforms/LLZKLoweringUtils.h
@@ -32,6 +32,12 @@ mlir::Value rebuildExprInCompute(
 mlir::LogicalResult
 checkForAuxMemberConflicts(component::StructDefOp structDef, llvm::StringRef auxPrefix);
 
+/// Rejects control flow under `constrainFunc`; polynomial and R1CS auxiliary
+/// materialization assumes control flow has already been flattened or otherwise
+/// lowered away.
+mlir::LogicalResult
+checkConstrainBodyIsStraightLine(function::FuncDefOp constrainFunc, llvm::StringRef passName);
+
 component::MemberDefOp addAuxMember(component::StructDefOp structDef, llvm::StringRef name);
 
 unsigned getFeltDegree(mlir::Value val, llvm::DenseMap<mlir::Value, unsigned> &memo);

--- a/include/llzk/Transforms/LLZKTransformationPasses.td
+++ b/include/llzk/Transforms/LLZKTransformationPasses.td
@@ -75,8 +75,9 @@ def PolyLoweringPass : LLZKPass<"llzk-poly-lowering-pass"> {
     equality operands and struct constrain call arguments satisfy their degree bounds.
 
     The pass expects already-flattened, straight-line `constrain` bodies. Run `llzk-flatten` or
-    another control-flow lowering pass before this pass; nested-region or multi-block constraints
-    are rejected instead of being rewritten with component-lifetime auxiliary members.
+    another control-flow lowering pass before this pass; nested-region, successor-bearing, or
+    multi-block constraints are rejected instead of being rewritten with component-lifetime
+    auxiliary members.
 
     This pass is best used on already-flattened input as part of the `-llzk-full-poly-lowering`
     pipeline, which includes additional cleanup passes to ensure correctness and optimal

--- a/include/llzk/Transforms/LLZKTransformationPasses.td
+++ b/include/llzk/Transforms/LLZKTransformationPasses.td
@@ -74,8 +74,13 @@ def PolyLoweringPass : LLZKPass<"llzk-poly-lowering-pass"> {
     through degree-neutral roots such as `felt.add`, `felt.sub`, and `felt.neg`, so composite
     equality operands and struct constrain call arguments satisfy their degree bounds.
 
-    This pass is best used as part of the `-llzk-full-poly-lowering` pipeline, which includes
-    additional cleanup passes to ensure correctness and optimal performance.
+    The pass expects already-flattened, straight-line `constrain` bodies. Run `llzk-flatten` or
+    another control-flow lowering pass before this pass; nested-region or multi-block constraints
+    are rejected instead of being rewritten with component-lifetime auxiliary members.
+
+    This pass is best used on already-flattened input as part of the `-llzk-full-poly-lowering`
+    pipeline, which includes additional cleanup passes to ensure correctness and optimal
+    performance.
   }];
   let options = [Option<"maxDegree", "max-degree", "unsigned",
                         /* default */ "2",

--- a/lib/Transforms/LLZKLoweringUtils.cpp
+++ b/lib/Transforms/LLZKLoweringUtils.cpp
@@ -99,6 +99,36 @@ LogicalResult checkForAuxMemberConflicts(StructDefOp structDef, StringRef prefix
   return failure(conflictFound);
 }
 
+LogicalResult checkConstrainBodyIsStraightLine(FuncDefOp constrainFunc, StringRef passName) {
+  auto emitStraightLineError = [passName](Operation *op) {
+    op->emitError() << passName
+                    << " expects a straight-line constrain body; run `llzk-flatten` or another "
+                       "control-flow lowering pass first";
+  };
+
+  Region &body = constrainFunc.getBody();
+  if (!body.hasOneBlock()) {
+    emitStraightLineError(constrainFunc.getOperation());
+    return failure();
+  }
+
+  Operation *unsupportedControlFlowOp = nullptr;
+  body.walk([&](Operation *op) {
+    if (op->getNumRegions() != 0 || op->getNumSuccessors() != 0) {
+      unsupportedControlFlowOp = op;
+      return WalkResult::interrupt();
+    }
+    return WalkResult::advance();
+  });
+
+  if (!unsupportedControlFlowOp) {
+    return success();
+  }
+
+  emitStraightLineError(unsupportedControlFlowOp);
+  return failure();
+}
+
 void replaceSubsequentUsesWith(Value oldVal, Value newVal, Operation *afterOp) {
   assert(afterOp && "afterOp must be a valid Operation*");
 

--- a/lib/Transforms/LLZKPolyLoweringPass.cpp
+++ b/lib/Transforms/LLZKPolyLoweringPass.cpp
@@ -371,6 +371,11 @@ class PassImpl : public llzk::impl::PolyLoweringPassBase<PassImpl> {
         return;
       }
 
+      if (failed(checkConstrainBodyIsStraightLine(constrainFunc, "poly lowering"))) {
+        signalPassFailure();
+        return;
+      }
+
       DenseMap<Value, unsigned> degreeMemo;
       DenseMap<Value, Value> rewrites;
       SmallVector<AuxAssignment> auxAssignments;

--- a/lib/Transforms/LLZKTransformationPassPipelines.cpp
+++ b/lib/Transforms/LLZKTransformationPassPipelines.cpp
@@ -53,8 +53,8 @@ void registerTransformationPassPipelines() {
 
   PassPipelineRegistration<FullPolyLoweringOptions>(
       "llzk-full-poly-lowering",
-      "Lower all polynomial constraints to a given max degree, then remove unnecessary operations "
-      "and definitions.",
+      "Lower already-flattened polynomial constraints to a given max degree, then remove "
+      "unnecessary operations and definitions.",
       [](OpPassManager &pm, const FullPolyLoweringOptions &opts) {
     // 1. Degree lowering
     pm.addPass(createPolyLoweringPass(PolyLoweringPassOptions {.maxDegree = opts.maxDegree}));

--- a/test/Transforms/PolyLowering/poly_lowering_fail_dynamic_aux_scope.llzk
+++ b/test/Transforms/PolyLowering/poly_lowering_fail_dynamic_aux_scope.llzk
@@ -1,6 +1,24 @@
 // RUN: llzk-opt -I %S -split-input-file -llzk-poly-lowering-pass="max-degree=2" -verify-diagnostics %s
 
 module attributes {llzk.lang = "llzk"} {
+  struct.def @MultiBlockAuxScope {
+    function.def @compute(%a: !felt.type) -> !struct.type<@MultiBlockAuxScope> {
+      %self = struct.new : !struct.type<@MultiBlockAuxScope>
+      function.return %self : !struct.type<@MultiBlockAuxScope>
+    }
+
+    // expected-error@+1 {{poly lowering expects a straight-line constrain body; run `llzk-flatten` or another control-flow lowering pass first}}
+    function.def @constrain(%self: !struct.type<@MultiBlockAuxScope>, %a: !felt.type) {
+      function.return
+    ^unreachable:
+      function.return
+    }
+  }
+}
+
+// -----
+
+module attributes {llzk.lang = "llzk"} {
   struct.def @LoopAuxScopeRepro {
     struct.member @out : !felt.type {llzk.pub}
 

--- a/test/Transforms/PolyLowering/poly_lowering_fail_dynamic_aux_scope.llzk
+++ b/test/Transforms/PolyLowering/poly_lowering_fail_dynamic_aux_scope.llzk
@@ -1,0 +1,128 @@
+// RUN: llzk-opt -I %S -split-input-file -llzk-poly-lowering-pass="max-degree=2" -verify-diagnostics %s
+
+module attributes {llzk.lang = "llzk"} {
+  struct.def @LoopAuxScopeRepro {
+    struct.member @out : !felt.type {llzk.pub}
+
+    function.def @compute(%a: !felt.type) -> !struct.type<@LoopAuxScopeRepro> {
+      %self = struct.new : !struct.type<@LoopAuxScopeRepro>
+      struct.writem %self[@out] = %a : !struct.type<@LoopAuxScopeRepro>, !felt.type
+      function.return %self : !struct.type<@LoopAuxScopeRepro>
+    }
+
+    function.def @constrain(%self: !struct.type<@LoopAuxScopeRepro>, %a: !felt.type) {
+      %lb = arith.constant 0 : index
+      %ub = arith.constant 2 : index
+      %step = arith.constant 1 : index
+      %one = felt.const 1 : !felt.type
+
+      // expected-error@+1 {{poly lowering expects a straight-line constrain body; run `llzk-flatten` or another control-flow lowering pass first}}
+      %res = scf.for %iv = %lb to %ub step %step iter_args(%acc = %a) -> !felt.type {
+        %sq = felt.mul %acc, %acc : !felt.type, !felt.type
+        %cube = felt.mul %sq, %acc : !felt.type, !felt.type
+        constrain.eq %cube, %cube : !felt.type
+        %next = felt.add %acc, %one : !felt.type, !felt.type
+        scf.yield %next : !felt.type
+      }
+
+      function.return
+    }
+  }
+}
+
+// -----
+
+module attributes {llzk.lang = "llzk"} {
+  struct.def @LoopIVAuxScope {
+    struct.member @out : !felt.type {llzk.pub}
+
+    function.def @compute(%a: !felt.type) -> !struct.type<@LoopIVAuxScope> {
+      %self = struct.new : !struct.type<@LoopIVAuxScope>
+      struct.writem %self[@out] = %a : !struct.type<@LoopIVAuxScope>, !felt.type
+      function.return %self : !struct.type<@LoopIVAuxScope>
+    }
+
+    function.def @constrain(%self: !struct.type<@LoopIVAuxScope>, %a: !felt.type) {
+      %lb = arith.constant 0 : index
+      %ub = arith.constant 2 : index
+      %step = arith.constant 1 : index
+
+      // expected-error@+1 {{poly lowering expects a straight-line constrain body; run `llzk-flatten` or another control-flow lowering pass first}}
+      scf.for %iv = %lb to %ub step %step {
+        %iv_felt = cast.tofelt %iv : index
+        %sq = felt.mul %iv_felt, %iv_felt : !felt.type, !felt.type
+        %cube = felt.mul %sq, %a : !felt.type, !felt.type
+        constrain.eq %cube, %cube : !felt.type
+      }
+
+      function.return
+    }
+  }
+}
+
+// -----
+
+module attributes {llzk.lang = "llzk"} {
+  struct.def @BranchAuxScope {
+    struct.member @out : !felt.type {llzk.pub}
+
+    function.def @compute(%a: !felt.type, %cond: i1) -> !struct.type<@BranchAuxScope> {
+      %self = struct.new : !struct.type<@BranchAuxScope>
+      struct.writem %self[@out] = %a : !struct.type<@BranchAuxScope>, !felt.type
+      function.return %self : !struct.type<@BranchAuxScope>
+    }
+
+    function.def @constrain(%self: !struct.type<@BranchAuxScope>, %a: !felt.type, %cond: i1) {
+      // expected-error@+1 {{poly lowering expects a straight-line constrain body; run `llzk-flatten` or another control-flow lowering pass first}}
+      scf.if %cond {
+        %sq = felt.mul %a, %a : !felt.type, !felt.type
+        %cube = felt.mul %sq, %a : !felt.type, !felt.type
+        constrain.eq %cube, %cube : !felt.type
+      }
+
+      function.return
+    }
+  }
+}
+
+// -----
+
+module attributes {llzk.lang = "llzk"} {
+  struct.def @ChildConstrainArg {
+    function.def @compute(%x: !felt.type) -> !struct.type<@ChildConstrainArg> {
+      %self = struct.new : !struct.type<@ChildConstrainArg>
+      function.return %self : !struct.type<@ChildConstrainArg>
+    }
+
+    function.def @constrain(%self: !struct.type<@ChildConstrainArg>, %x: !felt.type) {
+      function.return
+    }
+  }
+
+  struct.def @LoopCallArgAuxScope {
+    struct.member @child : !struct.type<@ChildConstrainArg>
+
+    function.def @compute(%a: !felt.type) -> !struct.type<@LoopCallArgAuxScope> {
+      %self = struct.new : !struct.type<@LoopCallArgAuxScope>
+      function.return %self : !struct.type<@LoopCallArgAuxScope>
+    }
+
+    function.def @constrain(%self: !struct.type<@LoopCallArgAuxScope>, %a: !felt.type) {
+      %lb = arith.constant 0 : index
+      %ub = arith.constant 2 : index
+      %step = arith.constant 1 : index
+      %one = felt.const 1 : !felt.type
+      %child = struct.readm %self[@child] : !struct.type<@LoopCallArgAuxScope>, !struct.type<@ChildConstrainArg>
+
+      // expected-error@+1 {{poly lowering expects a straight-line constrain body; run `llzk-flatten` or another control-flow lowering pass first}}
+      %res = scf.for %iv = %lb to %ub step %step iter_args(%acc = %a) -> !felt.type {
+        %sq = felt.mul %acc, %acc : !felt.type, !felt.type
+        function.call @ChildConstrainArg::@constrain(%child, %sq) : (!struct.type<@ChildConstrainArg>, !felt.type) -> ()
+        %next = felt.add %acc, %one : !felt.type, !felt.type
+        scf.yield %next : !felt.type
+      }
+
+      function.return
+    }
+  }
+}

--- a/test/Transforms/R1CSLowering/r1cs_lowering_fail_dynamic_aux_scope.llzk
+++ b/test/Transforms/R1CSLowering/r1cs_lowering_fail_dynamic_aux_scope.llzk
@@ -1,0 +1,55 @@
+// RUN: llzk-opt -split-input-file -llzk-r1cs-lowering -verify-diagnostics %s
+
+module attributes {llzk.lang = "llzk"} {
+  struct.def @R1CSLoopAuxScope {
+    struct.member @out : !felt.type {llzk.pub}
+
+    function.def @compute(%a: !felt.type) -> !struct.type<@R1CSLoopAuxScope> {
+      %self = struct.new : !struct.type<@R1CSLoopAuxScope>
+      struct.writem %self[@out] = %a : !struct.type<@R1CSLoopAuxScope>, !felt.type
+      function.return %self : !struct.type<@R1CSLoopAuxScope>
+    }
+
+    function.def @constrain(%self: !struct.type<@R1CSLoopAuxScope>, %a: !felt.type) {
+      %lb = arith.constant 0 : index
+      %ub = arith.constant 2 : index
+      %step = arith.constant 1 : index
+      %one = felt.const 1 : !felt.type
+
+      // expected-error@+1 {{R1CS lowering expects a straight-line constrain body; run `llzk-flatten` or another control-flow lowering pass first}}
+      %res = scf.for %iv = %lb to %ub step %step iter_args(%acc = %a) -> !felt.type {
+        %dynamic_sq = felt.mul %acc, %acc : !felt.type, !felt.type
+        %component_sq = felt.mul %a, %a : !felt.type, !felt.type
+        constrain.eq %dynamic_sq, %component_sq : !felt.type
+        %next = felt.add %acc, %one : !felt.type, !felt.type
+        scf.yield %next : !felt.type
+      }
+
+      function.return
+    }
+  }
+}
+
+// -----
+
+module attributes {llzk.lang = "llzk"} {
+  struct.def @R1CSBranchAuxScope {
+    struct.member @out : !felt.type {llzk.pub}
+
+    function.def @compute(%a: !felt.type, %cond: i1) -> !struct.type<@R1CSBranchAuxScope> {
+      %self = struct.new : !struct.type<@R1CSBranchAuxScope>
+      struct.writem %self[@out] = %a : !struct.type<@R1CSBranchAuxScope>, !felt.type
+      function.return %self : !struct.type<@R1CSBranchAuxScope>
+    }
+
+    function.def @constrain(%self: !struct.type<@R1CSBranchAuxScope>, %a: !felt.type, %cond: i1) {
+      // expected-error@+1 {{R1CS lowering expects a straight-line constrain body; run `llzk-flatten` or another control-flow lowering pass first}}
+      scf.if %cond {
+        %dynamic_sq = felt.mul %a, %a : !felt.type, !felt.type
+        constrain.eq %dynamic_sq, %dynamic_sq : !felt.type
+      }
+
+      function.return
+    }
+  }
+}

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -8,6 +8,7 @@ endfunction()
 
 add_subdirectory(Analysis)
 add_subdirectory(IR)
+add_subdirectory(Transforms)
 add_subdirectory(Util)
 add_subdirectory(Witgen)
 add_subdirectory(CAPI)

--- a/unittests/Transforms/CMakeLists.txt
+++ b/unittests/Transforms/CMakeLists.txt
@@ -1,0 +1,9 @@
+file(GLOB_RECURSE LLZK_TRANSFORMS_TEST_SOURCES "*.cpp")
+add_executable(LLZK_Transforms_Tests ${LLZK_TRANSFORMS_TEST_SOURCES})
+
+target_link_libraries(
+  LLZK_Transforms_Tests
+  PUBLIC LLZK::DialectRegistration LLZK::AllDialects ${GTEST_LIB_TARGETS} ${GTEST_EXE_TARGET}
+  ${LLZK_DEP_DIALECT_LIBS} MLIRParser LLZK::LLZKTransforms)
+
+llzk_gtest_suite(LLZK_Transforms_Tests)

--- a/unittests/Transforms/LoweringUtilsTests.cpp
+++ b/unittests/Transforms/LoweringUtilsTests.cpp
@@ -1,0 +1,47 @@
+//===-- LoweringUtilsTests.cpp - Transform utility tests --------*- C++ -*-===//
+//
+// Part of the LLZK Project, under the Apache License v2.0.
+// See LICENSE.txt for license information.
+// Copyright 2026 Project LLZK
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#include "../LLZKTestBase.h"
+
+#include "llzk/Dialect/Function/IR/Ops.h"
+#include "llzk/Transforms/LLZKLoweringUtils.h"
+
+#include <mlir/IR/Builders.h>
+#include <mlir/IR/BuiltinOps.h>
+#include <mlir/IR/OperationSupport.h>
+
+#include <gtest/gtest.h>
+
+using namespace mlir;
+using namespace llzk;
+
+namespace {
+
+class LoweringUtilsTests : public LLZKTest {};
+
+TEST_F(LoweringUtilsTests, RejectsSingleBlockSuccessorBearingConstrainBody) {
+  OpBuilder builder(&ctx);
+  OwningOpRef<ModuleOp> module = ModuleOp::create(loc);
+  builder.setInsertionPointToStart(module->getBody());
+
+  auto funcType = builder.getFunctionType(TypeRange {}, TypeRange {});
+  auto constrainFunc = builder.create<function::FuncDefOp>(loc, "constrain", funcType);
+  Block *entryBlock = constrainFunc.addEntryBlock();
+
+  OperationState successorOpState(loc, "test.successor");
+  successorOpState.addSuccessors(entryBlock);
+  entryBlock->push_back(Operation::create(successorOpState));
+
+  builder.setInsertionPointToEnd(entryBlock);
+  builder.create<function::ReturnOp>(loc);
+
+  EXPECT_TRUE(failed(checkConstrainBodyIsStraightLine(constrainFunc, "test pass")));
+}
+
+} // namespace

--- a/unittests/Transforms/LoweringUtilsTests.cpp
+++ b/unittests/Transforms/LoweringUtilsTests.cpp
@@ -26,6 +26,8 @@ namespace {
 class LoweringUtilsTests : public LLZKTest {};
 
 TEST_F(LoweringUtilsTests, RejectsSingleBlockSuccessorBearingConstrainBody) {
+  ctx.allowUnregisteredDialects();
+
   OpBuilder builder(&ctx);
   OwningOpRef<ModuleOp> module = ModuleOp::create(loc);
   builder.setInsertionPointToStart(module->getBody());
@@ -34,6 +36,8 @@ TEST_F(LoweringUtilsTests, RejectsSingleBlockSuccessorBearingConstrainBody) {
   auto constrainFunc = builder.create<function::FuncDefOp>(loc, "constrain", funcType);
   Block *entryBlock = constrainFunc.addEntryBlock();
 
+  // No registered LLZK test op has successors without regions, so use a synthetic op to cover the
+  // helper's successor-only rejection path without changing dialect registration.
   OperationState successorOpState(loc, "test.successor");
   successorOpState.addSuccessors(entryBlock);
   entryBlock->push_back(Operation::create(successorOpState));


### PR DESCRIPTION
Fixes #542.

## Summary

Make the straight-line `@constrain` precondition explicit for polynomial and R1CS lowering.

The lowering passes materialize auxiliary values at component scope and assume control flow has already been flattened or otherwise lowered away. When a `constrain` body is not straight-line, the passes now fail with a diagnostic instead of rewriting region-local expressions into component-lifetime auxiliaries.

## Changes

- Add a shared `@constrain` body check that rejects multi-block bodies and nested-region or successor-bearing operations before auxiliary materialization.
- Apply the check to `llzk-poly-lowering-pass` and `llzk-r1cs-lowering`.
- Document the already-flattened straight-line precondition in the pass descriptions and full lowering pipeline summaries.
- Add regression tests for multi-block, loop, branch, and loop-local struct constrain call argument cases in poly lowering, plus loop and branch cases in R1CS lowering.
- Add a changelog entry for the new non-straight-line rejection behavior.

## Testing

- `git diff --check`
- `git clang-format --diff upstream/main HEAD --binary clang-format`
- GitHub Actions on `6aab49a989ca686d40ba837bcbc5b49fed4fdee6`: all checks passing
