### PR TITLE
use `StringAttr` instead of `FlatSymbolRefAttr` in pod access ops

### DIFF
--- a/changelogs/unreleased/th__change_record_name_to_str.yaml
+++ b/changelogs/unreleased/th__change_record_name_to_str.yaml
@@ -1,0 +1,2 @@
+changed:
+  - use `StringAttr` instead of `FlatSymbolRefAttr` for record name in pod read/write ops

--- a/include/llzk/Dialect/POD/IR/OpInterfaces.td
+++ b/include/llzk/Dialect/POD/IR/OpInterfaces.td
@@ -49,18 +49,13 @@ def PodAccessOpInterface
       // Requires implementors to have a '$record_name' attribute.
       InterfaceMethod<
           [{Gets the record name attribute from the pod access op.}],
-          "::mlir::FlatSymbolRefAttr", "getRecordNameAttr", (ins)>,
+          "::mlir::StringAttr", "getRecordNameAttr", (ins)>,
       InterfaceMethod<
           [{Return `true` if the op is a read, `false` if it's a write.}],
           "bool", "isRead", (ins)>,
   ];
 
   let extraClassDeclaration = [{
-    /// Gets the record name as an attribute suitable for destructuring indices.
-    inline ::mlir::StringAttr getRecordNameAsStringAttr() {
-      return getRecordNameAttr().getLeafReference();
-    }
-
     /// Required by companion interface DestructurableAccessorOpInterface / SROA pass
     bool canRewire(const ::mlir::DestructurableMemorySlot &slot,
             ::llvm::SmallPtrSetImpl<::mlir::Attribute> &usedIndices,

--- a/include/llzk/Dialect/POD/IR/Ops.h
+++ b/include/llzk/Dialect/POD/IR/Ops.h
@@ -32,7 +32,7 @@ namespace llzk::pod {
 mlir::SmallVector<RecordValue>
 getInitializedRecordValues(mlir::ValueRange initialValues, mlir::ArrayAttr initializedRecords);
 
-mlir::ParseResult parseRecordName(mlir::AsmParser &parser, mlir::FlatSymbolRefAttr &name);
-void printRecordName(mlir::AsmPrinter &printer, mlir::Operation *, mlir::FlatSymbolRefAttr name);
+mlir::ParseResult parseRecordName(mlir::AsmParser &parser, mlir::StringAttr &name);
+void printRecordName(mlir::AsmPrinter &printer, mlir::Operation *, mlir::StringAttr name);
 
 } // namespace llzk::pod

--- a/include/llzk/Dialect/POD/IR/Ops.td
+++ b/include/llzk/Dialect/POD/IR/Ops.td
@@ -239,7 +239,7 @@ def LLZK_ReadPodOp : ScalarPODAccessOp<"read", 1> {
   }];
 
   let arguments = (ins Arg<LLZK_PODType, "the pod to read from">:$pod_ref,
-      FlatSymbolRefAttr:$record_name);
+      StrAttr:$record_name);
   let results = (outs AnyLLZKType:$result);
   let assemblyFormat = [{
     $pod_ref `[` custom<RecordName>($record_name) `]` `:` type($pod_ref) `,` type($result) attr-dict
@@ -264,7 +264,7 @@ def LLZK_WritePodOp : ScalarPODAccessOp<"write", 0> {
   }];
 
   let arguments = (ins Arg<LLZK_PODType, "the pod to write into">:$pod_ref,
-      FlatSymbolRefAttr:$record_name, AnyLLZKType:$value);
+      StrAttr:$record_name, AnyLLZKType:$value);
 
   let assemblyFormat = [{
     $pod_ref `[` custom<RecordName>($record_name) `]` `=` $value `:` type($pod_ref) `,` type($value) attr-dict

--- a/include/llzk/Dialect/POD/IR/Ops.td
+++ b/include/llzk/Dialect/POD/IR/Ops.td
@@ -244,6 +244,7 @@ def LLZK_ReadPodOp : ScalarPODAccessOp<"read", 1> {
   let assemblyFormat = [{
     $pod_ref `[` custom<RecordName>($record_name) `]` `:` type($pod_ref) `,` type($result) attr-dict
   }];
+  let useCustomPropertiesEncoding = 1;
   let hasVerifier = 1;
 }
 
@@ -269,6 +270,7 @@ def LLZK_WritePodOp : ScalarPODAccessOp<"write", 0> {
   let assemblyFormat = [{
     $pod_ref `[` custom<RecordName>($record_name) `]` `=` $value `:` type($pod_ref) `,` type($value) attr-dict
   }];
+  let useCustomPropertiesEncoding = 1;
   let hasVerifier = 1;
 }
 

--- a/lib/Dialect/Function/IR/Ops.cpp
+++ b/lib/Dialect/Function/IR/Ops.cpp
@@ -552,7 +552,7 @@ LogicalResult CallOp::readProperties(DialectBytecodeReader &reader, OperationSta
   return success();
 }
 
-// Same as tablegen would generate to serialize version 2 IR.
+// Same as tablegen would generate to serialize current version IR.
 void CallOp::writeProperties(DialectBytecodeWriter &writer) {
   auto &prop = getProperties();
   writer.writeAttribute(prop.callee);

--- a/lib/Dialect/POD/IR/Ops.cpp
+++ b/lib/Dialect/POD/IR/Ops.cpp
@@ -11,6 +11,7 @@
 
 #include "llzk/Dialect/Array/IR/Types.h"
 #include "llzk/Dialect/LLZK/IR/Ops.h"
+#include "llzk/Dialect/LLZK/IR/Versioning.h"
 #include "llzk/Dialect/POD/IR/Types.h"
 #include "llzk/Dialect/Struct/IR/Types.h"
 #include "llzk/Util/TypeHelper.h"
@@ -498,6 +499,42 @@ DeletionKind PodAccessOpInterface::rewire(
 // ReadPodOp
 //===----------------------------------------------------------------------===//
 
+namespace {
+
+LogicalResult readRecordNameProperty(DialectBytecodeReader &reader, StringAttr &recordName) {
+  auto versionOpt = reader.getDialectVersion<PODDialect>();
+  if (succeeded(versionOpt)) {
+    const auto &ver = static_cast<const LLZKDialectVersion &>(**versionOpt);
+    if (ver.majorVersion < 3) {
+      // Prior to v3 it was serialized as a `FlatSymbolRefAttr` instead of a `StringAttr`.
+      FlatSymbolRefAttr attr;
+      if (failed(reader.readAttribute(attr))) {
+        return failure();
+      }
+      recordName = attr.getAttr();
+      return success();
+    }
+  }
+
+  // Same as tablegen would generate to deserialize current-version IR.
+  return reader.readAttribute(recordName);
+}
+
+void writeRecordNameProperty(DialectBytecodeWriter &writer, StringAttr recordName) {
+  writer.writeAttribute(recordName);
+}
+
+} // namespace
+
+LogicalResult ReadPodOp::readProperties(DialectBytecodeReader &reader, OperationState &state) {
+  auto &prop = state.getOrAddProperties<Properties>();
+  return readRecordNameProperty(reader, prop.record_name);
+}
+
+void ReadPodOp::writeProperties(DialectBytecodeWriter &writer) {
+  writeRecordNameProperty(writer, getProperties().record_name);
+}
+
 LogicalResult ReadPodOp::verify() {
   auto podTy = llvm::dyn_cast<PodType>(getPodRef().getType());
   if (!podTy) {
@@ -521,6 +558,15 @@ LogicalResult ReadPodOp::verify() {
 //===----------------------------------------------------------------------===//
 // WritePodOp
 //===----------------------------------------------------------------------===//
+
+LogicalResult WritePodOp::readProperties(DialectBytecodeReader &reader, OperationState &state) {
+  auto &prop = state.getOrAddProperties<Properties>();
+  return readRecordNameProperty(reader, prop.record_name);
+}
+
+void WritePodOp::writeProperties(DialectBytecodeWriter &writer) {
+  writeRecordNameProperty(writer, getProperties().record_name);
+}
 
 LogicalResult WritePodOp::verify() {
   auto podTy = llvm::dyn_cast<PodType>(getPodRef().getType());

--- a/lib/Dialect/POD/IR/Ops.cpp
+++ b/lib/Dialect/POD/IR/Ops.cpp
@@ -470,7 +470,7 @@ bool PodAccessOpInterface::canRewire(
     return false;
   }
 
-  StringAttr recordName = getRecordNameAsStringAttr();
+  StringAttr recordName = getRecordNameAttr();
   if (!slot.subelementTypes.contains(recordName)) {
     return false;
   }
@@ -487,7 +487,7 @@ DeletionKind PodAccessOpInterface::rewire(
   assert(slot.ptr == getPodRef());
   assert(slot.elemType == getPodRefType());
 
-  StringAttr recordName = getRecordNameAsStringAttr();
+  StringAttr recordName = getRecordNameAttr();
   const MemorySlot &memorySlot = subslots.at(recordName);
   getPodRefMutable().set(memorySlot.ptr);
 
@@ -546,11 +546,16 @@ LogicalResult WritePodOp::verify() {
 // Parsing/Printing helpers
 //===----------------------------------------------------------------------===//
 
-ParseResult parseRecordName(AsmParser &parser, FlatSymbolRefAttr &name) {
-  return parser.parseCustomAttributeWithFallback(name);
+ParseResult parseRecordName(AsmParser &parser, StringAttr &name) {
+  FlatSymbolRefAttr symRef;
+  auto result = parser.parseCustomAttributeWithFallback(symRef);
+  if (succeeded(result)) {
+    name = symRef.getAttr();
+  }
+  return result;
 }
 
-void printRecordName(AsmPrinter &printer, Operation *, FlatSymbolRefAttr name) {
+void printRecordName(AsmPrinter &printer, Operation *, StringAttr name) {
   printer.printSymbolName(name.getValue());
 }
 

--- a/lib/Dialect/POD/Transforms/PodToScalarPass.cpp
+++ b/lib/Dialect/POD/Transforms/PodToScalarPass.cpp
@@ -759,24 +759,14 @@ step2(ModuleOp modOp, SymbolTableCollection &symTables, const MemberReplacementM
   return applyFullConversion(modOp, target, std::move(patterns));
 }
 
-/// Normalize the record name representation used by POD access ops to a plain `StringAttr`.
-inline static StringAttr getRecordNameAsStringAttr(ReadPodOp readOp) {
-  return readOp.getRecordNameAttr().getLeafReference();
-}
-
-/// Normalize the record name representation used by POD access ops to a plain `StringAttr`.
-inline static StringAttr getRecordNameAsStringAttr(WritePodOp writeOp) {
-  return writeOp.getRecordNameAttr().getLeafReference();
-}
-
 /// Return whether the given read/write access targets the same POD record.
 inline static bool isSamePodRecord(ReadPodOp readOp, Value podRef, StringAttr recordName) {
-  return readOp.getPodRef() == podRef && getRecordNameAsStringAttr(readOp) == recordName;
+  return readOp.getPodRef() == podRef && readOp.getRecordNameAttr() == recordName;
 }
 
 /// Return whether the given read/write access targets the same POD record.
 inline static bool isSamePodRecord(WritePodOp writeOp, Value podRef, StringAttr recordName) {
-  return writeOp.getPodRef() == podRef && getRecordNameAsStringAttr(writeOp) == recordName;
+  return writeOp.getPodRef() == podRef && writeOp.getRecordNameAttr() == recordName;
 }
 
 /// Return whether `op` contains a nested write to `podRef.recordName`.
@@ -803,7 +793,7 @@ static bool hasValueUse(Operation &op, Value value) {
 /// Return whether the read is preceded by a write to the same pod record within its block.
 static bool hasEarlierWriteInBlock(ReadPodOp readOp) {
   Value podRef = readOp.getPodRef();
-  StringAttr recordName = getRecordNameAsStringAttr(readOp);
+  StringAttr recordName = readOp.getRecordNameAttr();
 
   for (Operation &op : *readOp->getBlock()) {
     if (&op == readOp.getOperation()) {
@@ -854,7 +844,7 @@ static WritePodOp findPrecedingWriteForIfRead(ReadPodOp readOp) {
   }
 
   Value podRef = readOp.getPodRef();
-  StringAttr recordName = getRecordNameAsStringAttr(readOp);
+  StringAttr recordName = readOp.getRecordNameAttr();
   WritePodOp replacement = nullptr;
   for (Operation &op : *ifBlock) {
     if (&op == ifOp.getOperation()) {
@@ -897,9 +887,8 @@ public:
 
     rewriter.setInsertionPoint(ifOp);
     rewriter.replaceOp(
-        readOp,
-        genRead(readOp.getLoc(), readOp.getPodRef(), getRecordNameAsStringAttr(readOp), rewriter)
-            .getResult()
+        readOp, genRead(readOp.getLoc(), readOp.getPodRef(), readOp.getRecordNameAttr(), rewriter)
+                    .getResult()
     );
     return success();
   }
@@ -934,7 +923,7 @@ public:
     }
 
     auto writeOp = dyn_cast_or_null<WritePodOp>(readOp->getPrevNode());
-    if (!writeOp || getRecordNameAsStringAttr(writeOp) != getRecordNameAsStringAttr(readOp)) {
+    if (!writeOp || writeOp.getRecordNameAttr() != readOp.getRecordNameAttr()) {
       return failure();
     }
 
@@ -1022,7 +1011,7 @@ collectDirectWrites(Block *block, bool isThenBlock, SmallVectorImpl<IfWriteSlot>
     }
 
     IfWriteSlot &slot = getOrCreateSlot(
-        slots, writeOp.getPodRef(), getRecordNameAsStringAttr(writeOp), writeOp.getValue().getType()
+        slots, writeOp.getPodRef(), writeOp.getRecordNameAttr(), writeOp.getValue().getType()
     );
     if (isThenBlock) {
       slot.thenWrite = writeOp;
@@ -1179,7 +1168,7 @@ collectDirectLoopPodSlots(Block &block, Operation *ancestor, SmallVectorImpl<Loo
     if (auto readOp = dyn_cast<ReadPodOp>(&op)) {
       if (!isValueDefinedInside(ancestor, readOp.getPodRef())) {
         getOrCreateLoopSlot(
-            slots, readOp.getPodRef(), getRecordNameAsStringAttr(readOp), readOp.getType()
+            slots, readOp.getPodRef(), readOp.getRecordNameAttr(), readOp.getType()
         );
       }
       continue;
@@ -1188,8 +1177,7 @@ collectDirectLoopPodSlots(Block &block, Operation *ancestor, SmallVectorImpl<Loo
     if (auto writeOp = dyn_cast<WritePodOp>(&op)) {
       if (!isValueDefinedInside(ancestor, writeOp.getPodRef())) {
         getOrCreateLoopSlot(
-            slots, writeOp.getPodRef(), getRecordNameAsStringAttr(writeOp),
-            writeOp.getValue().getType()
+            slots, writeOp.getPodRef(), writeOp.getRecordNameAttr(), writeOp.getValue().getType()
         );
       }
     }
@@ -1214,14 +1202,14 @@ static bool hasNestedTrackedPodAccess(Operation &op, ArrayRef<LoopPodSlot> slots
     }
 
     if (auto readOp = dyn_cast<ReadPodOp>(nestedOp)) {
-      if (hasLoopSlot(slots, readOp.getPodRef(), getRecordNameAsStringAttr(readOp))) {
+      if (hasLoopSlot(slots, readOp.getPodRef(), readOp.getRecordNameAttr())) {
         return WalkResult::interrupt();
       }
       return WalkResult::advance();
     }
 
     if (auto writeOp = dyn_cast<WritePodOp>(nestedOp)) {
-      if (hasLoopSlot(slots, writeOp.getPodRef(), getRecordNameAsStringAttr(writeOp))) {
+      if (hasLoopSlot(slots, writeOp.getPodRef(), writeOp.getRecordNameAttr())) {
         return WalkResult::interrupt();
       }
     }
@@ -1375,7 +1363,7 @@ public:
 
       if (auto readOp = dyn_cast<ReadPodOp>(&op)) {
         if (std::optional<size_t> slotIdx =
-                findLoopSlotIndex(slots, readOp.getPodRef(), getRecordNameAsStringAttr(readOp))) {
+                findLoopSlotIndex(slots, readOp.getPodRef(), readOp.getRecordNameAttr())) {
           mapping.map(readOp.getResult(), slotValues[*slotIdx]);
           continue;
         }
@@ -1383,7 +1371,7 @@ public:
 
       if (auto writeOp = dyn_cast<WritePodOp>(&op)) {
         if (std::optional<size_t> slotIdx =
-                findLoopSlotIndex(slots, writeOp.getPodRef(), getRecordNameAsStringAttr(writeOp))) {
+                findLoopSlotIndex(slots, writeOp.getPodRef(), writeOp.getRecordNameAttr())) {
           slotValues[*slotIdx] = mapping.lookupOrDefault(writeOp.getValue());
           continue;
         }
@@ -1472,7 +1460,7 @@ public:
 
       if (auto readOp = dyn_cast<ReadPodOp>(&op)) {
         if (std::optional<size_t> slotIdx =
-                findLoopSlotIndex(slots, readOp.getPodRef(), getRecordNameAsStringAttr(readOp))) {
+                findLoopSlotIndex(slots, readOp.getPodRef(), readOp.getRecordNameAttr())) {
           beforeMapping.map(readOp.getResult(), beforeSlotValues[*slotIdx]);
           continue;
         }
@@ -1480,7 +1468,7 @@ public:
 
       if (auto writeOp = dyn_cast<WritePodOp>(&op)) {
         if (std::optional<size_t> slotIdx =
-                findLoopSlotIndex(slots, writeOp.getPodRef(), getRecordNameAsStringAttr(writeOp))) {
+                findLoopSlotIndex(slots, writeOp.getPodRef(), writeOp.getRecordNameAttr())) {
           beforeSlotValues[*slotIdx] = beforeMapping.lookupOrDefault(writeOp.getValue());
           continue;
         }
@@ -1518,7 +1506,7 @@ public:
 
       if (auto readOp = dyn_cast<ReadPodOp>(&op)) {
         if (std::optional<size_t> slotIdx =
-                findLoopSlotIndex(slots, readOp.getPodRef(), getRecordNameAsStringAttr(readOp))) {
+                findLoopSlotIndex(slots, readOp.getPodRef(), readOp.getRecordNameAttr())) {
           afterMapping.map(readOp.getResult(), afterSlotValues[*slotIdx]);
           continue;
         }
@@ -1526,7 +1514,7 @@ public:
 
       if (auto writeOp = dyn_cast<WritePodOp>(&op)) {
         if (std::optional<size_t> slotIdx =
-                findLoopSlotIndex(slots, writeOp.getPodRef(), getRecordNameAsStringAttr(writeOp))) {
+                findLoopSlotIndex(slots, writeOp.getPodRef(), writeOp.getRecordNameAttr())) {
           afterSlotValues[*slotIdx] = afterMapping.lookupOrDefault(writeOp.getValue());
           continue;
         }

--- a/lib/Dialect/Struct/IR/Ops.cpp
+++ b/lib/Dialect/Struct/IR/Ops.cpp
@@ -513,7 +513,7 @@ LogicalResult StructDefOp::readProperties(DialectBytecodeReader &reader, Operati
   return reader.readAttribute(prop.sym_name);
 }
 
-// Same as tablegen would generate to serialize version 2 IR.
+// Same as tablegen would generate to serialize current version IR.
 void StructDefOp::writeProperties(DialectBytecodeWriter &writer) {
   auto &prop = getProperties();
   writer.writeAttribute(prop.sym_name);

--- a/lib/Util/SymbolTableLLZK.cpp
+++ b/lib/Util/SymbolTableLLZK.cpp
@@ -35,8 +35,6 @@
 
 #include "llzk/Util/SymbolTableLLZK.h"
 
-#include "llzk/Dialect/POD/IR/Ops.h"
-
 #include <llvm/ADT/SmallPtrSet.h>
 
 using namespace mlir;
@@ -149,24 +147,7 @@ walkSymbolRefs(Operation *op, function_ref<WalkResult(SymbolTable::SymbolUse)> c
       return WalkResult::interrupt();
     }
   }
-
-  // TODO: Remove this when POD types are updated to use StringAttr.
-  // POD record names are encoded as FlatSymbolRefAttr for parsing/printing
-  // convenience, but they are not real symbol references and must not be
-  // surfaced as symbol uses.
-  auto shouldSkipAttr = [op](NamedAttribute attr) {
-    return attr.getName() == "record_name" &&
-           (isa<llzk::pod::ReadPodOp>(op) || isa<llzk::pod::WritePodOp>(op));
-  };
-  for (NamedAttribute attr : op->getAttrs()) {
-    if (shouldSkipAttr(attr)) {
-      continue;
-    }
-    if (attr.getValue().walk<WalkOrder::PreOrder>(walkFn).wasInterrupted()) {
-      return WalkResult::interrupt();
-    }
-  }
-  return WalkResult::advance();
+  return op->getAttrDictionary().walk<WalkOrder::PreOrder>(walkFn);
 }
 
 /// Walk all of the uses, for any symbol, that are nested within the given

--- a/nix/llzk.nix
+++ b/nix/llzk.nix
@@ -12,7 +12,7 @@
 }:
 
 let
-  version = "2.1.1";
+  version = "3.0.0";
 in
 stdenv.mkDerivation {
   pname = "llzk-${lib.toLower cmakeBuildType}";

--- a/unittests/CAPI/Dialect/POD.cpp
+++ b/unittests/CAPI/Dialect/POD.cpp
@@ -198,7 +198,7 @@ std::unique_ptr<ReadPodOpBuildFuncHelper> ReadPodOpBuildFuncHelper::get() {
           unwrap(testClass.context), {createRecordAttrCpp(name, unwrap(indexTy))}
       );
       auto newPodOp = unwrap(builder)->create<llzk::pod::NewPodOp>(unwrap(location), podTy);
-      auto recordName = mlir::FlatSymbolRefAttr::get(unwrap(testClass.context), name);
+      auto recordName = mlir::StringAttr::get(unwrap(testClass.context), name);
       return llzkPod_ReadPodOpBuild(
           builder, location, indexTy, wrap(newPodOp.getResult()), wrap(recordName)
       );
@@ -222,7 +222,7 @@ std::unique_ptr<WritePodOpBuildFuncHelper> WritePodOpBuildFuncHelper::get() {
           unwrap(testClass.context), {createRecordAttrCpp(name, unwrap(indexTy))}
       );
       auto newPodOp = unwrap(builder)->create<llzk::pod::NewPodOp>(unwrap(location), podTy);
-      auto recordName = mlir::FlatSymbolRefAttr::get(unwrap(testClass.context), name);
+      auto recordName = mlir::StringAttr::get(unwrap(testClass.context), name);
       return llzkPod_WritePodOpBuild(
           builder, location, wrap(newPodOp.getResult()),
           mlirOperationGetResult(testClass.createIndexOperation(), 0), wrap(recordName)


### PR DESCRIPTION
use `StringAttr` instead of `FlatSymbolRefAttr` for record name in pod read/write ops