### PR TITLE
Respect table offsets in duplicate read/write elimination

### DIFF
--- a/changelogs/unreleased/fix__issue-569-table-offset-rw-elim.yaml
+++ b/changelogs/unreleased/fix__issue-569-table-offset-rw-elim.yaml
@@ -1,0 +1,3 @@
+fixed:
+  - Prevent duplicate read/write elimination from conflating struct member
+    accesses with different table offsets or affine operands.

--- a/include/llzk/Transforms/LLZKTransformationPasses.td
+++ b/include/llzk/Transforms/LLZKTransformationPasses.td
@@ -16,7 +16,10 @@ def RedundantReadAndWriteEliminationPass
     : LLZKPass<"llzk-duplicate-read-write-elim"> {
   let summary = "Remove redundant reads and writes";
   let description = [{
-    Remove read and write operations to struct members and arrays that are redundant or unnecessary.
+    Remove struct-member and array reads or writes that repeat the same access.
+    Struct-member accesses match only when the base, member, table offset,
+    affine map metadata, and translated affine operands match. Omitted
+    member-read offsets and member writes denote the current row.
   }];
 }
 

--- a/lib/Transforms/LLZKRedundantReadAndWriteEliminationPass.cpp
+++ b/lib/Transforms/LLZKRedundantReadAndWriteEliminationPass.cpp
@@ -46,14 +46,14 @@ using namespace llzk::component;
 
 namespace {
 
-/// @brief An reference to a value, represented either by an SSA value, a
-/// symbol reference (e.g., a member name), or an int (e.g., a constant array index).
+/// @brief A reference to a value, represented by an SSA value, an attribute
+/// (e.g., a member name or access metadata), or an int (e.g., a constant array index).
 class ReferenceID {
 public:
   explicit ReferenceID(Value v) {
     // reserved special pointer values for DenseMapInfo
-    if (v.getImpl() == reinterpret_cast<mlir::detail::ValueImpl *>(1) ||
-        v.getImpl() == reinterpret_cast<mlir::detail::ValueImpl *>(2)) {
+    if (v == llvm::DenseMapInfo<Value>::getEmptyKey() ||
+        v == llvm::DenseMapInfo<Value>::getTombstoneKey()) {
       identifier = v;
     } else if (auto constVal = dyn_cast_if_present<FeltConstantOp>(v.getDefiningOp())) {
       identifier = constVal.getValue();
@@ -63,12 +63,12 @@ public:
       identifier = v;
     }
   }
-  explicit ReferenceID(FlatSymbolRefAttr s) : identifier(s) {}
+  explicit ReferenceID(Attribute attr) : identifier(attr) {}
   explicit ReferenceID(const APInt &i) : identifier(i) {}
   explicit ReferenceID(unsigned i) : identifier(APInt(64, i)) {}
 
   bool isValue() const { return std::holds_alternative<Value>(identifier); }
-  bool isSymbol() const { return std::holds_alternative<FlatSymbolRefAttr>(identifier); }
+  bool isAttribute() const { return std::holds_alternative<Attribute>(identifier); }
   bool isConst() const { return std::holds_alternative<APInt>(identifier); }
 
   Value getValue() const {
@@ -76,9 +76,9 @@ public:
     return std::get<Value>(identifier);
   }
 
-  FlatSymbolRefAttr getSymbol() const {
-    ensure(isSymbol(), "does not hold symbol");
-    return std::get<FlatSymbolRefAttr>(identifier);
+  Attribute getAttribute() const {
+    ensure(isAttribute(), "does not hold Attribute");
+    return std::get<Attribute>(identifier);
   }
 
   APInt getConst() const {
@@ -93,8 +93,8 @@ public:
       } else {
         os << *v;
       }
-    } else if (const auto *s = std::get_if<FlatSymbolRefAttr>(&identifier)) {
-      os << *s;
+    } else if (const auto *attr = std::get_if<Attribute>(&identifier)) {
+      os << *attr;
     } else {
       os << std::get<APInt>(identifier);
     }
@@ -111,10 +111,10 @@ public:
 
 private:
   /// @brief Three cases:
-  /// FlatSymbolRefAttr: identifier refers to a named member in a struct
+  /// Attribute: identifier refers to a named member or other access metadata
   /// APInt: identifier refers to a constant index in an array
-  /// Value: identifier refers to a dynamic index in an array
-  std::variant<FlatSymbolRefAttr, APInt, Value> identifier;
+  /// Value: identifier refers to a dynamic index or access operand
+  std::variant<Attribute, APInt, Value> identifier;
 };
 
 } // namespace
@@ -123,17 +123,15 @@ namespace llvm {
 
 /// @brief Allows ReferenceID to be a DenseMap key.
 template <> struct DenseMapInfo<ReferenceID> {
-  static ReferenceID getEmptyKey() {
-    return ReferenceID(mlir::Value(reinterpret_cast<mlir::detail::ValueImpl *>(1)));
-  }
+  static ReferenceID getEmptyKey() { return ReferenceID(DenseMapInfo<Value>::getEmptyKey()); }
   static inline ReferenceID getTombstoneKey() {
-    return ReferenceID(mlir::Value(reinterpret_cast<mlir::detail::ValueImpl *>(2)));
+    return ReferenceID(DenseMapInfo<Value>::getTombstoneKey());
   }
   static unsigned getHashValue(const ReferenceID &r) {
     if (r.isValue()) {
       return hash_value(r.getValue());
-    } else if (r.isSymbol()) {
-      return hash_value(r.getSymbol());
+    } else if (r.isAttribute()) {
+      return hash_value(r.getAttribute());
     }
     return hash_value(r.getConst());
   }
@@ -150,6 +148,7 @@ namespace {
 /// - A map of children (e.g., members of a struct or elements of an array).
 /// An example:
 /// %self -> @arr -> 1 represents %self[@arr][1].
+/// %self -> @column -> -1 : index represents a prior-row member access.
 ///
 /// Values not in this tree are unknown, and therefore not subject to read/write
 /// elimination until they become known and can be eliminated when redundant operations
@@ -222,6 +221,8 @@ public:
     return old;
   }
 
+  void clearLastWrite() { lastWrite = nullptr; }
+
   void setCurrentValue(Value v, const std::shared_ptr<ReferenceNode> &valTree = nullptr) {
     storedValue = v;
     if (valTree != nullptr) {
@@ -232,6 +233,19 @@ public:
   }
 
   void invalidateChildren() { children.clear(); }
+
+  bool invalidateNonIntegerOffsetChildren() {
+    SmallVector<ReferenceID> invalidChildren;
+    for (const auto &[id, _] : children) {
+      if (!id.isAttribute() || !isa<IntegerAttr>(id.getAttribute())) {
+        invalidChildren.push_back(id);
+      }
+    }
+    for (const ReferenceID &id : invalidChildren) {
+      children.erase(id);
+    }
+    return !invalidChildren.empty();
+  }
 
   bool isLeaf() const { return children.empty(); }
 
@@ -365,7 +379,7 @@ class PassImpl : public llzk::impl::RedundantReadAndWriteEliminationPassBase<Pas
     // Now that we have accumulated all necessary state, we perform the optimizations:
     // - Replace all redundant values.
     for (auto &[orig, replace] : replacementMap) {
-      LLVM_DEBUG(llvm::dbgs() << "replacing " << orig << " with " << orig << '\n');
+      LLVM_DEBUG(llvm::dbgs() << "replacing " << orig << " with " << replace << '\n');
       orig.replaceAllUsesWith(replace);
       // We save the deletion to the readVals loop to prevent double-free.
     }
@@ -515,6 +529,27 @@ class PassImpl : public llzk::impl::RedundantReadAndWriteEliminationPassBase<Pas
       return nullptr;
     };
 
+    // An omitted table offset denotes the current row.
+    const IntegerAttr zeroTableOffset = IntegerAttr::get(IndexType::get(op->getContext()), 0);
+    auto getMemberNode = [&](Value component, FlatSymbolRefAttr member) {
+      return state.at(translate(component))->getOrCreateChild(member);
+    };
+    auto getMemberAccessNode = [&](MemberReadOp readm) {
+      std::shared_ptr<ReferenceNode> access =
+          getMemberNode(readm.getComponent(), readm.getMemberNameAttr());
+      access = access->getOrCreateChild(readm.getTableOffset().value_or(zeroTableOffset));
+      if (!readm.getMapOperands().empty()) {
+        access = access->getOrCreateChild(readm.getMapOpGroupSizesAttr());
+        access = access->getOrCreateChild(readm.getNumDimsPerMapAttr());
+      }
+      for (auto mapOperands : readm.getMapOperands()) {
+        for (Value operand : mapOperands) {
+          access = access->getOrCreateChild(translate(operand));
+        }
+      }
+      return access;
+    };
+
     // Read a value from an array. This works on both readarr operations (which
     // return a scalar value) and extractarr operations (which return a subarray).
     auto doArrayReadLike = [&]<HasInterface<ArrayAccessOpInterface> OpClass>(OpClass readarr) {
@@ -550,9 +585,8 @@ class PassImpl : public llzk::impl::RedundantReadAndWriteEliminationPassBase<Pas
     // Write a scalar value (for writearr) or a subarray value (for insertarr)
     // to an array. The unique part of this operation relative to others is that
     // we may receive a variable index (i.e., not a constant). In this case, we
-    // invalidate ajoining parts of the subtree, since it is possible that
-    // the variable index aliases one of the other elements and may or may not
-    // override that value.
+    // invalidate adjacent subtree state because the variable index may alias
+    // another element.
     auto doArrayWriteLike = [&]<HasInterface<ArrayAccessOpInterface> OpClass>(OpClass writearr) {
       std::shared_ptr<ReferenceNode> currValTree = state.at(translate(writearr.getArrRef()));
       Value newVal = translate(writearr.getRvalue());
@@ -596,48 +630,52 @@ class PassImpl : public llzk::impl::RedundantReadAndWriteEliminationPassBase<Pas
       // adding this to readVals
       readVals.push_back(newStruct);
     } else if (auto readm = dyn_cast<MemberReadOp>(op)) {
-      auto structVal = state.at(translate(readm.getComponent()));
-      FlatSymbolRefAttr symbol = readm.getMemberNameAttr();
-      Value resVal = translate(readm.getVal());
-      // Check if such a child already exists.
-      if (auto child = structVal->getChild(symbol)) {
+      std::shared_ptr<ReferenceNode> access = getMemberAccessNode(readm);
+      Value resVal = readm.getVal();
+      if (!access->hasStoredValue()) {
+        access->setCurrentValue(resVal);
+      }
+      if (access->getStoredValue() != resVal) {
         LLVM_DEBUG(
             llvm::dbgs() << readm.getOperationName() << ": adding replacement map entry { "
-                         << resVal << " => " << child->getStoredValue() << " }\n"
+                         << resVal << " => " << access->getStoredValue() << " }\n"
         );
-        replacementMap[resVal] = child->getStoredValue();
+        replacementMap[resVal] = access->getStoredValue();
       } else {
-        // If we have no previous store, we create a new symbolic value for
-        // this location.
-        state[readm] = structVal->createChild(symbol, resVal);
-        LLVM_DEBUG(llvm::dbgs() << readm.getOperationName() << ": " << *state[readm] << '\n');
+        state[resVal] = access;
+        LLVM_DEBUG(llvm::dbgs() << readm.getOperationName() << ": " << *access << '\n');
       }
-      // specifically add the untranslated value back for removal checks
-      readVals.push_back(readm.getVal());
+      readVals.push_back(resVal);
     } else if (auto writem = dyn_cast<MemberWriteOp>(op)) {
-      auto structVal = state.at(translate(writem.getComponent()));
+      std::shared_ptr<ReferenceNode> member =
+          getMemberNode(writem.getComponent(), writem.getMemberNameAttr());
+      // Symbolic and affine offsets may resolve to the current row. Constant
+      // nonzero offsets stay distinct from a current-row member write.
+      bool invalidatedMayAliasRead = member->invalidateNonIntegerOffsetChildren();
       Value writeVal = translate(writem.getVal());
-      FlatSymbolRefAttr symbol = writem.getMemberNameAttr();
       auto valTree = tryGetValTree(writeVal);
 
-      auto child = structVal->getOrCreateChild(symbol);
-      if (child->getStoredValue() == writeVal) {
+      auto access = member->getOrCreateChild(zeroTableOffset);
+      if (invalidatedMayAliasRead) {
+        access->clearLastWrite();
+      }
+      if (access->getStoredValue() == writeVal) {
         LLVM_DEBUG(
             llvm::dbgs() << writem.getOperationName() << ": recording redundant write " << writem
                          << '\n'
         );
         redundantWrites.push_back(writem);
       } else {
-        if (auto *lastWrite = child->updateLastWrite(writem)) {
+        if (auto *lastWrite = access->updateLastWrite(writem)) {
           LLVM_DEBUG(
               llvm::dbgs() << writem.getOperationName() << ": recording overwritten write "
                            << *lastWrite << '\n'
           );
           redundantWrites.push_back(lastWrite);
         }
-        child->setCurrentValue(writeVal, valTree);
+        access->setCurrentValue(writeVal, valTree);
         LLVM_DEBUG(
-            llvm::dbgs() << writem.getOperationName() << ": " << *child << " set to " << writeVal
+            llvm::dbgs() << writem.getOperationName() << ": " << *access << " set to " << writeVal
                          << '\n'
         );
       }

--- a/test/Transforms/RedundantAndUnusedElim/redundant_read_write_table_offset.llzk
+++ b/test/Transforms/RedundantAndUnusedElim/redundant_read_write_table_offset.llzk
@@ -1,0 +1,356 @@
+// RUN: llzk-opt -split-input-file -llzk-duplicate-read-write-elim %s 2>&1 | FileCheck %s
+
+module attributes {llzk.lang} {
+  struct.def @DifferentOffsets {
+    struct.member @cell : !felt.type {column}
+
+    function.def @compute() -> !struct.type<@DifferentOffsets> {
+      %self = struct.new : !struct.type<@DifferentOffsets>
+      function.return %self : !struct.type<@DifferentOffsets>
+    }
+
+    function.def @constrain(%self: !struct.type<@DifferentOffsets>) {
+      %prev = struct.readm %self[@cell] : !struct.type<@DifferentOffsets>, !felt.type {tableOffset = -1 : index}
+      %curr = struct.readm %self[@cell] : !struct.type<@DifferentOffsets>, !felt.type {tableOffset = 0 : index}
+      constrain.eq %prev, %curr : !felt.type
+      function.return
+    }
+  }
+}
+
+// CHECK-LABEL: struct.def @DifferentOffsets {
+// CHECK: function.def @constrain(%[[SELF:.*]]: !struct.type<@DifferentOffsets>)
+// CHECK-NEXT: %[[PREV:.*]] = struct.readm %[[SELF]][@cell] : <@DifferentOffsets>, !felt.type {tableOffset = -1 : index}
+// CHECK-NEXT: %[[CURR:.*]] = struct.readm %[[SELF]][@cell] : <@DifferentOffsets>, !felt.type {tableOffset = 0 : index}
+// CHECK-NEXT: constrain.eq %[[PREV]], %[[CURR]] : !felt.type, !felt.type
+
+// -----
+
+module attributes {llzk.lang} {
+  struct.def @SameOffset {
+    struct.member @cell : !felt.type {column}
+
+    function.def @compute() -> !struct.type<@SameOffset> {
+      %self = struct.new : !struct.type<@SameOffset>
+      function.return %self : !struct.type<@SameOffset>
+    }
+
+    function.def @constrain(%self: !struct.type<@SameOffset>) {
+      %first = struct.readm %self[@cell] : !struct.type<@SameOffset>, !felt.type {tableOffset = -1 : index}
+      %second = struct.readm %self[@cell] : !struct.type<@SameOffset>, !felt.type {tableOffset = -1 : index}
+      constrain.eq %first, %second : !felt.type
+      function.return
+    }
+  }
+}
+
+// CHECK-LABEL: struct.def @SameOffset {
+// CHECK: function.def @constrain(%[[SELF:.*]]: !struct.type<@SameOffset>)
+// CHECK-NEXT: %[[READ:.*]] = struct.readm %[[SELF]][@cell] : <@SameOffset>, !felt.type {tableOffset = -1 : index}
+// CHECK-NEXT: constrain.eq %[[READ]], %[[READ]] : !felt.type, !felt.type
+
+// -----
+
+module attributes {llzk.lang} {
+  struct.def @DefaultOffset {
+    struct.member @cell : !felt.type {column}
+
+    function.def @compute() -> !struct.type<@DefaultOffset> {
+      %self = struct.new : !struct.type<@DefaultOffset>
+      function.return %self : !struct.type<@DefaultOffset>
+    }
+
+    function.def @constrain(%self: !struct.type<@DefaultOffset>) {
+      %implicit = struct.readm %self[@cell] : !struct.type<@DefaultOffset>, !felt.type
+      %explicit = struct.readm %self[@cell] : !struct.type<@DefaultOffset>, !felt.type {tableOffset = 0 : index}
+      constrain.eq %implicit, %explicit : !felt.type
+      function.return
+    }
+  }
+}
+
+// CHECK-LABEL: struct.def @DefaultOffset {
+// CHECK: function.def @constrain(%[[SELF:.*]]: !struct.type<@DefaultOffset>)
+// CHECK-NEXT: %[[READ:.*]] = struct.readm %[[SELF]][@cell] : <@DefaultOffset>, !felt.type
+// CHECK-NEXT: constrain.eq %[[READ]], %[[READ]] : !felt.type, !felt.type
+
+// -----
+
+module attributes {llzk.lang} {
+  struct.def @WriteOffsets {
+    struct.member @cell : !felt.type {column}
+    struct.member @first : !felt.type
+    struct.member @second : !felt.type
+    struct.member @current : !felt.type
+
+    function.def @compute(%value: !felt.type) -> !struct.type<@WriteOffsets> {
+      %self = struct.new : !struct.type<@WriteOffsets>
+      %before = struct.readm %self[@cell] : !struct.type<@WriteOffsets>, !felt.type {tableOffset = -1 : index}
+      struct.writem %self[@cell] = %value : !struct.type<@WriteOffsets>, !felt.type
+      %after = struct.readm %self[@cell] : !struct.type<@WriteOffsets>, !felt.type {tableOffset = -1 : index}
+      %at_current = struct.readm %self[@cell] : !struct.type<@WriteOffsets>, !felt.type
+      struct.writem %self[@first] = %before : !struct.type<@WriteOffsets>, !felt.type
+      struct.writem %self[@second] = %after : !struct.type<@WriteOffsets>, !felt.type
+      struct.writem %self[@current] = %at_current : !struct.type<@WriteOffsets>, !felt.type
+      function.return %self : !struct.type<@WriteOffsets>
+    }
+
+    function.def @constrain(%self: !struct.type<@WriteOffsets>, %value: !felt.type) {
+      function.return
+    }
+  }
+}
+
+// CHECK-LABEL: struct.def @WriteOffsets {
+// CHECK: function.def @compute(%[[VALUE:.*]]: !felt.type) -> !struct.type<@WriteOffsets>
+// CHECK-NEXT: %[[SELF:.*]] = struct.new : <@WriteOffsets>
+// CHECK-NEXT: %[[PREV:.*]] = struct.readm %[[SELF]][@cell] : <@WriteOffsets>, !felt.type {tableOffset = -1 : index}
+// CHECK-NEXT: struct.writem %[[SELF]][@cell] = %[[VALUE]] : <@WriteOffsets>, !felt.type
+// CHECK-NEXT: struct.writem %[[SELF]][@first] = %[[PREV]] : <@WriteOffsets>, !felt.type
+// CHECK-NEXT: struct.writem %[[SELF]][@second] = %[[PREV]] : <@WriteOffsets>, !felt.type
+// CHECK-NEXT: struct.writem %[[SELF]][@current] = %[[VALUE]] : <@WriteOffsets>, !felt.type
+
+// -----
+
+module attributes {llzk.lang} {
+  struct.def @AffineWriteAlias {
+    struct.member @cell : !felt.type {column}
+    struct.member @before : !felt.type
+    struct.member @other : !felt.type
+    struct.member @reuse : !felt.type
+    struct.member @after : !felt.type
+
+    function.def @compute(%i: index, %j: index, %value: !felt.type) -> !struct.type<@AffineWriteAlias> {
+      %self = struct.new : !struct.type<@AffineWriteAlias>
+      %first_i = struct.readm %self[@cell] {()[%i]}
+          : !struct.type<@AffineWriteAlias>, !felt.type {tableOffset = affine_map<()[s0] -> (s0)>}
+      %first_j = struct.readm %self[@cell] {()[%j]}
+          : !struct.type<@AffineWriteAlias>, !felt.type {tableOffset = affine_map<()[s0] -> (s0)>}
+      %again_i = struct.readm %self[@cell] {()[%i]}
+          : !struct.type<@AffineWriteAlias>, !felt.type {tableOffset = affine_map<()[s0] -> (s0)>}
+      struct.writem %self[@cell] = %value : !struct.type<@AffineWriteAlias>, !felt.type
+      %second = struct.readm %self[@cell] {()[%i]}
+          : !struct.type<@AffineWriteAlias>, !felt.type {tableOffset = affine_map<()[s0] -> (s0)>}
+      struct.writem %self[@before] = %first_i : !struct.type<@AffineWriteAlias>, !felt.type
+      struct.writem %self[@other] = %first_j : !struct.type<@AffineWriteAlias>, !felt.type
+      struct.writem %self[@reuse] = %again_i : !struct.type<@AffineWriteAlias>, !felt.type
+      struct.writem %self[@after] = %second : !struct.type<@AffineWriteAlias>, !felt.type
+      function.return %self : !struct.type<@AffineWriteAlias>
+    }
+
+    function.def @constrain(%self: !struct.type<@AffineWriteAlias>, %i: index, %j: index, %value: !felt.type) {
+      function.return
+    }
+  }
+}
+
+// CHECK: #map = affine_map<()[s0] -> (s0)>
+// CHECK-LABEL: struct.def @AffineWriteAlias {
+// CHECK: function.def @compute(%[[I:.*]]: index, %[[J:.*]]: index, %[[VALUE:.*]]: !felt.type) -> !struct.type<@AffineWriteAlias>
+// CHECK-NEXT: %[[SELF:.*]] = struct.new : <@AffineWriteAlias>
+// CHECK-NEXT: %[[FIRST:.*]] = struct.readm %[[SELF]][@cell] {()[%[[I]]]} : <@AffineWriteAlias>, !felt.type {tableOffset = #map}
+// CHECK-NEXT: %[[OTHER:.*]] = struct.readm %[[SELF]][@cell] {()[%[[J]]]} : <@AffineWriteAlias>, !felt.type {tableOffset = #map}
+// CHECK-NEXT: struct.writem %[[SELF]][@cell] = %[[VALUE]] : <@AffineWriteAlias>, !felt.type
+// CHECK-NEXT: %[[SECOND:.*]] = struct.readm %[[SELF]][@cell] {()[%[[I]]]} : <@AffineWriteAlias>, !felt.type {tableOffset = #map}
+// CHECK-NEXT: struct.writem %[[SELF]][@before] = %[[FIRST]] : <@AffineWriteAlias>, !felt.type
+// CHECK-NEXT: struct.writem %[[SELF]][@other] = %[[OTHER]] : <@AffineWriteAlias>, !felt.type
+// CHECK-NEXT: struct.writem %[[SELF]][@reuse] = %[[FIRST]] : <@AffineWriteAlias>, !felt.type
+// CHECK-NEXT: struct.writem %[[SELF]][@after] = %[[SECOND]] : <@AffineWriteAlias>, !felt.type
+
+// -----
+
+module attributes {llzk.lang} {
+  struct.def @DifferentAffineMaps {
+    struct.member @cell : !felt.type {column}
+
+    function.def @compute(%i: index) -> !struct.type<@DifferentAffineMaps> {
+      %self = struct.new : !struct.type<@DifferentAffineMaps>
+      function.return %self : !struct.type<@DifferentAffineMaps>
+    }
+
+    function.def @constrain(%self: !struct.type<@DifferentAffineMaps>, %i: index) {
+      %same = struct.readm %self[@cell] {()[%i]}
+          : !struct.type<@DifferentAffineMaps>, !felt.type {tableOffset = affine_map<()[s0] -> (s0)>}
+      %next = struct.readm %self[@cell] {()[%i]}
+          : !struct.type<@DifferentAffineMaps>, !felt.type {tableOffset = affine_map<()[s0] -> (s0 + 1)>}
+      constrain.eq %same, %next : !felt.type
+      function.return
+    }
+  }
+}
+
+// CHECK: #map = affine_map<()[s0] -> (s0)>
+// CHECK: #map1 = affine_map<()[s0] -> (s0 + 1)>
+// CHECK-LABEL: struct.def @DifferentAffineMaps {
+// CHECK: function.def @constrain(%[[SELF:.*]]: !struct.type<@DifferentAffineMaps>, %[[I:.*]]: index)
+// CHECK-NEXT: %[[SAME:.*]] = struct.readm %[[SELF]][@cell] {()[%[[I]]]} : <@DifferentAffineMaps>, !felt.type {tableOffset = #map}
+// CHECK-NEXT: %[[NEXT:.*]] = struct.readm %[[SELF]][@cell] {()[%[[I]]]} : <@DifferentAffineMaps>, !felt.type {tableOffset = #map1}
+// CHECK-NEXT: constrain.eq %[[SAME]], %[[NEXT]] : !felt.type
+
+// -----
+
+module attributes {llzk.lang} {
+  struct.def @AffineDimMetadata {
+    struct.member @cell : !felt.type {column}
+
+    function.def @compute(%i: index, %j: index) -> !struct.type<@AffineDimMetadata> {
+      %self = struct.new : !struct.type<@AffineDimMetadata>
+      function.return %self : !struct.type<@AffineDimMetadata>
+    }
+
+    function.def @constrain(%self: !struct.type<@AffineDimMetadata>, %i: index, %j: index) {
+      %dim_symbol = struct.readm %self[@cell] {(%i)[%j]}
+          : !struct.type<@AffineDimMetadata>, !felt.type {tableOffset = affine_map<(d0)[s0] -> (d0 + s0)>}
+      %symbols = struct.readm %self[@cell] {()[%i, %j]}
+          : !struct.type<@AffineDimMetadata>, !felt.type {tableOffset = affine_map<()[s0, s1] -> (s0 + s1)>}
+      constrain.eq %dim_symbol, %symbols : !felt.type
+      function.return
+    }
+  }
+}
+
+// CHECK: #map = affine_map<(d0)[s0] -> (d0 + s0)>
+// CHECK: #map1 = affine_map<()[s0, s1] -> (s0 + s1)>
+// CHECK-LABEL: struct.def @AffineDimMetadata {
+// CHECK: function.def @constrain(%[[SELF:.*]]: !struct.type<@AffineDimMetadata>, %[[I:.*]]: index, %[[J:.*]]: index)
+// CHECK-NEXT: %[[DIM_SYMBOL:.*]] = struct.readm %[[SELF]][@cell] {(%[[I]])[%[[J]]]} : <@AffineDimMetadata>, !felt.type {tableOffset = #map}
+// CHECK-NEXT: %[[SYMBOLS:.*]] = struct.readm %[[SELF]][@cell] {()[%[[I]], %[[J]]]} : <@AffineDimMetadata>, !felt.type {tableOffset = #map1}
+// CHECK-NEXT: constrain.eq %[[DIM_SYMBOL]], %[[SYMBOLS]] : !felt.type
+
+// -----
+
+module attributes {llzk.lang} {
+  struct.def @AffineReadBetweenWrites {
+    struct.member @cell : !felt.type {column}
+    struct.member @seen : !felt.type
+    struct.member @final : !felt.type
+
+    function.def @compute(
+        %i: index, %first: !felt.type, %second: !felt.type
+    ) -> !struct.type<@AffineReadBetweenWrites> {
+      %self = struct.new : !struct.type<@AffineReadBetweenWrites>
+      struct.writem %self[@cell] = %first
+          : !struct.type<@AffineReadBetweenWrites>, !felt.type
+      %maybe_current = struct.readm %self[@cell] {()[%i]}
+          : !struct.type<@AffineReadBetweenWrites>, !felt.type {tableOffset = affine_map<()[s0] -> (s0)>}
+      struct.writem %self[@cell] = %second
+          : !struct.type<@AffineReadBetweenWrites>, !felt.type
+      struct.writem %self[@seen] = %maybe_current
+          : !struct.type<@AffineReadBetweenWrites>, !felt.type
+      %current = struct.readm %self[@cell]
+          : !struct.type<@AffineReadBetweenWrites>, !felt.type
+      struct.writem %self[@final] = %current
+          : !struct.type<@AffineReadBetweenWrites>, !felt.type
+      function.return %self : !struct.type<@AffineReadBetweenWrites>
+    }
+
+    function.def @constrain(
+        %self: !struct.type<@AffineReadBetweenWrites>, %i: index, %first: !felt.type,
+        %second: !felt.type
+    ) {
+      function.return
+    }
+  }
+}
+
+// CHECK: #map = affine_map<()[s0] -> (s0)>
+// CHECK-LABEL: struct.def @AffineReadBetweenWrites {
+// CHECK: function.def @compute(%[[I:.*]]: index, %[[FIRST:.*]]: !felt.type, %[[SECOND:.*]]: !felt.type)
+// CHECK-NEXT: %[[SELF:.*]] = struct.new : <@AffineReadBetweenWrites>
+// CHECK-NEXT: struct.writem %[[SELF]][@cell] = %[[FIRST]] : <@AffineReadBetweenWrites>, !felt.type
+// CHECK-NEXT: %[[MAYBE:.*]] = struct.readm %[[SELF]][@cell] {()[%[[I]]]} : <@AffineReadBetweenWrites>, !felt.type {tableOffset = #map}
+// CHECK-NEXT: struct.writem %[[SELF]][@cell] = %[[SECOND]] : <@AffineReadBetweenWrites>, !felt.type
+// CHECK-NEXT: struct.writem %[[SELF]][@seen] = %[[MAYBE]] : <@AffineReadBetweenWrites>, !felt.type
+// CHECK-NEXT: struct.writem %[[SELF]][@final] = %[[SECOND]] : <@AffineReadBetweenWrites>, !felt.type
+
+// -----
+
+module attributes {llzk.lang} {
+  struct.def @AffineReadBetweenSameValueRewriteAndOverwrite {
+    struct.member @cell : !felt.type {column}
+    struct.member @seen : !felt.type
+    struct.member @final : !felt.type
+
+    function.def @compute(
+        %i: index, %first: !felt.type, %second: !felt.type
+    ) -> !struct.type<@AffineReadBetweenSameValueRewriteAndOverwrite> {
+      %self = struct.new : !struct.type<@AffineReadBetweenSameValueRewriteAndOverwrite>
+      struct.writem %self[@cell] = %first
+          : !struct.type<@AffineReadBetweenSameValueRewriteAndOverwrite>, !felt.type
+      %maybe_current = struct.readm %self[@cell] {()[%i]}
+          : !struct.type<@AffineReadBetweenSameValueRewriteAndOverwrite>, !felt.type {tableOffset = affine_map<()[s0] -> (s0)>}
+      struct.writem %self[@cell] = %first
+          : !struct.type<@AffineReadBetweenSameValueRewriteAndOverwrite>, !felt.type
+      struct.writem %self[@cell] = %second
+          : !struct.type<@AffineReadBetweenSameValueRewriteAndOverwrite>, !felt.type
+      struct.writem %self[@seen] = %maybe_current
+          : !struct.type<@AffineReadBetweenSameValueRewriteAndOverwrite>, !felt.type
+      %current = struct.readm %self[@cell]
+          : !struct.type<@AffineReadBetweenSameValueRewriteAndOverwrite>, !felt.type
+      struct.writem %self[@final] = %current
+          : !struct.type<@AffineReadBetweenSameValueRewriteAndOverwrite>, !felt.type
+      function.return %self : !struct.type<@AffineReadBetweenSameValueRewriteAndOverwrite>
+    }
+
+    function.def @constrain(
+        %self: !struct.type<@AffineReadBetweenSameValueRewriteAndOverwrite>, %i: index,
+        %first: !felt.type, %second: !felt.type
+    ) {
+      function.return
+    }
+  }
+}
+
+// CHECK: #map = affine_map<()[s0] -> (s0)>
+// CHECK-LABEL: struct.def @AffineReadBetweenSameValueRewriteAndOverwrite {
+// CHECK: function.def @compute(%[[I:.*]]: index, %[[FIRST:.*]]: !felt.type, %[[SECOND:.*]]: !felt.type)
+// CHECK-NEXT: %[[SELF:.*]] = struct.new : <@AffineReadBetweenSameValueRewriteAndOverwrite>
+// CHECK-NEXT: struct.writem %[[SELF]][@cell] = %[[FIRST]] : <@AffineReadBetweenSameValueRewriteAndOverwrite>, !felt.type
+// CHECK-NEXT: %[[MAYBE:.*]] = struct.readm %[[SELF]][@cell] {()[%[[I]]]} : <@AffineReadBetweenSameValueRewriteAndOverwrite>, !felt.type {tableOffset = #map}
+// CHECK-NEXT: struct.writem %[[SELF]][@cell] = %[[SECOND]] : <@AffineReadBetweenSameValueRewriteAndOverwrite>, !felt.type
+// CHECK-NEXT: struct.writem %[[SELF]][@seen] = %[[MAYBE]] : <@AffineReadBetweenSameValueRewriteAndOverwrite>, !felt.type
+// CHECK-NEXT: struct.writem %[[SELF]][@final] = %[[SECOND]] : <@AffineReadBetweenSameValueRewriteAndOverwrite>, !felt.type
+
+// -----
+
+module attributes {llzk.lang} {
+  poly.template @T {
+    poly.param @Offset : index
+
+    struct.def @SymbolicWriteAlias {
+      struct.member @cell : !felt.type {column}
+      struct.member @before : !felt.type
+      struct.member @after : !felt.type
+
+      function.def @compute(%value: !felt.type) -> !struct.type<@T::@SymbolicWriteAlias<[@Offset]>> {
+        %self = struct.new : !struct.type<@T::@SymbolicWriteAlias<[@Offset]>>
+        %before = struct.readm %self[@cell]
+            : !struct.type<@T::@SymbolicWriteAlias<[@Offset]>>, !felt.type {tableOffset = @Offset}
+        struct.writem %self[@cell] = %value
+            : !struct.type<@T::@SymbolicWriteAlias<[@Offset]>>, !felt.type
+        %after = struct.readm %self[@cell]
+            : !struct.type<@T::@SymbolicWriteAlias<[@Offset]>>, !felt.type {tableOffset = @Offset}
+        struct.writem %self[@before] = %before
+            : !struct.type<@T::@SymbolicWriteAlias<[@Offset]>>, !felt.type
+        struct.writem %self[@after] = %after
+            : !struct.type<@T::@SymbolicWriteAlias<[@Offset]>>, !felt.type
+        function.return %self : !struct.type<@T::@SymbolicWriteAlias<[@Offset]>>
+      }
+
+      function.def @constrain(
+          %self: !struct.type<@T::@SymbolicWriteAlias<[@Offset]>>, %value: !felt.type
+      ) {
+        function.return
+      }
+    }
+  }
+}
+
+// CHECK-LABEL: struct.def @SymbolicWriteAlias {
+// CHECK: function.def @compute(%[[VALUE:.*]]: !felt.type) -> !struct.type<@T::@SymbolicWriteAlias<[@Offset]>>
+// CHECK-NEXT: %[[SELF:.*]] = struct.new : <@T::@SymbolicWriteAlias<[@Offset]>>
+// CHECK-NEXT: %[[BEFORE:.*]] = struct.readm %[[SELF]][@cell] : <@T::@SymbolicWriteAlias<[@Offset]>>, !felt.type {tableOffset = @Offset}
+// CHECK-NEXT: struct.writem %[[SELF]][@cell] = %[[VALUE]] : <@T::@SymbolicWriteAlias<[@Offset]>>, !felt.type
+// CHECK-NEXT: %[[AFTER:.*]] = struct.readm %[[SELF]][@cell] : <@T::@SymbolicWriteAlias<[@Offset]>>, !felt.type {tableOffset = @Offset}
+// CHECK-NEXT: struct.writem %[[SELF]][@before] = %[[BEFORE]] : <@T::@SymbolicWriteAlias<[@Offset]>>, !felt.type
+// CHECK-NEXT: struct.writem %[[SELF]][@after] = %[[AFTER]] : <@T::@SymbolicWriteAlias<[@Offset]>>, !felt.type

--- a/test/Transforms/RedundantAndUnusedElim/redundant_read_write_table_offset.llzk
+++ b/test/Transforms/RedundantAndUnusedElim/redundant_read_write_table_offset.llzk
@@ -23,6 +23,8 @@ module attributes {llzk.lang} {
 // CHECK-NEXT: %[[PREV:.*]] = struct.readm %[[SELF]][@cell] : <@DifferentOffsets>, !felt.type {tableOffset = -1 : index}
 // CHECK-NEXT: %[[CURR:.*]] = struct.readm %[[SELF]][@cell] : <@DifferentOffsets>, !felt.type {tableOffset = 0 : index}
 // CHECK-NEXT: constrain.eq %[[PREV]], %[[CURR]] : !felt.type, !felt.type
+// CHECK-NEXT: function.return
+// CHECK-NEXT: }
 
 // -----
 
@@ -48,6 +50,8 @@ module attributes {llzk.lang} {
 // CHECK: function.def @constrain(%[[SELF:.*]]: !struct.type<@SameOffset>)
 // CHECK-NEXT: %[[READ:.*]] = struct.readm %[[SELF]][@cell] : <@SameOffset>, !felt.type {tableOffset = -1 : index}
 // CHECK-NEXT: constrain.eq %[[READ]], %[[READ]] : !felt.type, !felt.type
+// CHECK-NEXT: function.return
+// CHECK-NEXT: }
 
 // -----
 
@@ -73,6 +77,8 @@ module attributes {llzk.lang} {
 // CHECK: function.def @constrain(%[[SELF:.*]]: !struct.type<@DefaultOffset>)
 // CHECK-NEXT: %[[READ:.*]] = struct.readm %[[SELF]][@cell] : <@DefaultOffset>, !felt.type
 // CHECK-NEXT: constrain.eq %[[READ]], %[[READ]] : !felt.type, !felt.type
+// CHECK-NEXT: function.return
+// CHECK-NEXT: }
 
 // -----
 
@@ -109,6 +115,8 @@ module attributes {llzk.lang} {
 // CHECK-NEXT: struct.writem %[[SELF]][@first] = %[[PREV]] : <@WriteOffsets>, !felt.type
 // CHECK-NEXT: struct.writem %[[SELF]][@second] = %[[PREV]] : <@WriteOffsets>, !felt.type
 // CHECK-NEXT: struct.writem %[[SELF]][@current] = %[[VALUE]] : <@WriteOffsets>, !felt.type
+// CHECK-NEXT: function.return %[[SELF]] : !struct.type<@WriteOffsets>
+// CHECK-NEXT: }
 
 // -----
 
@@ -156,6 +164,8 @@ module attributes {llzk.lang} {
 // CHECK-NEXT: struct.writem %[[SELF]][@other] = %[[OTHER]] : <@AffineWriteAlias>, !felt.type
 // CHECK-NEXT: struct.writem %[[SELF]][@reuse] = %[[FIRST]] : <@AffineWriteAlias>, !felt.type
 // CHECK-NEXT: struct.writem %[[SELF]][@after] = %[[SECOND]] : <@AffineWriteAlias>, !felt.type
+// CHECK-NEXT: function.return %[[SELF]] : !struct.type<@AffineWriteAlias>
+// CHECK-NEXT: }
 
 // -----
 
@@ -186,6 +196,8 @@ module attributes {llzk.lang} {
 // CHECK-NEXT: %[[SAME:.*]] = struct.readm %[[SELF]][@cell] {()[%[[I]]]} : <@DifferentAffineMaps>, !felt.type {tableOffset = #map}
 // CHECK-NEXT: %[[NEXT:.*]] = struct.readm %[[SELF]][@cell] {()[%[[I]]]} : <@DifferentAffineMaps>, !felt.type {tableOffset = #map1}
 // CHECK-NEXT: constrain.eq %[[SAME]], %[[NEXT]] : !felt.type
+// CHECK-NEXT: function.return
+// CHECK-NEXT: }
 
 // -----
 
@@ -216,6 +228,8 @@ module attributes {llzk.lang} {
 // CHECK-NEXT: %[[DIM_SYMBOL:.*]] = struct.readm %[[SELF]][@cell] {(%[[I]])[%[[J]]]} : <@AffineDimMetadata>, !felt.type {tableOffset = #map}
 // CHECK-NEXT: %[[SYMBOLS:.*]] = struct.readm %[[SELF]][@cell] {()[%[[I]], %[[J]]]} : <@AffineDimMetadata>, !felt.type {tableOffset = #map1}
 // CHECK-NEXT: constrain.eq %[[DIM_SYMBOL]], %[[SYMBOLS]] : !felt.type
+// CHECK-NEXT: function.return
+// CHECK-NEXT: }
 
 // -----
 
@@ -262,6 +276,8 @@ module attributes {llzk.lang} {
 // CHECK-NEXT: struct.writem %[[SELF]][@cell] = %[[SECOND]] : <@AffineReadBetweenWrites>, !felt.type
 // CHECK-NEXT: struct.writem %[[SELF]][@seen] = %[[MAYBE]] : <@AffineReadBetweenWrites>, !felt.type
 // CHECK-NEXT: struct.writem %[[SELF]][@final] = %[[SECOND]] : <@AffineReadBetweenWrites>, !felt.type
+// CHECK-NEXT: function.return %[[SELF]] : !struct.type<@AffineReadBetweenWrites>
+// CHECK-NEXT: }
 
 // -----
 
@@ -310,6 +326,8 @@ module attributes {llzk.lang} {
 // CHECK-NEXT: struct.writem %[[SELF]][@cell] = %[[SECOND]] : <@AffineReadBetweenSameValueRewriteAndOverwrite>, !felt.type
 // CHECK-NEXT: struct.writem %[[SELF]][@seen] = %[[MAYBE]] : <@AffineReadBetweenSameValueRewriteAndOverwrite>, !felt.type
 // CHECK-NEXT: struct.writem %[[SELF]][@final] = %[[SECOND]] : <@AffineReadBetweenSameValueRewriteAndOverwrite>, !felt.type
+// CHECK-NEXT: function.return %[[SELF]] : !struct.type<@AffineReadBetweenSameValueRewriteAndOverwrite>
+// CHECK-NEXT: }
 
 // -----
 
@@ -354,3 +372,5 @@ module attributes {llzk.lang} {
 // CHECK-NEXT: %[[AFTER:.*]] = struct.readm %[[SELF]][@cell] : <@T::@SymbolicWriteAlias<[@Offset]>>, !felt.type {tableOffset = @Offset}
 // CHECK-NEXT: struct.writem %[[SELF]][@before] = %[[BEFORE]] : <@T::@SymbolicWriteAlias<[@Offset]>>, !felt.type
 // CHECK-NEXT: struct.writem %[[SELF]][@after] = %[[AFTER]] : <@T::@SymbolicWriteAlias<[@Offset]>>, !felt.type
+// CHECK-NEXT: function.return %[[SELF]] : !struct.type<@T::@SymbolicWriteAlias<[@Offset]>>
+// CHECK-NEXT: }


### PR DESCRIPTION
Fixes #569.

## Summary
`llzk-duplicate-read-write-elim` now includes struct member table offsets and affine operands in the access identity, so reads from different rows or affine operands are not conflated.

## Changes
- Include `tableOffset`, affine operand group metadata, and translated affine operands in member-access keys.
- Treat omitted `tableOffset` as the current row.
- Keep constant nonzero row reads distinct across current-row writes.
- Invalidate symbolic and affine offset reads when a current-row write may alias them.
- Add regression coverage for different, same, default, write, and affine offset cases.

## Testing
- `git diff --check`
- `git-clang-format --diff upstream/main -- include/llzk/Transforms/LLZKTransformationPasses.td lib/Transforms/LLZKRedundantReadAndWriteEliminationPass.cpp`
- GitHub Actions: Clang/GCC lit and unit tests, Nix debug/release checks, docs, changelog, format, publish-tests
- Regression covered by `test/Transforms/RedundantAndUnusedElim/redundant_read_write_table_offset.llzk`
