### PR TITLE
produce an error diagnostic instead of assertion failure

### DIFF
--- a/changelogs/unreleased/th__fix_assertion_failure.yaml
+++ b/changelogs/unreleased/th__fix_assertion_failure.yaml
@@ -1,0 +1,2 @@
+fixed:
+  - Produce an error diagnostic rather than assertion faiure when a struct has no functions

--- a/lib/Dialect/Verif/IR/Ops.cpp
+++ b/lib/Dialect/Verif/IR/Ops.cpp
@@ -115,15 +115,16 @@ FailureOr<TargetTypeInfo> getTargetTypeInfo(Operation *op) {
     };
   }
   if (auto structOp = dyn_cast<StructDefOp>(op)) {
-    if (structOp.hasComputeConstrain()) {
-      auto fnOp = structOp.getConstrainFuncOp();
+    if (FuncDefOp fnOp = structOp.getConstrainFuncOp(); fnOp && structOp.getComputeFuncOp()) {
       return TargetTypeInfo {
           .funcType = fnOp.getFunctionType(),
           .argAttrs = fnOp.getArgAttrsAttr(),
       };
     } else {
       FuncDefOp productFn = structOp.getProductFuncOp();
-      assert(productFn);
+      if (!productFn) {
+        return failure();
+      }
       // Augment the product function signature to accept the self argument.
       FunctionType fnTy = productFn.getFunctionType();
       ArrayRef<Type> curInputs = fnTy.getInputs();
@@ -422,6 +423,12 @@ LogicalResult ContractOp::verifySymbolUses(SymbolTableCollection &tables) {
   }
   FailureOr<TargetTypeInfo> targetInfoRes = getTargetTypeInfo(targetOp);
   if (failed(targetInfoRes)) {
+    // The struct verifier reports malformed struct bodies; avoid cascading diagnostics here.
+    // Returning failure() would actually cause the expected diagnostic from the first failure
+    // to be suppressed, so we return success() to avoid that.
+    if (isa<StructDefOp>(targetOp)) {
+      return success();
+    }
     return emitOpError()
         .append("unsupported target type \"", targetOp->getName(), "\"")
         .attachNote(targetOp->getLoc())

--- a/test/Dialect/Verif/contracts_fail.llzk
+++ b/test/Dialect/Verif/contracts_fail.llzk
@@ -1116,3 +1116,21 @@ module attributes {llzk.lang} {
     verif.ensure_compute %1
   }
 }
+
+// -----
+
+module attributes {llzk.lang} {
+  poly.template @TBox {
+    poly.param @T : !poly.tvar<@T>
+
+    // expected-error@+1 {{'struct.def' op must define either only a non-derived "@product" function, or both non-derived "@compute" and "@constrain" functions; could not find "@product", "@compute", or "@constrain"}}
+    struct.def @Box {
+      struct.member @value : !poly.tvar<@T>
+    }
+  }
+
+  verif.contract @C for @TBox::@Box (%self: !struct.type<@TBox::@Box<[index]>>) {
+    %ok = arith.constant true
+    verif.ensure_compute %ok
+  }
+}

--- a/test/Dialect/Verif/contracts_pass.llzk
+++ b/test/Dialect/Verif/contracts_pass.llzk
@@ -16,7 +16,6 @@ module attributes {llzk.lang} {
     verif.ensure_compute %1
   }
 }
-
 // CHECK-LABEL: module attributes {llzk.lang} {
 // CHECK-NEXT:    struct.def @Top {
 // CHECK-NEXT:      function.def @compute() -> !struct.type<@Top> attributes {function.allow_witness} {
@@ -32,7 +31,6 @@ module attributes {llzk.lang} {
 // CHECK-NEXT:      verif.ensure_compute %[[VAL_3]]
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
-
 // -----
 
 module attributes {llzk.main = !struct.type<@Main>, llzk.lang} {
@@ -52,7 +50,6 @@ module attributes {llzk.main = !struct.type<@Main>, llzk.lang} {
     verif.require_constrain %ok
   }
 }
-
 // CHECK-LABEL: module attributes {llzk.lang, llzk.main = !struct.type<@Main>} {
 // CHECK-NEXT:    struct.def @Main {
 // CHECK-NEXT:      function.def @compute(%[[VAL_0:[0-9a-zA-Z_\.]+]]: !felt.type) -> !struct.type<@Main> attributes {function.allow_witness} {
@@ -69,7 +66,6 @@ module attributes {llzk.main = !struct.type<@Main>, llzk.lang} {
 // CHECK-NEXT:      verif.require_constrain %[[VAL_6]]
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
-
 // -----
 
 module attributes {llzk.lang} {
@@ -86,7 +82,6 @@ module attributes {llzk.lang} {
   verif.contract @Foo for @Top (%self: !struct.type<@Top>, %a: !felt.type) {
   }
 }
-
 // CHECK-LABEL: module attributes {llzk.lang} {
 // CHECK-NEXT:    struct.def @Top {
 // CHECK-NEXT:      function.def @compute(%[[VAL_0:[0-9a-zA-Z_\.]+]]: !felt.type) -> !struct.type<@Top> attributes {function.allow_witness} {
@@ -100,7 +95,6 @@ module attributes {llzk.lang} {
 // CHECK-NEXT:    verif.contract @Foo for @Top (%[[VAL_4:[0-9a-zA-Z_\.]+]]: !struct.type<@Top>, %[[VAL_5:[0-9a-zA-Z_\.]+]]: !felt.type) {
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
-
 // -----
 
 module attributes {llzk.lang} {
@@ -117,7 +111,6 @@ module attributes {llzk.lang} {
     }
   }
 }
-
 // CHECK-LABEL: module attributes {llzk.lang} {
 // CHECK-NEXT:    module @lib {
 // CHECK-NEXT:      function.def @token(%[[VAL_0:[0-9a-zA-Z_\.]+]]: index) {
@@ -131,7 +124,6 @@ module attributes {llzk.lang} {
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
-
 // -----
 
 module attributes {llzk.lang} {
@@ -150,7 +142,6 @@ module attributes {llzk.lang} {
     }
   }
 }
-
 // CHECK-LABEL: module attributes {llzk.lang} {
 // CHECK-NEXT:    function.def @outer(%[[VAL_0:[0-9a-zA-Z_\.]+]]: index) {
 // CHECK-NEXT:      function.return
@@ -165,7 +156,6 @@ module attributes {llzk.lang} {
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
-
 // -----
 
 module attributes {llzk.lang} {
@@ -193,7 +183,6 @@ module attributes {llzk.lang} {
     }
   }
 }
-
 // CHECK-LABEL: module attributes {llzk.lang} {
 // CHECK-NEXT:    poly.template @T {
 // CHECK-NEXT:      poly.param @N
@@ -216,7 +205,6 @@ module attributes {llzk.lang} {
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
-
 // -----
 
 module attributes {llzk.lang} {
@@ -235,7 +223,6 @@ module attributes {llzk.lang} {
     verif.ensure_compute %ok
   }
 }
-
 // CHECK-LABEL: module attributes {llzk.lang} {
 // CHECK-NEXT:    poly.template @T {
 // CHECK-NEXT:      poly.param @N : index
@@ -250,7 +237,6 @@ module attributes {llzk.lang} {
 // CHECK-NEXT:      verif.ensure_compute %[[VAL_4]]
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
-
 // -----
 
 module attributes {llzk.lang} {
@@ -269,7 +255,6 @@ module attributes {llzk.lang} {
     verif.ensure_compute %ok
   }
 }
-
 // CHECK-LABEL: module attributes {llzk.lang} {
 // CHECK-NEXT:    poly.template @SpecTemplate {
 // CHECK-NEXT:      poly.param @N : index
@@ -284,7 +269,6 @@ module attributes {llzk.lang} {
 // CHECK-NEXT:      verif.ensure_compute %[[VAL_2]]
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
-
 // -----
 
 module attributes {llzk.lang} {
@@ -311,7 +295,6 @@ module attributes {llzk.lang} {
     verif.ensure_compute %ok
   }
 }
-
 // CHECK-LABEL: module attributes {llzk.lang} {
 // CHECK-NEXT:    poly.template @T {
 // CHECK-NEXT:      poly.param @N : index
@@ -334,7 +317,6 @@ module attributes {llzk.lang} {
 // CHECK-NEXT:      verif.ensure_compute %[[VAL_8]]
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
-
 // -----
 
 module attributes {llzk.lang} {
@@ -351,7 +333,6 @@ module attributes {llzk.lang} {
     verif.include @Base(%x, %ok) : (index, i1) -> ()
   }
 }
-
 // CHECK-LABEL: module attributes {llzk.lang} {
 // CHECK-NEXT:    function.def @check(%[[VAL_0:[0-9a-zA-Z_\.]+]]: index, %[[VAL_1:[0-9a-zA-Z_\.]+]]: i1) {
 // CHECK-NEXT:      function.return
@@ -364,7 +345,6 @@ module attributes {llzk.lang} {
 // CHECK-NEXT:      verif.include @Base(%[[VAL_4]], %[[VAL_5]]) : (index, i1) -> ()
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
-
 // -----
 
 module attributes {llzk.lang} {
@@ -385,7 +365,6 @@ module attributes {llzk.lang} {
     verif.require_compute %isEq
   }
 }
-
 // CHECK-LABEL: module attributes {llzk.lang} {
 // CHECK-NEXT:    function.def @touch_input_if(%[[VAL_0:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_1:[0-9a-zA-Z_\.]+]]: i1) -> !felt.type {
 // CHECK-NEXT:      scf.if %[[VAL_1]] {
@@ -402,7 +381,6 @@ module attributes {llzk.lang} {
 // CHECK-NEXT:      verif.require_compute %[[VAL_8]]
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
-
 // -----
 
 module attributes {llzk.lang} {
@@ -420,7 +398,6 @@ module attributes {llzk.lang} {
     verif.require_compute %isEq
   }
 }
-
 // CHECK-LABEL: module attributes {llzk.lang} {
 // CHECK-NEXT:    function.def @same(%[[VAL_0:[0-9a-zA-Z_\.]+]]: !felt.type) -> !felt.type {
 // CHECK-NEXT:      function.return %[[VAL_0]] : !felt.type
@@ -434,7 +411,6 @@ module attributes {llzk.lang} {
 // CHECK-NEXT:      verif.require_compute %[[VAL_4]]
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
-
 // -----
 
 module attributes {llzk.lang} {
@@ -457,7 +433,6 @@ module attributes {llzk.lang} {
     verif.require_compute %isEq
   }
 }
-
 // CHECK-LABEL: module attributes {llzk.lang} {
 // CHECK-NEXT:    function.def @select_input(%[[VAL_0:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_1:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_2:[0-9a-zA-Z_\.]+]]: i1) -> !felt.type {
 // CHECK-NEXT:      %[[VAL_3:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_2]] -> (!felt.type) {
@@ -476,7 +451,6 @@ module attributes {llzk.lang} {
 // CHECK-NEXT:      verif.require_compute %[[VAL_9]]
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
-
 // -----
 
 module attributes {llzk.lang} {
@@ -491,7 +465,6 @@ module attributes {llzk.lang} {
     }
   }
 }
-
 // CHECK-LABEL: module attributes {llzk.lang} {
 // CHECK-NEXT:    function.def @check(%[[VAL_0:[0-9a-zA-Z_\.]+]]: i1) {
 // CHECK-NEXT:      function.return
@@ -503,7 +476,6 @@ module attributes {llzk.lang} {
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
-
 // -----
 
 module attributes {llzk.lang} {
@@ -533,7 +505,6 @@ module attributes {llzk.lang} {
     verif.require_compute %selected
   }
 }
-
 // CHECK-LABEL: module attributes {llzk.lang} {
 // CHECK-NEXT:    struct.def @GateBox {
 // CHECK-NEXT:      struct.member @gate : i1
@@ -560,7 +531,6 @@ module attributes {llzk.lang} {
 // CHECK-NEXT:      verif.require_compute %[[VAL_8]]
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
-
 // -----
 
 module attributes {llzk.lang} {
@@ -578,7 +548,6 @@ module attributes {llzk.lang} {
     verif.ensure_compute %isEq
   }
 }
-
 // CHECK-LABEL: module attributes {llzk.lang} {
 // CHECK-NEXT:    function.def @same(%[[VAL_0:[0-9a-zA-Z_\.]+]]: !felt.type) -> !felt.type {
 // CHECK-NEXT:      function.return %[[VAL_0]] : !felt.type
@@ -592,7 +561,6 @@ module attributes {llzk.lang} {
 // CHECK-NEXT:      verif.ensure_compute %[[VAL_5]]
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
-
 // -----
 
 module attributes {llzk.lang} {
@@ -618,7 +586,6 @@ module attributes {llzk.lang} {
     verif.ensure_constrain %isEq
   }
 }
-
 // CHECK-LABEL: module attributes {llzk.lang} {
 // CHECK-NEXT:    struct.def @SecretBox {
 // CHECK-NEXT:      struct.member @secret : !felt.type
@@ -639,7 +606,6 @@ module attributes {llzk.lang} {
 // CHECK-NEXT:      verif.ensure_constrain %[[VAL_8]]
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
-
 // -----
 
 module attributes {llzk.lang} {
@@ -661,7 +627,6 @@ module attributes {llzk.lang} {
     }
   }
 }
-
 // CHECK-LABEL: module attributes {llzk.lang} {
 // CHECK-NEXT:    poly.template @SpecTemplate {
 // CHECK-NEXT:      poly.param @N : index
@@ -678,7 +643,6 @@ module attributes {llzk.lang} {
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
-
 // -----
 
 module attributes {llzk.lang} {
@@ -694,7 +658,6 @@ module attributes {llzk.lang} {
     verif.ensure_compute %ok
   }
 }
-
 // CHECK-LABEL: module attributes {llzk.lang} {
 // CHECK-NEXT:    struct.def @ProductOnly {
 // CHECK-NEXT:      function.def @product(%[[VAL_0:[0-9a-zA-Z_\.]+]]: !felt.type {function.arg_name = "foo"}) -> !struct.type<@ProductOnly> attributes {function.allow_constraint, function.allow_witness} {
@@ -707,7 +670,6 @@ module attributes {llzk.lang} {
 // CHECK-NEXT:      verif.ensure_compute %[[VAL_4]]
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
-
 // -----
 
 module attributes {llzk.lang} {
@@ -723,7 +685,6 @@ module attributes {llzk.lang} {
     verif.ensure_compute %ok
   }
 }
-
 // CHECK-LABEL: module attributes {llzk.lang} {
 // CHECK-NEXT:    struct.def @ProductOnlyEmptyArgs {
 // CHECK-NEXT:      function.def @product() -> !struct.type<@ProductOnlyEmptyArgs> attributes {function.allow_constraint, function.allow_witness} {
@@ -736,7 +697,6 @@ module attributes {llzk.lang} {
 // CHECK-NEXT:      verif.ensure_compute %[[VAL_2]]
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
-
 // -----
 
 module attributes {llzk.lang} {
@@ -750,7 +710,6 @@ module attributes {llzk.lang} {
     verif.ensure_compute %is_eq
   }
 }
-
 // CHECK-LABEL: module attributes {llzk.lang} {
 // CHECK-NEXT:    function.def @passthrough(%[[VAL_0:[0-9a-zA-Z_\.]+]]: !felt.type) -> !felt.type {
 // CHECK-NEXT:      function.return %[[VAL_0]] : !felt.type
@@ -761,7 +720,6 @@ module attributes {llzk.lang} {
 // CHECK-NEXT:      verif.ensure_compute %[[VAL_4]]
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
-
 // -----
 
 module attributes {llzk.lang} {
@@ -775,7 +733,6 @@ module attributes {llzk.lang} {
     verif.ensure_compute %is_eq
   }
 }
-
 // CHECK-LABEL: module attributes {llzk.lang} {
 // CHECK-NEXT:    function.def @passthrough(%[[VAL_0:[0-9a-zA-Z_\.]+]]: !felt.type) -> (!felt.type {function.res_name = "ret_value"}) {
 // CHECK-NEXT:      function.return %[[VAL_0]] : !felt.type
@@ -786,7 +743,6 @@ module attributes {llzk.lang} {
 // CHECK-NEXT:      verif.ensure_compute %[[VAL_4]]
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
-
 // -----
 
 module attributes {llzk.main = !struct.type<@Main>, llzk.lang} {
@@ -814,7 +770,6 @@ module attributes {llzk.main = !struct.type<@Main>, llzk.lang} {
     verif.ensure_compute %ok
   }
 }
-
 // CHECK-LABEL: module attributes {llzk.lang, llzk.main = !struct.type<@Main>} {
 // CHECK-NEXT:    function.def @helper(%[[VAL_0:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_1:[0-9a-zA-Z_\.]+]]: i1) {
 // CHECK-NEXT:      function.return
@@ -837,7 +792,6 @@ module attributes {llzk.main = !struct.type<@Main>, llzk.lang} {
 // CHECK-NEXT:      verif.ensure_compute %[[VAL_10]]
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
-
 // -----
 
 module attributes {llzk.lang} {
@@ -863,7 +817,6 @@ module attributes {llzk.lang} {
 // CHECK-NEXT:      verif.ensure_compute %[[VAL_5]]
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
-
 // -----
 
 module attributes {llzk.lang} {
@@ -884,7 +837,6 @@ module attributes {llzk.lang} {
     verif.ensure_compute %ok
   }
 }
-
 // CHECK-LABEL: module attributes {llzk.lang} {
 // CHECK-NEXT:    function.def @helper_gate(%[[VAL_0:[0-9a-zA-Z_\.]+]]: i1) {
 // CHECK-NEXT:      function.return


### PR DESCRIPTION
The new test case previously failed the `assert(productFn)`. It must produce an error diagnostic instead.