### PR TITLE
Add pcl.const integer value accessor

### DIFF
--- a/backends/pcl/include/pcl/Dialect/IR/Ops.td
+++ b/backends/pcl/include/pcl/Dialect/IR/Ops.td
@@ -54,6 +54,9 @@ def PCL_ConstOp : PCL_Op<"const", [Pure, InsideFunc]> {
   let arguments = (ins FeltAttr:$value);
   let results = (outs PCL_FieldType:$res);
   let assemblyFormat = "$value attr-dict";
+  let extraClassDeclaration = [{
+    auto getValueAPInt() -> ::llvm::APInt { return getValue().getValue().getValue(); }
+  }];
 }
 
 def PCL_AddOp : PCL_Op<"add", [Pure, Commutative, SameOperandsAndResultType,

--- a/backends/pcl/lib/Conversion/PCLLoweringPass.cpp
+++ b/backends/pcl/lib/Conversion/PCLLoweringPass.cpp
@@ -239,8 +239,7 @@ class ConvertEmitEqualityOp : public OpConversionPattern<EmitEqualityOp> {
 
   std::optional<llvm::APInt> getConstAPInt(Value v) const {
     if (auto c = llvm::dyn_cast_if_present<pcl::ConstOp>(v.getDefiningOp())) {
-      // Chain: ConstOp -> FeltAttr (or BoolAttr-as-int) -> IntegerAttr -> APInt
-      return c.getValue().getValue().getValue();
+      return c.getValueAPInt();
     }
     return std::nullopt;
   }

--- a/changelogs/unreleased/pcl-const-value-helper.yaml
+++ b/changelogs/unreleased/pcl-const-value-helper.yaml
@@ -1,0 +1,2 @@
+added:
+  - convenience accessor for the integer value of `pcl.const`


### PR DESCRIPTION
Closes #589.

Adds `getValueAPInt()` to `pcl.const` and uses it in PCL equality lowering.

Validation: CI