### PR TITLE
CAPI: ensure new ops are inserted via builders

### DIFF
--- a/changelogs/unreleased/th__capi_build_insert.yaml
+++ b/changelogs/unreleased/th__capi_build_insert.yaml
@@ -1,0 +1,2 @@
+fixed:
+  - Ensure all CAPI "build" functions perform insertion of the new op via the builder

--- a/lib/CAPI/Dialect/Array.cpp
+++ b/lib/CAPI/Dialect/Array.cpp
@@ -62,11 +62,13 @@ LLZK_DEFINE_SUFFIX_OP_BUILD_METHOD(
     Array, CreateArrayOp, WithValues, MlirType arrayType, intptr_t nValues, MlirValue const *values
 ) {
   SmallVector<Value> valueSto;
-  return wrap(
-      create<CreateArrayOp>(
-          builder, location, unwrap_cast<ArrayType>(arrayType),
-          ValueRange(unwrapList(nValues, values, valueSto))
-      )
+  return mlirOpBuilderInsert(
+      builder, wrap(
+                   create<CreateArrayOp>(
+                       builder, location, unwrap_cast<ArrayType>(arrayType),
+                       ValueRange(unwrapList(nValues, values, valueSto))
+                   )
+               )
   );
 }
 
@@ -77,10 +79,12 @@ LLZK_DEFINE_SUFFIX_OP_BUILD_METHOD(
   MapOperandsHelper<> mapOps(mapOperands.nMapOperands, mapOperands.mapOperands);
   auto numDimsPerMap =
       llzkAffineMapOperandsBuilderGetDimsPerMapAttr(mapOperands, mlirLocationGetContext(location));
-  return wrap(
-      create<CreateArrayOp>(
-          builder, location, unwrap_cast<ArrayType>(arrayType), *mapOps,
-          unwrap_cast<DenseI32ArrayAttr>(numDimsPerMap)
-      )
+  return mlirOpBuilderInsert(
+      builder, wrap(
+                   create<CreateArrayOp>(
+                       builder, location, unwrap_cast<ArrayType>(arrayType), *mapOps,
+                       unwrap_cast<DenseI32ArrayAttr>(numDimsPerMap)
+                   )
+               )
   );
 }

--- a/lib/CAPI/Dialect/Cast.cpp
+++ b/lib/CAPI/Dialect/Cast.cpp
@@ -32,5 +32,7 @@ MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(Cast, llzk__cast, CastDialect)
 LLZK_DEFINE_SUFFIX_OP_BUILD_METHOD(
     Cast, IntToFeltOp, WithType, MlirType feltType, MlirValue value
 ) {
-  return wrap(create<IntToFeltOp>(builder, location, unwrap(feltType), unwrap(value)));
+  return mlirOpBuilderInsert(
+      builder, wrap(create<IntToFeltOp>(builder, location, unwrap(feltType), unwrap(value)))
+  );
 }

--- a/lib/CAPI/Dialect/Function.cpp
+++ b/lib/CAPI/Dialect/Function.cpp
@@ -105,11 +105,13 @@ LLZK_DEFINE_OP_BUILD_METHOD(
 ) {
   SmallVector<Type> resultsSto;
   SmallVector<Value> operandsSto;
-  return wrap(
-      create<CallOp>(
-          builder, location, unwrapList(numResults, results, resultsSto), unwrapName(name),
-          unwrapList(numOperands, operands, operandsSto)
-      )
+  return mlirOpBuilderInsert(
+      builder, wrap(
+                   create<CallOp>(
+                       builder, location, unwrapList(numResults, results, resultsSto),
+                       unwrapName(name), unwrapList(numOperands, operands, operandsSto)
+                   )
+               )
   );
 }
 
@@ -118,10 +120,13 @@ LLZK_DEFINE_SUFFIX_OP_BUILD_METHOD(
     MlirValue const *operands
 ) {
   SmallVector<Value> operandsSto;
-  return wrap(
-      create<CallOp>(
-          builder, location, unwrapCallee(callee), unwrapList(numOperands, operands, operandsSto)
-      )
+  return mlirOpBuilderInsert(
+      builder, wrap(
+                   create<CallOp>(
+                       builder, location, unwrapCallee(callee),
+                       unwrapList(numOperands, operands, operandsSto)
+                   )
+               )
   );
 }
 
@@ -135,12 +140,14 @@ LLZK_DEFINE_SUFFIX_OP_BUILD_METHOD(
   MapOperandsHelper<> mapOperandsHelper(mapOperands.nMapOperands, mapOperands.mapOperands);
   auto numDimsPerMap =
       llzkAffineMapOperandsBuilderGetDimsPerMapAttr(mapOperands, mlirLocationGetContext(location));
-  return wrap(
-      create<CallOp>(
-          builder, location, unwrapList(numResults, results, resultsSto), unwrapName(name),
-          *mapOperandsHelper, unwrapDims(numDimsPerMap),
-          unwrapList(numArgOperands, argOperands, argOperandsSto)
-      )
+  return mlirOpBuilderInsert(
+      builder, wrap(
+                   create<CallOp>(
+                       builder, location, unwrapList(numResults, results, resultsSto),
+                       unwrapName(name), *mapOperandsHelper, unwrapDims(numDimsPerMap),
+                       unwrapList(numArgOperands, argOperands, argOperandsSto)
+                   )
+               )
   );
 }
 
@@ -152,10 +159,13 @@ LLZK_DEFINE_SUFFIX_OP_BUILD_METHOD(
   MapOperandsHelper<> mapOperandsHelper(mapOperands.nMapOperands, mapOperands.mapOperands);
   auto numDimsPerMap =
       llzkAffineMapOperandsBuilderGetDimsPerMapAttr(mapOperands, mlirLocationGetContext(location));
-  return wrap(
-      create<CallOp>(
-          builder, location, unwrapCallee(callee), *mapOperandsHelper, unwrapDims(numDimsPerMap),
-          unwrapList(numArgOperands, argOperands, argOperandsSto)
+  return mlirOpBuilderInsert(
+      builder,
+      wrap(
+          create<CallOp>(
+              builder, location, unwrapCallee(callee), *mapOperandsHelper,
+              unwrapDims(numDimsPerMap), unwrapList(numArgOperands, argOperands, argOperandsSto)
+          )
       )
   );
 }
@@ -168,12 +178,14 @@ LLZK_DEFINE_SUFFIX_OP_BUILD_METHOD(
   SmallVector<Type> resultsSto;
   SmallVector<Value> argOperandsSto;
   SmallVector<Attribute> templateParamsSto;
-  return wrap(
-      create<CallOp>(
-          builder, location, unwrapList(numResults, results, resultsSto), unwrapName(name),
-          unwrapList(numArgOperands, argOperands, argOperandsSto),
-          unwrapList(numTemplateParams, templateParams, templateParamsSto)
-      )
+  return mlirOpBuilderInsert(
+      builder, wrap(
+                   create<CallOp>(
+                       builder, location, unwrapList(numResults, results, resultsSto),
+                       unwrapName(name), unwrapList(numArgOperands, argOperands, argOperandsSto),
+                       unwrapList(numTemplateParams, templateParams, templateParamsSto)
+                   )
+               )
   );
 }
 
@@ -183,11 +195,13 @@ LLZK_DEFINE_SUFFIX_OP_BUILD_METHOD(
 ) {
   SmallVector<Value> argOperandsSto;
   SmallVector<Attribute> templateParamsSto;
-  return wrap(
-      create<CallOp>(
-          builder, location, unwrapCallee(callee),
-          unwrapList(numArgOperands, argOperands, argOperandsSto),
-          unwrapList(numTemplateParams, templateParams, templateParamsSto)
-      )
+  return mlirOpBuilderInsert(
+      builder, wrap(
+                   create<CallOp>(
+                       builder, location, unwrapCallee(callee),
+                       unwrapList(numArgOperands, argOperands, argOperandsSto),
+                       unwrapList(numTemplateParams, templateParams, templateParamsSto)
+                   )
+               )
   );
 }

--- a/lib/CAPI/Dialect/POD.cpp
+++ b/lib/CAPI/Dialect/POD.cpp
@@ -130,14 +130,16 @@ LLZK_DEFINE_SUFFIX_OP_BUILD_METHOD(
     Pod, NewPodOp, InferredFromInitialValues, intptr_t nValues, LlzkRecordValue const *values
 ) {
   auto recordValues = fromRawRecordValues(nValues, values);
-  return wrap(create<NewPodOp>(builder, location, recordValues));
+  return mlirOpBuilderInsert(builder, wrap(create<NewPodOp>(builder, location, recordValues)));
 }
 
 LLZK_DEFINE_OP_BUILD_METHOD(
     Pod, NewPodOp, MlirType type, intptr_t nValues, LlzkRecordValue const *values
 ) {
   auto recordValues = fromRawRecordValues(nValues, values);
-  return wrap(create<NewPodOp>(builder, location, unwrap_cast<PodType>(type), recordValues));
+  return mlirOpBuilderInsert(
+      builder, wrap(create<NewPodOp>(builder, location, unwrap_cast<PodType>(type), recordValues))
+  );
 }
 
 LLZK_DEFINE_SUFFIX_OP_BUILD_METHOD(
@@ -148,10 +150,12 @@ LLZK_DEFINE_SUFFIX_OP_BUILD_METHOD(
   MapOperandsHelper<> mapOps(mapOperands.nMapOperands, mapOperands.mapOperands);
   auto numDimsPerMap =
       llzkAffineMapOperandsBuilderGetDimsPerMapAttr(mapOperands, mlirLocationGetContext(location));
-  return wrap(
-      create<NewPodOp>(
-          builder, location, unwrap_cast<PodType>(type), *mapOps,
-          unwrap_cast<DenseI32ArrayAttr>(numDimsPerMap), recordValues
-      )
+  return mlirOpBuilderInsert(
+      builder, wrap(
+                   create<NewPodOp>(
+                       builder, location, unwrap_cast<PodType>(type), *mapOps,
+                       unwrap_cast<DenseI32ArrayAttr>(numDimsPerMap), recordValues
+                   )
+               )
   );
 }

--- a/lib/CAPI/Dialect/Poly.cpp
+++ b/lib/CAPI/Dialect/Poly.cpp
@@ -108,11 +108,13 @@ bool llzkPoly_TemplateOpHasConstExprNamed(MlirOperation op, MlirStringRef find) 
 
 LLZK_DEFINE_OP_BUILD_METHOD(Poly, ApplyMapOp, MlirAttribute map, MlirValueRange mapOperands) {
   SmallVector<Value> mapOperandsSto;
-  return wrap(
-      create<ApplyMapOp>(
-          builder, location, llvm::cast<AffineMapAttr>(unwrap(map)),
-          ValueRange(unwrapList(mapOperands.size, mapOperands.values, mapOperandsSto))
-      )
+  return mlirOpBuilderInsert(
+      builder, wrap(
+                   create<ApplyMapOp>(
+                       builder, location, llvm::cast<AffineMapAttr>(unwrap(map)),
+                       ValueRange(unwrapList(mapOperands.size, mapOperands.values, mapOperandsSto))
+                   )
+               )
   );
 }
 
@@ -120,11 +122,13 @@ LLZK_DEFINE_SUFFIX_OP_BUILD_METHOD(
     Poly, ApplyMapOp, WithAffineMap, MlirAffineMap map, MlirValueRange mapOperands
 ) {
   SmallVector<Value> mapOperandsSto;
-  return wrap(
-      create<ApplyMapOp>(
-          builder, location, unwrap(map),
-          ValueRange(unwrapList(mapOperands.size, mapOperands.values, mapOperandsSto))
-      )
+  return mlirOpBuilderInsert(
+      builder, wrap(
+                   create<ApplyMapOp>(
+                       builder, location, unwrap(map),
+                       ValueRange(unwrapList(mapOperands.size, mapOperands.values, mapOperandsSto))
+                   )
+               )
   );
 }
 
@@ -132,11 +136,13 @@ LLZK_DEFINE_SUFFIX_OP_BUILD_METHOD(
     Poly, ApplyMapOp, WithAffineExpr, MlirAffineExpr expr, MlirValueRange mapOperands
 ) {
   SmallVector<Value> mapOperandsSto;
-  return wrap(
-      create<ApplyMapOp>(
-          builder, location, unwrap(expr),
-          ValueRange(unwrapList(mapOperands.size, mapOperands.values, mapOperandsSto))
-      )
+  return mlirOpBuilderInsert(
+      builder, wrap(
+                   create<ApplyMapOp>(
+                       builder, location, unwrap(expr),
+                       ValueRange(unwrapList(mapOperands.size, mapOperands.values, mapOperandsSto))
+                   )
+               )
   );
 }
 

--- a/lib/CAPI/Dialect/Struct.cpp
+++ b/lib/CAPI/Dialect/Struct.cpp
@@ -186,10 +186,12 @@ void llzkStruct_MemberDefOpSetSignalValue(MlirOperation op, bool newValue) {
 LLZK_DEFINE_OP_BUILD_METHOD(
     Struct, MemberReadOp, MlirType memberType, MlirValue component, MlirIdentifier memberName
 ) {
-  return wrap(
-      create<MemberReadOp>(
-          builder, location, unwrap(memberType), unwrap(component), unwrap(memberName)
-      )
+  return mlirOpBuilderInsert(
+      builder, wrap(
+                   create<MemberReadOp>(
+                       builder, location, unwrap(memberType), unwrap(component), unwrap(memberName)
+                   )
+               )
   );
 }
 
@@ -199,12 +201,14 @@ LLZK_DEFINE_SUFFIX_OP_BUILD_METHOD(
 ) {
   SmallVector<Value> mapOperandsSto;
   auto mapAttr = AffineMapAttr::get(unwrap(map));
-  return wrap(
-      create<MemberReadOp>(
-          builder, location, unwrap(memberType), unwrap(component), unwrap(memberName), mapAttr,
-          unwrapList(mapOperands.size, mapOperands.values, mapOperandsSto),
-          mapAttr.getAffineMap().getNumDims()
-      )
+  return mlirOpBuilderInsert(
+      builder, wrap(
+                   create<MemberReadOp>(
+                       builder, location, unwrap(memberType), unwrap(component), unwrap(memberName),
+                       mapAttr, unwrapList(mapOperands.size, mapOperands.values, mapOperandsSto),
+                       mapAttr.getAffineMap().getNumDims()
+                   )
+               )
   );
 }
 
@@ -212,11 +216,13 @@ LLZK_DEFINE_SUFFIX_OP_BUILD_METHOD(
     Struct, MemberReadOp, WithTemplateSymbolDistance, MlirType memberType, MlirValue component,
     MlirIdentifier memberName, MlirStringRef symbol
 ) {
-  return wrap(
-      create<MemberReadOp>(
-          builder, location, unwrap(memberType), unwrap(component), unwrap(memberName),
-          FlatSymbolRefAttr::get(unwrap(builder)->getStringAttr(unwrap(symbol)))
-      )
+  return mlirOpBuilderInsert(
+      builder, wrap(
+                   create<MemberReadOp>(
+                       builder, location, unwrap(memberType), unwrap(component), unwrap(memberName),
+                       FlatSymbolRefAttr::get(unwrap(builder)->getStringAttr(unwrap(symbol)))
+                   )
+               )
   );
 }
 
@@ -224,10 +230,12 @@ LLZK_DEFINE_SUFFIX_OP_BUILD_METHOD(
     Struct, MemberReadOp, WithLiteralDistance, MlirType memberType, MlirValue component,
     MlirIdentifier memberName, int64_t distance
 ) {
-  return wrap(
-      create<MemberReadOp>(
-          builder, location, unwrap(memberType), unwrap(component), unwrap(memberName),
-          unwrap(builder)->getIndexAttr(distance)
-      )
+  return mlirOpBuilderInsert(
+      builder, wrap(
+                   create<MemberReadOp>(
+                       builder, location, unwrap(memberType), unwrap(component), unwrap(memberName),
+                       unwrap(builder)->getIndexAttr(distance)
+                   )
+               )
   );
 }

--- a/unittests/CAPI/Dialect/Cast.cpp
+++ b/unittests/CAPI/Dialect/Cast.cpp
@@ -22,6 +22,41 @@
 #include "llzk/Dialect/Cast/IR/Enums.capi.test.cpp.inc"
 #include "llzk/Dialect/Cast/IR/Ops.capi.test.cpp.inc"
 
+namespace {
+
+void countInsertedOps(MlirOperation, MlirOpBuilderInsertPoint, void *userData) {
+  ++*static_cast<unsigned *>(userData);
+}
+
+void ignoreInsertedBlocks(MlirBlock, MlirRegion, MlirBlock, void *) {}
+
+} // namespace
+
+TEST_F(CAPITest, llzk_int_to_felt_op_build_with_type_inserts_with_builder) {
+  unsigned insertions = 0;
+  MlirOpBuilderListener listener =
+      mlirOpBuilderListenerCreate(countInsertedOps, ignoreInsertedBlocks, &insertions);
+  MlirOpBuilder builder = mlirOpBuilderCreateWithListener(context, listener);
+  MlirLocation location = mlirLocationUnknownGet(context);
+  MlirModule module = mlirModuleCreateEmpty(location);
+  MlirBlock block = mlirModuleGetBody(module);
+  MlirOperation input = createIndexOperation();
+  mlirBlockAppendOwnedOperation(block, input);
+  mlirOpBuilderSetInsertionPointToEnd(builder, block);
+
+  MlirOperation op = llzkCast_IntToFeltOpBuildWithType(
+      builder, location, wrap(cppGetFeltType(builder)), mlirOperationGetResult(input, 0)
+  );
+
+  EXPECT_NE(op.ptr, (void *)NULL);
+  EXPECT_EQ(insertions, 1u);
+  EXPECT_TRUE(mlirOperationEqual(mlirOperationGetNextInBlock(input), op));
+
+  mlirModuleDestroy(module);
+  mlirOpBuilderDestroy(builder);
+  mlirOpBuilderListenerDestroy(listener);
+}
+
 // Implementation for `IntToFeltOp_build_pass` test
 std::unique_ptr<IntToFeltOpBuildFuncHelper> IntToFeltOpBuildFuncHelper::get() {
   struct Impl : public IntToFeltOpBuildFuncHelper {


### PR DESCRIPTION
This makes manually implemented builders consistent with builders generated by the `llzk-tblgen` tool.