### PR TITLE
update CAPI builder functions that were inconsistent

### DIFF
--- a/changelogs/unreleased/th__fix_builder_api.yaml
+++ b/changelogs/unreleased/th__fix_builder_api.yaml
@@ -1,0 +1,7 @@
+changed:
+  - CAPI:
+    - llzkFunction_FuncDefOpCreateWithAttrsAndArgAttrs -> llzkFunction_FuncDefOpBuildWithAttrsAndArgAttrs
+    - llzkFunction_FuncDefOpCreateWithAttrs -> llzkFunction_FuncDefOpBuildWithAttrs
+    - llzkFunction_FuncDefOpCreateWithArgAttrs -> llzkFunction_FuncDefOpBuildWithArgAttrs
+    - llzkFunction_FuncDefOpCreateWithoutAttrs -> llzkFunction_FuncDefOpBuildWithoutAttrs
+    - llzkInclude_IncludeOpCreateInferredContext -> llzkInclude_IncludeOpBuildInferredContext

--- a/include/llzk-c/Dialect/Function.h
+++ b/include/llzk-c/Dialect/Function.h
@@ -40,39 +40,30 @@ MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(Function, llzk__function);
 // FuncDefOp
 //===----------------------------------------------------------------------===//
 
-/// Creates a FuncDefOp with the given attributes and argument attributes. Each argument attribute
-/// has to be a DictionaryAttr.
-MLIR_CAPI_EXPORTED MlirOperation llzkFunction_FuncDefOpCreateWithAttrsAndArgAttrs(
-    MlirLocation loc, MlirStringRef name, MlirType type, intptr_t nAttrs,
+/// Builds a FuncDefOp with the given attributes and argument attributes. Each argument attribute
+/// must be a DictionaryAttr.
+LLZK_DECLARE_SUFFIX_OP_BUILD_METHOD(
+    Function, FuncDefOp, WithAttrsAndArgAttrs, MlirStringRef name, MlirType type, intptr_t nAttrs,
     MlirNamedAttribute const *attrs, intptr_t nArgAttrs, MlirAttribute const *argAttrs
 );
 
-/// Creates a FuncDefOp with the given attributes.
-static inline MlirOperation llzkFunction_FuncDefOpCreateWithAttrs(
-    MlirLocation loc, MlirStringRef name, MlirType type, intptr_t nAttrs,
+/// Builds a FuncDefOp with the given attributes.
+LLZK_DECLARE_SUFFIX_OP_BUILD_METHOD(
+    Function, FuncDefOp, WithAttrs, MlirStringRef name, MlirType type, intptr_t nAttrs,
     MlirNamedAttribute const *attrs
-) {
-  return llzkFunction_FuncDefOpCreateWithAttrsAndArgAttrs(
-      loc, name, type, nAttrs, attrs, /*nArgAttrs=*/0, /*argAttrs=*/NULL
-  );
-}
+);
 
-/// Creates a FuncDefOp with the given argument attributes. Each argument attribute has to be a
+/// Builds a FuncDefOp with the given argument attributes. Each argument attribute must be a
 /// DictionaryAttr.
-static inline MlirOperation llzkFunction_FuncDefOpCreateWithArgAttrs(
-    MlirLocation loc, MlirStringRef name, MlirType type, intptr_t nArgAttrs,
+LLZK_DECLARE_SUFFIX_OP_BUILD_METHOD(
+    Function, FuncDefOp, WithArgAttrs, MlirStringRef name, MlirType type, intptr_t nArgAttrs,
     MlirAttribute const *argAttrs
-) {
-  return llzkFunction_FuncDefOpCreateWithAttrsAndArgAttrs(
-      loc, name, type, /*nAttrs=*/0, /*attrs=*/NULL, nArgAttrs, argAttrs
-  );
-}
+);
 
-/// Creates a FuncDefOp.
-static inline MlirOperation
-llzkFunction_FuncDefOpCreateWithoutAttrs(MlirLocation loc, MlirStringRef name, MlirType type) {
-  return llzkFunction_FuncDefOpCreateWithAttrs(loc, name, type, /*nAttrs=*/0, /*attrs=*/NULL);
-}
+/// Builds a FuncDefOp.
+LLZK_DECLARE_SUFFIX_OP_BUILD_METHOD(
+    Function, FuncDefOp, WithoutAttrs, MlirStringRef name, MlirType type
+);
 
 /// Returns the `function.arg_name` StringAttr for the argument at the given index, or null if the
 /// argument has no `function.arg_name` attribute.

--- a/include/llzk-c/Dialect/Include.h
+++ b/include/llzk-c/Dialect/Include.h
@@ -18,6 +18,8 @@
 #ifndef LLZK_C_DIALECT_INCLUDE_H
 #define LLZK_C_DIALECT_INCLUDE_H
 
+#include "llzk-c/Support.h"
+
 #include <mlir-c/IR.h>
 #include <mlir-c/Support.h>
 
@@ -36,9 +38,9 @@ MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(Include, llzk__include);
 // IncludeOp
 //===----------------------------------------------------------------------===//
 
-/// Creates an IncludeOp pointing to another MLIR file.
-MLIR_CAPI_EXPORTED MlirOperation llzkInclude_IncludeOpCreateInferredContext(
-    MlirLocation loc, MlirStringRef name, MlirStringRef path
+/// Builds an IncludeOp pointing to another MLIR file.
+LLZK_DECLARE_SUFFIX_OP_BUILD_METHOD(
+    Include, IncludeOp, InferredContext, MlirStringRef name, MlirStringRef path
 );
 
 #ifdef __cplusplus

--- a/lib/CAPI/Dialect/Function.cpp
+++ b/lib/CAPI/Dialect/Function.cpp
@@ -43,11 +43,10 @@ MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(Function, llzk__function, FunctionDialect)
 // FuncDefOp
 //===----------------------------------------------------------------------===//
 
-/// Creates a FuncDefOp with the given attributes and argument attributes. Each argument attribute
-/// has to be a DictionaryAttr.
-MlirOperation llzkFunction_FuncDefOpCreateWithAttrsAndArgAttrs(
-    MlirLocation location, MlirStringRef name, MlirType funcType, intptr_t numAttrs,
-    MlirNamedAttribute const *attrs, intptr_t numArgAttrs, MlirAttribute const *argAttrs
+LLZK_DEFINE_SUFFIX_OP_BUILD_METHOD(
+    Function, FuncDefOp, WithAttrsAndArgAttrs, MlirStringRef name, MlirType funcType,
+    intptr_t numAttrs, MlirNamedAttribute const *attrs, intptr_t numArgAttrs,
+    MlirAttribute const *argAttrs
 ) {
   SmallVector<NamedAttribute> attrsSto;
   SmallVector<Attribute> argAttrsSto;
@@ -55,11 +54,39 @@ MlirOperation llzkFunction_FuncDefOpCreateWithAttrsAndArgAttrs(
       llvm::map_to_vector(unwrapList(numArgAttrs, argAttrs, argAttrsSto), [](auto attr) {
     return llvm::cast<DictionaryAttr>(attr);
   });
-  return wrap(
-      FuncDefOp::create(
-          unwrap(location), unwrap(name), llvm::cast<FunctionType>(unwrap(funcType)),
-          unwrapList(numAttrs, attrs, attrsSto), unwrappedArgAttrs
-      )
+  return mlirOpBuilderInsert(
+      builder, wrap(
+                   create<FuncDefOp>(
+                       builder, location, unwrap(name), llvm::cast<FunctionType>(unwrap(funcType)),
+                       unwrapList(numAttrs, attrs, attrsSto), unwrappedArgAttrs
+                   )
+               )
+  );
+}
+
+LLZK_DEFINE_SUFFIX_OP_BUILD_METHOD(
+    Function, FuncDefOp, WithAttrs, MlirStringRef name, MlirType funcType, intptr_t numAttrs,
+    MlirNamedAttribute const *attrs
+) {
+  return llzkFunction_FuncDefOpBuildWithAttrsAndArgAttrs(
+      builder, location, name, funcType, numAttrs, attrs, /*numArgAttrs=*/0, /*argAttrs=*/NULL
+  );
+}
+
+LLZK_DEFINE_SUFFIX_OP_BUILD_METHOD(
+    Function, FuncDefOp, WithArgAttrs, MlirStringRef name, MlirType funcType, intptr_t numArgAttrs,
+    MlirAttribute const *argAttrs
+) {
+  return llzkFunction_FuncDefOpBuildWithAttrsAndArgAttrs(
+      builder, location, name, funcType, /*numAttrs=*/0, /*attrs=*/NULL, numArgAttrs, argAttrs
+  );
+}
+
+LLZK_DEFINE_SUFFIX_OP_BUILD_METHOD(
+    Function, FuncDefOp, WithoutAttrs, MlirStringRef name, MlirType funcType
+) {
+  return llzkFunction_FuncDefOpBuildWithAttrs(
+      builder, location, name, funcType, /*numAttrs=*/0, /*attrs=*/NULL
   );
 }
 

--- a/lib/CAPI/Dialect/Include.cpp
+++ b/lib/CAPI/Dialect/Include.cpp
@@ -9,6 +9,7 @@
 
 #include "llzk-c/Dialect/Include.h"
 
+#include "llzk/CAPI/Builder.h"
 #include "llzk/CAPI/Support.h"
 #include "llzk/Dialect/Include/IR/Dialect.h"
 #include "llzk/Dialect/Include/IR/Ops.h"
@@ -30,8 +31,10 @@ static inline void registerLLZKIncludeTransformationPasses() { registerTransform
 
 MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(Include, llzk__include, IncludeDialect)
 
-MlirOperation llzkInclude_IncludeOpCreateInferredContext(
-    MlirLocation location, MlirStringRef name, MlirStringRef path
+LLZK_DEFINE_SUFFIX_OP_BUILD_METHOD(
+    Include, IncludeOp, InferredContext, MlirStringRef name, MlirStringRef path
 ) {
-  return wrap(IncludeOp::create(unwrap(location), unwrap(name), unwrap(path)));
+  return mlirOpBuilderInsert(
+      builder, wrap(llzk::create<IncludeOp>(builder, location, unwrap(name), unwrap(path)))
+  );
 }

--- a/unittests/CAPI/Dialect/Function.cpp
+++ b/unittests/CAPI/Dialect/Function.cpp
@@ -41,11 +41,18 @@ static MlirOperation create_func_def_op(
     llvm::ArrayRef<MlirAttribute> arg_attrs
 ) {
   auto location = mlirLocationUnknownGet(ctx);
-  return llzkFunction_FuncDefOpCreateWithAttrsAndArgAttrs(
-      location, mlirStringRefCreateFromCString(name), type,
+  MlirModule module = mlirModuleCreateEmpty(location);
+  MlirOpBuilder builder = mlirOpBuilderCreate(ctx);
+  mlirOpBuilderSetInsertionPointToStart(builder, mlirModuleGetBody(module));
+  MlirOperation op = llzkFunction_FuncDefOpBuildWithAttrsAndArgAttrs(
+      builder, location, mlirStringRefCreateFromCString(name), type,
       llzk::checkedCast<intptr_t>(attrs.size()), attrs.data(),
       llzk::checkedCast<intptr_t>(arg_attrs.size()), arg_attrs.data()
   );
+  mlirOperationRemoveFromParent(op);
+  mlirOpBuilderDestroy(builder);
+  mlirModuleDestroy(module);
+  return op;
 }
 
 static MlirOperation create_module_with_owned_op(MlirContext ctx, MlirOperation op) {
@@ -141,7 +148,7 @@ struct FuncDialectTest : public CAPITest {
   }
 };
 
-TEST_F(FuncDialectTest, llzk_func_def_op_create_with_attrs_and_arg_attrs) {
+TEST_F(FuncDialectTest, llzk_func_def_op_build_with_attrs_and_arg_attrs) {
   MlirType in_types[] = {createIndexType()};
   auto in_attrs = empty_arg_attrs<1>(context);
   auto op = create_func_def_op(

--- a/unittests/CAPI/Dialect/Include.cpp
+++ b/unittests/CAPI/Dialect/Include.cpp
@@ -15,14 +15,19 @@
 #include "llzk/Dialect/Include/IR/Dialect.capi.test.cpp.inc"
 #include "llzk/Dialect/Include/IR/Ops.capi.test.cpp.inc"
 
-TEST_F(CAPITest, llzk_include_op_create) {
+TEST_F(CAPITest, llzk_include_op_build_inferred_context) {
   auto location = mlirLocationUnknownGet(context);
-  auto op = llzkInclude_IncludeOpCreateInferredContext(
-      location, mlirStringRefCreateFromCString("test"), mlirStringRefCreateFromCString("test.mlir")
+  MlirModule module = mlirModuleCreateEmpty(location);
+  MlirOpBuilder builder = mlirOpBuilderCreate(context);
+  mlirOpBuilderSetInsertionPointToStart(builder, mlirModuleGetBody(module));
+  auto op = llzkInclude_IncludeOpBuildInferredContext(
+      builder, location, mlirStringRefCreateFromCString("test"),
+      mlirStringRefCreateFromCString("test.mlir")
   );
 
   EXPECT_NE(op.ptr, (void *)NULL);
-  mlirOperationDestroy(op);
+  mlirOpBuilderDestroy(builder);
+  mlirModuleDestroy(module);
 }
 
 // Implementation for `IncludeOp_build_pass` test


### PR DESCRIPTION
Change several manually written CAPI build functions that did not have OpBuilder parameter to follow the pattern used everywhere else.