### PR TITLE
Relax `isConcrete` type restriction for replacements in `llzk-infer-tvar` pass

### DIFF
--- a/include/llzk/Util/TypeHelper.h
+++ b/include/llzk/Util/TypeHelper.h
@@ -111,6 +111,14 @@ bool isValidArrayType(mlir::Type type);
 /// - `StructType` with parameters if `allowStructParams==false`
 bool isConcreteType(mlir::Type type, bool allowStructParams = true);
 
+/// Return `false` if the type contains a `TypeVarType`.
+///
+/// This is weaker than `isConcreteType`: array dimensions may be symbols or affine maps, and
+/// parameterized struct types may use nested type attributes or direct affine-map parameters.
+/// Direct symbol references remain invalid as struct type parameters because they still require
+/// template instantiation.
+bool isTypeVarFreeType(mlir::Type type);
+
 /// Concreteness classification for an argument to a parameterized struct type.
 enum class AttrConcreteness : std::uint8_t {
   NonConcrete,

--- a/lib/Dialect/Polymorphic/Transforms/TypeVarInferencePass.cpp
+++ b/lib/Dialect/Polymorphic/Transforms/TypeVarInferencePass.cpp
@@ -1885,19 +1885,19 @@ private:
     );
   }
 
-  /// Record one concrete type inference and diagnose conflicts.
+  /// Record one type-variable-free type inference and diagnose conflicts.
   ///
   /// Inferences are tracked in two dimensions:
   ///   * by template parameter, so `@T` cannot be proven to be two different
-  ///     concrete types;
+  ///     resolved types;
   ///   * by SSA value, so a single value cannot be rewritten to incompatible
-  ///     concrete types through separate casts.
+  ///     resolved types through separate casts.
   ///
   /// Non-eligible parameters are ignored. A candidate type variable records a
-  /// parameter equality instead of a concrete replacement, so later concrete
+  /// parameter equality instead of a replacement, so later type-variable-free
   /// proofs can propagate across aggregate casts such as `array<T> -> array<U>`.
-  /// Other non-concrete candidates are ignored because this pass only removes
-  /// template type variables once a concrete replacement is known.
+  /// Other candidates are ignored because this pass only removes template type
+  /// variables once no type variables remain in the replacement type.
   LogicalResult recordInference(StringAttr paramName, Type inferredTy, Value value, Location loc) {
     if (!inferenceInfo.typeVarParams.contains(paramName)) {
       return success();
@@ -1905,7 +1905,7 @@ private:
     if (auto inferredTvar = llvm::dyn_cast<TypeVarType>(inferredTy)) {
       return recordParamRelation(paramName, inferredTvar.getNameRef().getAttr(), loc);
     }
-    if (!isConcreteType(inferredTy)) {
+    if (!isTypeVarFreeType(inferredTy)) {
       return success();
     }
 
@@ -2264,12 +2264,12 @@ static ArrayAttr expandCurrentTemplateParamsToOriginalOrder(
   return ArrayAttr::get(callParams.getContext(), expandedParams);
 }
 
-/// Build concrete type-variable replacements from an explicit call instantiation.
+/// Build type-variable-free replacements from an explicit call instantiation.
 ///
 /// A specialized function clone keeps the original enclosing `poly.template`,
 /// so non-type parameters remain available to operations such as
 /// `poly.read_const`. Type-variable parameters mentioned by the cloned function
-/// are replaced by concrete types from the call's template argument list.
+/// are replaced by resolved types from the call's template argument list.
 template <typename TargetOp>
 static DenseMap<StringAttr, Type> getConcreteCallSiteReplacements(
     ArrayAttr callParams, const TemplateInferenceInfo &info, TargetOp targetOp
@@ -2311,7 +2311,7 @@ static DenseMap<StringAttr, Type> getConcreteCallSiteReplacements(
       /*trimResolvedParams=*/false
   );
   for (const auto &entry : replacements) {
-    if (!isConcreteType(converter.convertType(entry.second))) {
+    if (!isTypeVarFreeType(converter.convertType(entry.second))) {
       return DenseMap<StringAttr, Type>();
     }
   }

--- a/lib/Util/TypeHelper.cpp
+++ b/lib/Util/TypeHelper.cpp
@@ -320,6 +320,7 @@ class AllowedTypes {
   bool no_int : 1 = false;
   bool no_struct_params : 1 = false;
   bool must_be_column : 1 = false;
+  bool type_var_free : 1 = false;
 
   ColumnCheckData columnCheck;
 
@@ -376,6 +377,12 @@ public:
     return *this;
   }
 
+  constexpr AllowedTypes &typeVarFree() {
+    no_var = true;
+    type_var_free = true;
+    return *this;
+  }
+
   constexpr AllowedTypes &onlyInt() {
     no_int = false;
     return noFelt().noString().noStruct().noArray().noPod().noVar();
@@ -406,7 +413,7 @@ public:
       if (!ArrayDimensionTypes::matches(a)) {
         ArrayDimensionTypes::reportInvalid(emitError, a, "Array dimension");
         success = false;
-      } else if (no_var && !llvm::isa_and_present<IntegerAttr>(a)) {
+      } else if (no_var && !type_var_free && !llvm::isa_and_present<IntegerAttr>(a)) {
         TypeList<IntegerAttr>::reportInvalid(emitError, a, "Concrete array dimension");
         success = false;
       } else if (failed(verifyAffineMapAttrType(emitError, a))) {
@@ -477,7 +484,12 @@ public:
           }
           success = false;
         }
-      } else if (no_var && !llvm::isa<IntegerAttr, FeltConstAttr>(p)) {
+      } else if (type_var_free && llvm::isa<SymbolRefAttr>(p)) {
+        TypeList<IntegerAttr, FeltConstAttr, TypeAttr, AffineMapAttr>::reportInvalid(
+            emitError, p, "Type-variable-free struct parameter"
+        );
+        success = false;
+      } else if (no_var && !type_var_free && !llvm::isa<IntegerAttr, FeltConstAttr>(p)) {
         TypeList<IntegerAttr>::reportInvalid(emitError, p, "Concrete struct parameter");
         success = false;
       } else if (failed(verifyAffineMapAttrType(emitError, p))) {
@@ -553,6 +565,8 @@ bool isConcreteType(Type type, bool allowStructParams) {
   return AllowedTypes().noVar().noStructParams(!allowStructParams).isValidTypeImpl(type);
 }
 
+bool isTypeVarFreeType(Type type) { return AllowedTypes().typeVarFree().isValidTypeImpl(type); }
+
 AttrConcreteness classifyAttrConcreteness(Attribute attr, bool allowStructParams) {
   if (auto tyAttr = llvm::dyn_cast<TypeAttr>(attr)) {
     return isConcreteType(tyAttr.getValue(), allowStructParams) ? AttrConcreteness::Concrete
@@ -566,12 +580,7 @@ AttrConcreteness classifyAttrConcreteness(Attribute attr, bool allowStructParams
 }
 
 bool hasAffineMapAttr(Type type) {
-  bool encountered = false;
-  type.walk([&](AffineMapAttr) {
-    encountered = true;
-    return WalkResult::interrupt();
-  });
-  return encountered;
+  return type.walk([](AffineMapAttr) { return WalkResult::interrupt(); }).wasInterrupted();
 }
 
 bool isDynamic(IntegerAttr intAttr) { return ShapedType::isDynamic(fromAPInt(intAttr.getValue())); }

--- a/test/Transforms/TypeVarInference/typevar_free_replacements.llzk
+++ b/test/Transforms/TypeVarInference/typevar_free_replacements.llzk
@@ -1,0 +1,128 @@
+// RUN: llzk-opt -split-input-file -llzk-infer-tvar -verify-diagnostics %s | FileCheck --enable-var-scope %s
+
+#map = affine_map<()[s0] -> (s0)>
+
+module attributes {llzk.lang} {
+  poly.template @InferAffineArrayDim {
+    poly.param @T : !poly.tvar<@T>
+
+    function.def @id(%arg: !poly.tvar<@T>) -> !array.type<#map x index> {
+      %cast = poly.unifiable_cast %arg : (!poly.tvar<@T>) -> !array.type<#map x index>
+      function.return %cast : !array.type<#map x index>
+    }
+  }
+}
+// CHECK-LABEL: #map = affine_map<()[s0] -> (s0)>
+// CHECK-LABEL: module attributes {llzk.lang} {
+// CHECK-NEXT:    poly.template @InferAffineArrayDim {
+// CHECK-NEXT:      function.def @id(%[[VAL_0:[0-9a-zA-Z_\.]+]]: !array.type<#map x index>) -> !array.type<#map x index> {
+// CHECK-NEXT:        function.return %[[VAL_0]] : !array.type<#map x index>
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }
+// -----
+
+module attributes {llzk.lang} {
+  poly.template @InferSymbolArrayDim {
+    poly.param @N : index
+    poly.param @T : !poly.tvar<@T>
+
+    function.def @id(%arg: !poly.tvar<@T>) -> !array.type<@N x index> {
+      %cast = poly.unifiable_cast %arg : (!poly.tvar<@T>) -> !array.type<@N x index>
+      function.return %cast : !array.type<@N x index>
+    }
+  }
+}
+// CHECK-LABEL: module attributes {llzk.lang} {
+// CHECK-NEXT:    poly.template @InferSymbolArrayDim {
+// CHECK-NEXT:      poly.param @N : index
+// CHECK-NEXT:      function.def @id(%[[VAL_0:[0-9a-zA-Z_\.]+]]: !array.type<@N x index>) -> !array.type<@N x index> {
+// CHECK-NEXT:        function.return %[[VAL_0]] : !array.type<@N x index>
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }
+// -----
+
+#map = affine_map<()[s0] -> (s0)>
+
+module attributes {llzk.lang} {
+  poly.template @AffineParamBox {
+    poly.param @M
+
+    struct.def @Box {
+      function.def @product() -> !struct.type<@AffineParamBox::@Box<[@M]>> {
+        %self = struct.new : !struct.type<@AffineParamBox::@Box<[@M]>>
+        function.return %self : !struct.type<@AffineParamBox::@Box<[@M]>>
+      }
+    }
+  }
+
+  poly.template @InferAffineStructParam {
+    poly.param @T : !poly.tvar<@T>
+
+    function.def @id(%arg: !poly.tvar<@T>) -> !struct.type<@AffineParamBox::@Box<[#map]>> {
+      %cast = poly.unifiable_cast %arg : (!poly.tvar<@T>) -> !struct.type<@AffineParamBox::@Box<[#map]>>
+      function.return %cast : !struct.type<@AffineParamBox::@Box<[#map]>>
+    }
+  }
+}
+// CHECK-LABEL: #map = affine_map<()[s0] -> (s0)>
+// CHECK-LABEL: module attributes {llzk.lang} {
+// CHECK-NEXT:    poly.template @AffineParamBox {
+// CHECK-NEXT:      poly.param @M
+// CHECK-NEXT:      struct.def @Box {
+// CHECK-NEXT:        function.def @product() -> !struct.type<@AffineParamBox::@Box<[@M]>> attributes {function.allow_constraint, function.allow_witness} {
+// CHECK-NEXT:          %[[VAL_0:[0-9a-zA-Z_\.]+]] = struct.new  : <@AffineParamBox::@Box<[@M]>>
+// CHECK-NEXT:          function.return %[[VAL_0]] : !struct.type<@AffineParamBox::@Box<[@M]>>
+// CHECK-NEXT:        }
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:    poly.template @InferAffineStructParam {
+// CHECK-NEXT:      function.def @id(%[[VAL_1:[0-9a-zA-Z_\.]+]]: !struct.type<@AffineParamBox::@Box<[#map]>>) -> !struct.type<@AffineParamBox::@Box<[#map]>> {
+// CHECK-NEXT:        function.return %[[VAL_1]] : !struct.type<@AffineParamBox::@Box<[#map]>>
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }
+// -----
+
+module attributes {llzk.lang} {
+  poly.template @SymbolParamBox {
+    poly.param @N : index
+
+    struct.def @Box {
+      function.def @product() -> !struct.type<@SymbolParamBox::@Box<[@N]>> {
+        %self = struct.new : !struct.type<@SymbolParamBox::@Box<[@N]>>
+        function.return %self : !struct.type<@SymbolParamBox::@Box<[@N]>>
+      }
+    }
+  }
+
+  poly.template @RejectSymbolStructParam {
+    poly.param @N : index
+    poly.param @T : !poly.tvar<@T>
+
+    function.def @id(%arg: !poly.tvar<@T>) -> !struct.type<@SymbolParamBox::@Box<[@N]>> {
+      %cast = poly.unifiable_cast %arg : (!poly.tvar<@T>) -> !struct.type<@SymbolParamBox::@Box<[@N]>>
+      function.return %cast : !struct.type<@SymbolParamBox::@Box<[@N]>>
+    }
+  }
+}
+// CHECK-LABEL: module attributes {llzk.lang} {
+// CHECK-NEXT:    poly.template @SymbolParamBox {
+// CHECK-NEXT:      poly.param @N : index
+// CHECK-NEXT:      struct.def @Box {
+// CHECK-NEXT:        function.def @product() -> !struct.type<@SymbolParamBox::@Box<[@N]>> attributes {function.allow_constraint, function.allow_witness} {
+// CHECK-NEXT:          %[[VAL_0:[0-9a-zA-Z_\.]+]] = struct.new  : <@SymbolParamBox::@Box<[@N]>>
+// CHECK-NEXT:          function.return %[[VAL_0]] : !struct.type<@SymbolParamBox::@Box<[@N]>>
+// CHECK-NEXT:        }
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:    poly.template @RejectSymbolStructParam {
+// CHECK-NEXT:      poly.param @N : index
+// CHECK-NEXT:      poly.param @T : !poly.tvar<@T>
+// CHECK-NEXT:      function.def @id(%[[VAL_1:[0-9a-zA-Z_\.]+]]: !poly.tvar<@T>) -> !struct.type<@SymbolParamBox::@Box<[@N]>> {
+// CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = poly.unifiable_cast %[[VAL_1]] : (!poly.tvar<@T>) -> !struct.type<@SymbolParamBox::@Box<[@N]>>
+// CHECK-NEXT:        function.return %[[VAL_2]] : !struct.type<@SymbolParamBox::@Box<[@N]>>
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }


### PR DESCRIPTION
Extracted from https://github.com/project-llzk/llzk-lib/pull/565 where I noticed the `isConcrete` check was overly restrictive for what this pass is capable of.