### PR TITLE
Gracefully handle a missing product alignment root

### DIFF
--- a/changelogs/unreleased/missing-root-struct-diagnostic.yaml
+++ b/changelogs/unreleased/missing-root-struct-diagnostic.yaml
@@ -1,0 +1,4 @@
+fixed:
+  - >-
+    Resolve the documented default `@Main` product-alignment root and report a diagnostic when the
+    configured root does not exist.

--- a/include/llzk/Transforms/LLZKTransformationPasses.td
+++ b/include/llzk/Transforms/LLZKTransformationPasses.td
@@ -106,7 +106,7 @@ def ComputeConstrainToProductPass
                 "struct with a single @product function";
   let description = summary;
   let options = [Option<"rootStruct", "root-struct", "std::string",
-                        /* default */ "\"@Main\"",
+                        /* default */ "\"Main\"",
                         "Root struct at which to start alignment "
                         "(default to `@Main`)">];
 }

--- a/lib/Transforms/LLZKComputeConstrainToProductPass.cpp
+++ b/lib/Transforms/LLZKComputeConstrainToProductPass.cpp
@@ -245,6 +245,12 @@ class PassImpl : public llzk::impl::ComputeConstrainToProductPassBase<PassImpl> 
       }
     });
 
+    if (!root) {
+      mod.emitError().append("could not find root struct \"", rootStruct, "\"").report();
+      signalPassFailure();
+      return;
+    }
+
     if (failed(alignStartingAt(root, tables, equivalence))) {
       signalPassFailure();
     }

--- a/test/Transforms/ComputeConstrainToProduct/default_root.llzk
+++ b/test/Transforms/ComputeConstrainToProduct/default_root.llzk
@@ -1,0 +1,40 @@
+// RUN: llzk-opt --llzk-compute-constrain-to-product %s | FileCheck --enable-var-scope %s
+
+module attributes {llzk.lang} {
+  struct.def @Main {
+    struct.member @foo : !felt.type
+    function.def @compute(%a: !felt.type) -> !struct.type<@Main> {
+      %self = struct.new : !struct.type<@Main>
+      struct.writem %self[@foo] = %a : !struct.type<@Main>, !felt.type
+      function.return %self : !struct.type<@Main>
+    }
+    function.def @constrain(%self: !struct.type<@Main>, %a: !felt.type) {
+      %foo = struct.readm %self[@foo] : !struct.type<@Main>, !felt.type
+      constrain.eq %foo, %a : !felt.type
+      function.return
+    }
+  }
+}
+
+// CHECK-LABEL: module attributes {llzk.lang} {
+// CHECK-NEXT:    struct.def @Main {
+// CHECK-NEXT:      struct.member @foo : !felt.type
+// CHECK-NEXT:      function.def @product(%[[INPUT:[0-9a-zA-Z_\.]+]]: !felt.type) -> !struct.type<@Main> attributes {function.allow_constraint, function.allow_witness, llzk.derived} {
+// CHECK-NEXT:        %[[PRODUCT_SELF:[0-9a-zA-Z_\.]+]] = struct.new : <@Main> {product_source = "compute"}
+// CHECK-NEXT:        struct.writem %[[PRODUCT_SELF]][@foo] = %[[INPUT]] : <@Main>, !felt.type {product_source = "compute"}
+// CHECK-NEXT:        %[[PRODUCT_FOO:[0-9a-zA-Z_\.]+]] = struct.readm %[[PRODUCT_SELF]][@foo] : <@Main>, !felt.type {product_source = "constrain"}
+// CHECK-NEXT:        constrain.eq %[[PRODUCT_FOO]], %[[INPUT]] : !felt.type, !felt.type {product_source = "constrain"}
+// CHECK-NEXT:        function.return %[[PRODUCT_SELF]] : !struct.type<@Main>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.def @compute(%[[COMPUTE_INPUT:[0-9a-zA-Z_\.]+]]: !felt.type) -> !struct.type<@Main> attributes {function.allow_witness, product_source = "compute"} {
+// CHECK-NEXT:        %[[COMPUTE_SELF:[0-9a-zA-Z_\.]+]] = struct.new : <@Main> {product_source = "compute"}
+// CHECK-NEXT:        struct.writem %[[COMPUTE_SELF]][@foo] = %[[COMPUTE_INPUT]] : <@Main>, !felt.type {product_source = "compute"}
+// CHECK-NEXT:        function.return {product_source = "compute"} %[[COMPUTE_SELF]] : !struct.type<@Main>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.def @constrain(%[[CONSTRAIN_SELF:[0-9a-zA-Z_\.]+]]: !struct.type<@Main>, %[[CONSTRAIN_INPUT:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, product_source = "constrain"} {
+// CHECK-NEXT:        %[[CONSTRAIN_FOO:[0-9a-zA-Z_\.]+]] = struct.readm %[[CONSTRAIN_SELF]][@foo] : <@Main>, !felt.type {product_source = "constrain"}
+// CHECK-NEXT:        constrain.eq %[[CONSTRAIN_FOO]], %[[CONSTRAIN_INPUT]] : !felt.type, !felt.type {product_source = "constrain"}
+// CHECK-NEXT:        function.return {product_source = "constrain"}
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/test/Transforms/ComputeConstrainToProduct/missing_root.llzk
+++ b/test/Transforms/ComputeConstrainToProduct/missing_root.llzk
@@ -1,0 +1,4 @@
+// RUN: llzk-opt --llzk-compute-constrain-to-product="root-struct=Missing" -verify-diagnostics %s
+
+// expected-error@+1 {{could not find root struct "Missing"}}
+module attributes {llzk.lang} {}


### PR DESCRIPTION
Closes #311.

- Resolves the documented default product-alignment root as `@Main`.
- Diagnoses a configured root struct that does not exist and covers the failure path.

Validation: CI