### PR TITLE
Reject felt template table offsets

### DIFF
--- a/changelogs/unreleased/fix__felt-template-table-offsets.yaml
+++ b/changelogs/unreleased/fix__felt-template-table-offsets.yaml
@@ -1,2 +1,2 @@
 fixed:
-  - Reject felt template values used as index-only member table offsets
+  - In `llzk-flatten` pass, reject felt template values used as index-only member table offsets

--- a/changelogs/unreleased/fix__felt-template-table-offsets.yaml
+++ b/changelogs/unreleased/fix__felt-template-table-offsets.yaml
@@ -1,0 +1,2 @@
+fixed:
+  - Reject felt template values used as index-only member table offsets

--- a/include/llzk/Dialect/Polymorphic/Transforms/TransformationPasses.td
+++ b/include/llzk/Dialect/Polymorphic/Transforms/TransformationPasses.td
@@ -61,7 +61,6 @@ def FlatteningPass : LLZKPass<"llzk-flatten"> {
     - Replace parameterized structs with flattened (i.e., no parameter)
       versions of those structs based on requested return type at calls
       to `compute()` functions and unroll loops
-    - Materialize symbolic member table offsets only from integer template values
     - Unroll loops
   }];
   // Implementation note: These options should be kept in sync with

--- a/include/llzk/Dialect/Polymorphic/Transforms/TransformationPasses.td
+++ b/include/llzk/Dialect/Polymorphic/Transforms/TransformationPasses.td
@@ -61,6 +61,7 @@ def FlatteningPass : LLZKPass<"llzk-flatten"> {
     - Replace parameterized structs with flattened (i.e., no parameter)
       versions of those structs based on requested return type at calls
       to `compute()` functions and unroll loops
+    - Materialize symbolic member table offsets only from integer template values
     - Unroll loops
   }];
   // Implementation note: These options should be kept in sync with

--- a/lib/Dialect/Polymorphic/Transforms/FlatteningPass.cpp
+++ b/lib/Dialect/Polymorphic/Transforms/FlatteningPass.cpp
@@ -616,6 +616,14 @@ class StructCloner {
       return success();
     }
 
+    LogicalResult handleDefaultRewrite(
+        Attribute, MemberReadOp op, OpAdaptor, ConversionPatternRewriter &, Attribute a
+    ) const override {
+      return op->emitOpError().append(
+          "table offset requires an integer template value, but found ", a
+      );
+    }
+
     LogicalResult matchAndRewrite(
         MemberReadOp op, OpAdaptor adaptor, ConversionPatternRewriter &rewriter
     ) const override {

--- a/lib/Dialect/Polymorphic/Transforms/FlatteningPass.cpp
+++ b/lib/Dialect/Polymorphic/Transforms/FlatteningPass.cpp
@@ -592,8 +592,7 @@ class StructCloner {
 
   class ClonedStructMemberReadOpPattern
       : public SymbolUserHelper<ClonedStructMemberReadOpPattern, MemberReadOp, IntegerAttr> {
-    using super =
-        SymbolUserHelper<ClonedStructMemberReadOpPattern, MemberReadOp, IntegerAttr>;
+    using super = SymbolUserHelper<ClonedStructMemberReadOpPattern, MemberReadOp, IntegerAttr>;
 
   public:
     ClonedStructMemberReadOpPattern(

--- a/lib/Dialect/Polymorphic/Transforms/FlatteningPass.cpp
+++ b/lib/Dialect/Polymorphic/Transforms/FlatteningPass.cpp
@@ -506,6 +506,8 @@ static inline bool tableOffsetIsntSymbol(MemberReadOp op) {
   return !llvm::isa_and_present<SymbolRefAttr>(op.getTableOffset().value_or(nullptr));
 }
 
+/// Materialize symbolic member table offsets only from integer template bindings. Member tables are
+/// index-addressed, so other concrete attribute kinds must diagnose instead of being coerced.
 class ClonedMemberReadOpPattern
     : public SymbolUserHelper<ClonedMemberReadOpPattern, MemberReadOp, IntegerAttr> {
   using super = SymbolUserHelper<ClonedMemberReadOpPattern, MemberReadOp, IntegerAttr>;

--- a/lib/Dialect/Polymorphic/Transforms/FlatteningPass.cpp
+++ b/lib/Dialect/Polymorphic/Transforms/FlatteningPass.cpp
@@ -591,10 +591,9 @@ class StructCloner {
   };
 
   class ClonedStructMemberReadOpPattern
-      : public SymbolUserHelper<
-            ClonedStructMemberReadOpPattern, MemberReadOp, IntegerAttr, FeltConstAttr> {
+      : public SymbolUserHelper<ClonedStructMemberReadOpPattern, MemberReadOp, IntegerAttr> {
     using super =
-        SymbolUserHelper<ClonedStructMemberReadOpPattern, MemberReadOp, IntegerAttr, FeltConstAttr>;
+        SymbolUserHelper<ClonedStructMemberReadOpPattern, MemberReadOp, IntegerAttr>;
 
   public:
     ClonedStructMemberReadOpPattern(
@@ -616,14 +615,6 @@ class StructCloner {
       });
 
       return success();
-    }
-
-    LogicalResult handleRewrite(
-        Attribute, MemberReadOp op, OpAdaptor, ConversionPatternRewriter &, FeltConstAttr a
-    ) const {
-      return op->emitOpError().append(
-          "table offset requires an integer template value, but found ", a
-      );
     }
 
     LogicalResult matchAndRewrite(

--- a/lib/Dialect/Polymorphic/Transforms/FlatteningPass.cpp
+++ b/lib/Dialect/Polymorphic/Transforms/FlatteningPass.cpp
@@ -608,15 +608,22 @@ class StructCloner {
       return op.getTableOffset().value_or(nullptr);
     }
 
-    template <typename Attr>
     LogicalResult handleRewrite(
-        Attribute, MemberReadOp op, OpAdaptor, ConversionPatternRewriter &rewriter, Attr a
+        Attribute, MemberReadOp op, OpAdaptor, ConversionPatternRewriter &rewriter, IntegerAttr a
     ) const {
       rewriter.modifyOpInPlace(op, [&]() {
         op.setTableOffsetAttr(rewriter.getIndexAttr(fromAPInt(a.getValue())));
       });
 
       return success();
+    }
+
+    LogicalResult handleRewrite(
+        Attribute, MemberReadOp op, OpAdaptor, ConversionPatternRewriter &, FeltConstAttr a
+    ) const {
+      return op->emitOpError().append(
+          "table offset requires an integer template value, but found ", a
+      );
     }
 
     LogicalResult matchAndRewrite(

--- a/lib/Dialect/Polymorphic/Transforms/FlatteningPass.cpp
+++ b/lib/Dialect/Polymorphic/Transforms/FlatteningPass.cpp
@@ -502,11 +502,57 @@ evaluateTemplateExprs(TemplateOp templateOp, DenseMap<Attribute, Attribute> &par
   );
 }
 
-namespace Step1_InstantiateStructs {
-
 static inline bool tableOffsetIsntSymbol(MemberReadOp op) {
   return !llvm::isa_and_present<SymbolRefAttr>(op.getTableOffset().value_or(nullptr));
 }
+
+class ClonedMemberReadOpPattern
+    : public SymbolUserHelper<ClonedMemberReadOpPattern, MemberReadOp, IntegerAttr> {
+  using super = SymbolUserHelper<ClonedMemberReadOpPattern, MemberReadOp, IntegerAttr>;
+
+public:
+  ClonedMemberReadOpPattern(
+      TypeConverter &converter, MLIRContext *ctx,
+      const DenseMap<Attribute, Attribute> &paramNameToInstantiatedValue
+  )
+      // benefit>0 so this applies instead of GeneralTypeReplacePattern<MemberReadOp>
+      : super(converter, ctx, /*patternBenefit=*/1, paramNameToInstantiatedValue) {}
+
+  Attribute getNameAttr(MemberReadOp op) const override {
+    return op.getTableOffset().value_or(nullptr);
+  }
+
+  LogicalResult handleRewrite(
+      Attribute, MemberReadOp op, OpAdaptor, ConversionPatternRewriter &rewriter, IntegerAttr a
+  ) const {
+    rewriter.modifyOpInPlace(op, [&]() {
+      op.setTableOffsetAttr(rewriter.getIndexAttr(fromAPInt(a.getValue())));
+    });
+
+    return success();
+  }
+
+  LogicalResult handleDefaultRewrite(
+      Attribute, MemberReadOp op, OpAdaptor, ConversionPatternRewriter &, Attribute a
+  ) const override {
+    return op->emitOpError().append(
+        "table offset requires an integer template value, but found ", a
+    );
+  }
+
+  LogicalResult matchAndRewrite(
+      MemberReadOp op, OpAdaptor adaptor, ConversionPatternRewriter &rewriter
+  ) const override {
+    LLVM_DEBUG(llvm::dbgs() << "[ClonedMemberReadOpPattern]   MemberReadOp: " << op << '\n';);
+    if (tableOffsetIsntSymbol(op)) {
+      return failure();
+    }
+
+    return super::matchAndRewrite(op, adaptor, rewriter);
+  }
+};
+
+namespace Step1_InstantiateStructs {
 
 /// Implements cloning a `StructDefOp` for a specific instantiation site, using the concrete
 /// parameters from the instantiation to replace parameters from the original `StructDefOp`.
@@ -587,54 +633,6 @@ class StructCloner {
         }
         return inputTy;
       });
-    }
-  };
-
-  class ClonedStructMemberReadOpPattern
-      : public SymbolUserHelper<ClonedStructMemberReadOpPattern, MemberReadOp, IntegerAttr> {
-    using super = SymbolUserHelper<ClonedStructMemberReadOpPattern, MemberReadOp, IntegerAttr>;
-
-  public:
-    ClonedStructMemberReadOpPattern(
-        TypeConverter &converter, MLIRContext *ctx,
-        const DenseMap<Attribute, Attribute> &paramNameToInstantiatedValue
-    )
-        // benefit>0 so this applies instead of GeneralTypeReplacePattern<MemberReadOp>
-        : super(converter, ctx, /*patternBenefit=*/1, paramNameToInstantiatedValue) {}
-
-    Attribute getNameAttr(MemberReadOp op) const override {
-      return op.getTableOffset().value_or(nullptr);
-    }
-
-    LogicalResult handleRewrite(
-        Attribute, MemberReadOp op, OpAdaptor, ConversionPatternRewriter &rewriter, IntegerAttr a
-    ) const {
-      rewriter.modifyOpInPlace(op, [&]() {
-        op.setTableOffsetAttr(rewriter.getIndexAttr(fromAPInt(a.getValue())));
-      });
-
-      return success();
-    }
-
-    LogicalResult handleDefaultRewrite(
-        Attribute, MemberReadOp op, OpAdaptor, ConversionPatternRewriter &, Attribute a
-    ) const override {
-      return op->emitOpError().append(
-          "table offset requires an integer template value, but found ", a
-      );
-    }
-
-    LogicalResult matchAndRewrite(
-        MemberReadOp op, OpAdaptor adaptor, ConversionPatternRewriter &rewriter
-    ) const override {
-      LLVM_DEBUG(
-          llvm::dbgs() << "[ClonedStructMemberReadOpPattern]   MemberReadOp: " << op << '\n';
-      );
-      if (tableOffsetIsntSymbol(op)) {
-        return failure();
-      }
-
-      return super::matchAndRewrite(op, adaptor, rewriter);
     }
   };
 
@@ -786,7 +784,7 @@ class StructCloner {
     patterns.add<ClonedBodyConstReadOpPattern>(
         tyConv, ctx, paramNameToConcrete, tracker_.delayedDiagnosticSet(newLocalType)
     );
-    patterns.add<ClonedStructMemberReadOpPattern>(tyConv, ctx, paramNameToConcrete);
+    patterns.add<ClonedMemberReadOpPattern>(tyConv, ctx, paramNameToConcrete);
     if (failed(applyFullConversion(newStruct, target, std::move(patterns)))) {
       LLVM_DEBUG(llvm::dbgs() << "[StructCloner]   instantiating body of struct failed \n");
       return failure();
@@ -1273,7 +1271,7 @@ static LogicalResult applyBodyConversions(
 ) {
   MLIRContext *ctx = op.getContext();
   FuncInstTypeConverter tyConv(paramNameToConcrete);
-  ConversionTarget target = newConverterDefinedTarget<>(tyConv, ctx);
+  ConversionTarget target = newConverterDefinedTarget<>(tyConv, ctx, tableOffsetIsntSymbol);
   target.addDynamicallyLegalOp<ConstReadOp>([&tyConv](ConstReadOp p) {
     // Legal if it's not in the map of concrete attribute instantiations
     return !tyConv.containsParam(p.getConstNameAttr());
@@ -1284,6 +1282,7 @@ static LogicalResult applyBodyConversions(
       tyConv, ctx, tyConv.getParamMap(), delayedDiagnostics
   );
   bodyPatterns.add<ClonedBodyArrayReadOpPattern, ClonedBodyArrayWriteOpPattern>(tyConv, ctx);
+  bodyPatterns.add<ClonedMemberReadOpPattern>(tyConv, ctx, paramNameToConcrete);
   if (failed(applyFullConversion(newFunc, target, std::move(bodyPatterns)))) {
     return failure();
   }

--- a/lib/Dialect/Polymorphic/Transforms/FlatteningPass.cpp
+++ b/lib/Dialect/Polymorphic/Transforms/FlatteningPass.cpp
@@ -507,7 +507,7 @@ static inline bool tableOffsetIsntSymbol(MemberReadOp op) {
 }
 
 /// Materialize symbolic member table offsets only from integer template bindings. Member tables are
-/// index-addressed, so other concrete attribute kinds must diagnose instead of being coerced.
+/// index-addressed, so other concrete attribute kinds emit diagnostics instead of being coerced.
 class ClonedMemberReadOpPattern
     : public SymbolUserHelper<ClonedMemberReadOpPattern, MemberReadOp, IntegerAttr> {
   using super = SymbolUserHelper<ClonedMemberReadOpPattern, MemberReadOp, IntegerAttr>;

--- a/test/Transforms/Flattening/instantiate_column_field_fail.llzk
+++ b/test/Transforms/Flattening/instantiate_column_field_fail.llzk
@@ -35,34 +35,20 @@ module attributes {
   llzk.lang,
   llzk.main = !struct.type<@OffsetTemplate::@Main<[#felt<const 35 : !felt.type<"bn128">>]>>
 } {
-  struct.def @Row {
-    struct.member @value : !felt.type<"bn128"> {column, llzk.pub}
-
-    function.def @compute() -> !struct.type<@Row> {
-      %self = struct.new : <@Row>
-      function.return %self : !struct.type<@Row>
-    }
-
-    function.def @constrain(%self: !struct.type<@Row>) {
-      function.return
-    }
-  }
-
   poly.template @OffsetTemplate {
     poly.param @Offset
 
     struct.def @Main {
-      function.def @compute(%row: !struct.type<@Row>) -> !struct.type<@OffsetTemplate::@Main<[@Offset]>> {
+      struct.member @value : !felt.type<"bn128"> {column, llzk.pub}
+
+      function.def @compute() -> !struct.type<@OffsetTemplate::@Main<[@Offset]>> {
         %self = struct.new : <@OffsetTemplate::@Main<[@Offset]>>
         // expected-error@+1 {{'struct.readm' op table offset requires an integer template value}}
-        %value = struct.readm %row[@value] : <@Row>, !felt.type<"bn128"> {tableOffset = @Offset}
+        %value = struct.readm %self[@value] : <@OffsetTemplate::@Main<[@Offset]>>, !felt.type<"bn128"> {tableOffset = @Offset}
         function.return %self : !struct.type<@OffsetTemplate::@Main<[@Offset]>>
       }
 
-      function.def @constrain(
-          %self: !struct.type<@OffsetTemplate::@Main<[@Offset]>>,
-          %row: !struct.type<@Row>
-      ) {
+      function.def @constrain(%self: !struct.type<@OffsetTemplate::@Main<[@Offset]>>) {
         function.return
       }
     }

--- a/test/Transforms/Flattening/instantiate_column_field_fail.llzk
+++ b/test/Transforms/Flattening/instantiate_column_field_fail.llzk
@@ -43,7 +43,8 @@ module attributes {
 
       function.def @compute() -> !struct.type<@OffsetTemplate::@Main<[@Offset]>> {
         %self = struct.new : <@OffsetTemplate::@Main<[@Offset]>>
-        // expected-error@+1 {{failed to legalize operation 'struct.readm'}}
+        // expected-error@+2 {{'struct.readm' op table offset requires an integer template value}}
+        // expected-error@+1 {{'struct.readm' op table offset requires an integer template value}}
         %value = struct.readm %self[@value] : <@OffsetTemplate::@Main<[@Offset]>>, !felt.type<"bn128"> {tableOffset = @Offset}
         function.return %self : !struct.type<@OffsetTemplate::@Main<[@Offset]>>
       }

--- a/test/Transforms/Flattening/instantiate_column_field_fail.llzk
+++ b/test/Transforms/Flattening/instantiate_column_field_fail.llzk
@@ -43,7 +43,7 @@ module attributes {
 
       function.def @compute() -> !struct.type<@OffsetTemplate::@Main<[@Offset]>> {
         %self = struct.new : <@OffsetTemplate::@Main<[@Offset]>>
-        // expected-error@+1 {{'struct.readm' op table offset requires an integer template value}}
+        // expected-error@+1 {{failed to legalize operation 'struct.readm'}}
         %value = struct.readm %self[@value] : <@OffsetTemplate::@Main<[@Offset]>>, !felt.type<"bn128"> {tableOffset = @Offset}
         function.return %self : !struct.type<@OffsetTemplate::@Main<[@Offset]>>
       }

--- a/test/Transforms/Flattening/instantiate_column_field_fail.llzk
+++ b/test/Transforms/Flattening/instantiate_column_field_fail.llzk
@@ -44,7 +44,7 @@ module attributes {
       function.def @compute() -> !struct.type<@OffsetTemplate::@Main<[@Offset]>> {
         %self = struct.new : <@OffsetTemplate::@Main<[@Offset]>>
         // expected-error@+2 {{'struct.readm' op table offset requires an integer template value}}
-        // expected-error@+1 {{'struct.readm' op table offset requires an integer template value}}
+        // expected-error@+1 {{failed to legalize operation 'struct.readm'}}
         %value = struct.readm %self[@value] : <@OffsetTemplate::@Main<[@Offset]>>, !felt.type<"bn128"> {tableOffset = @Offset}
         function.return %self : !struct.type<@OffsetTemplate::@Main<[@Offset]>>
       }

--- a/test/Transforms/Flattening/instantiate_column_field_fail.llzk
+++ b/test/Transforms/Flattening/instantiate_column_field_fail.llzk
@@ -28,3 +28,43 @@ module attributes {llzk.lang} {
     }
   }
 }
+
+// -----
+
+module attributes {
+  llzk.lang,
+  llzk.main = !struct.type<@OffsetTemplate::@Main<[#felt<const 35 : !felt.type<"bn128">>]>>
+} {
+  struct.def @Row {
+    struct.member @value : !felt.type<"bn128"> {column, llzk.pub}
+
+    function.def @compute() -> !struct.type<@Row> {
+      %self = struct.new : <@Row>
+      function.return %self : !struct.type<@Row>
+    }
+
+    function.def @constrain(%self: !struct.type<@Row>) {
+      function.return
+    }
+  }
+
+  poly.template @OffsetTemplate {
+    poly.param @Offset
+
+    struct.def @Main {
+      function.def @compute(%row: !struct.type<@Row>) -> !struct.type<@OffsetTemplate::@Main<[@Offset]>> {
+        %self = struct.new : <@OffsetTemplate::@Main<[@Offset]>>
+        // expected-error@+1 {{'struct.readm' op table offset requires an integer template value}}
+        %value = struct.readm %row[@value] : <@Row>, !felt.type<"bn128"> {tableOffset = @Offset}
+        function.return %self : !struct.type<@OffsetTemplate::@Main<[@Offset]>>
+      }
+
+      function.def @constrain(
+          %self: !struct.type<@OffsetTemplate::@Main<[@Offset]>>,
+          %row: !struct.type<@Row>
+      ) {
+        function.return
+      }
+    }
+  }
+}

--- a/test/Transforms/Flattening/instantiate_column_field_fail.llzk
+++ b/test/Transforms/Flattening/instantiate_column_field_fail.llzk
@@ -55,3 +55,37 @@ module attributes {
     }
   }
 }
+
+// -----
+
+module attributes {llzk.lang} {
+  struct.def @Data {
+    struct.member @value : !felt.type<"bn128"> {column, llzk.pub}
+
+    function.def @compute() -> !struct.type<@Data> {
+      %self = struct.new : !struct.type<@Data>
+      function.return %self : !struct.type<@Data>
+    }
+
+    function.def @constrain(%self: !struct.type<@Data>) {
+      function.return
+    }
+  }
+
+  poly.template @OffsetTemplate {
+    poly.param @Offset
+
+    function.def @read(%data: !struct.type<@Data>) -> !felt.type<"bn128"> {
+      // expected-error@+2 {{'struct.readm' op table offset requires an integer template value}}
+      // expected-error@+1 {{failed to legalize operation 'struct.readm'}}
+      %value = struct.readm %data[@value] : <@Data>, !felt.type<"bn128"> {tableOffset = @Offset}
+      function.return %value : !felt.type<"bn128">
+    }
+  }
+
+  function.def @main(%data: !struct.type<@Data>) -> !felt.type<"bn128"> {
+    // expected-error@+1 {{failure while creating instantiated function 'OffsetTemplate__read'}}
+    %value = function.call @OffsetTemplate::@read<[#felt<const 35 : !felt.type<"bn128">>]>(%data) : (!struct.type<@Data>) -> !felt.type<"bn128">
+    function.return %value : !felt.type<"bn128">
+  }
+}

--- a/test/Transforms/Flattening/instantiate_function_table_offset.llzk
+++ b/test/Transforms/Flattening/instantiate_function_table_offset.llzk
@@ -28,7 +28,23 @@ module attributes {llzk.lang} {
     function.return %value : !felt.type<"bn128">
   }
 }
-// CHECK-LABEL: function.def @OffsetTemplate_2_read(
-// CHECK:         struct.readm {{.*}} {tableOffset = 2 : index}
-// CHECK-LABEL: function.def @main(
-// CHECK:         function.call @OffsetTemplate_2_read(
+// CHECK-LABEL: module attributes {llzk.lang} {
+// CHECK-NEXT:    struct.def @Data {
+// CHECK-NEXT:      struct.member @value : !felt.type<"bn128"> {column, llzk.pub}
+// CHECK-NEXT:      function.def @compute() -> !struct.type<@Data> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[VAL_0:[0-9a-zA-Z_\.]+]] = struct.new : <@Data>
+// CHECK-NEXT:        function.return %[[VAL_0]] : !struct.type<@Data>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.def @constrain(%[[VAL_1:[0-9a-zA-Z_\.]+]]: !struct.type<@Data>) attributes {function.allow_constraint} {
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:    function.def @OffsetTemplate_2_read(%[[VAL_2:[0-9a-zA-Z_\.]+]]: !struct.type<@Data>) -> !felt.type<"bn128"> {
+// CHECK-NEXT:      %[[VAL_3:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_2]][@value] : <@Data>, !felt.type<"bn128"> {tableOffset = 2 : index}
+// CHECK-NEXT:      function.return %[[VAL_3]] : !felt.type<"bn128">
+// CHECK-NEXT:    }
+// CHECK-NEXT:    function.def @main(%[[VAL_4:[0-9a-zA-Z_\.]+]]: !struct.type<@Data>) -> !felt.type<"bn128"> {
+// CHECK-NEXT:      %[[VAL_5:[0-9a-zA-Z_\.]+]] = function.call @OffsetTemplate_2_read(%[[VAL_4]]) : (!struct.type<@Data>) -> !felt.type<"bn128">
+// CHECK-NEXT:      function.return %[[VAL_5]] : !felt.type<"bn128">
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/test/Transforms/Flattening/instantiate_function_table_offset.llzk
+++ b/test/Transforms/Flattening/instantiate_function_table_offset.llzk
@@ -1,0 +1,34 @@
+// RUN: llzk-opt -llzk-flatten %s | FileCheck %s
+
+module attributes {llzk.lang} {
+  struct.def @Data {
+    struct.member @value : !felt.type<"bn128"> {column, llzk.pub}
+
+    function.def @compute() -> !struct.type<@Data> {
+      %self = struct.new : !struct.type<@Data>
+      function.return %self : !struct.type<@Data>
+    }
+
+    function.def @constrain(%self: !struct.type<@Data>) {
+      function.return
+    }
+  }
+
+  poly.template @OffsetTemplate {
+    poly.param @Offset
+
+    function.def @read(%data: !struct.type<@Data>) -> !felt.type<"bn128"> {
+      %value = struct.readm %data[@value] : <@Data>, !felt.type<"bn128"> {tableOffset = @Offset}
+      function.return %value : !felt.type<"bn128">
+    }
+  }
+
+  function.def @main(%data: !struct.type<@Data>) -> !felt.type<"bn128"> {
+    %value = function.call @OffsetTemplate::@read<[2]>(%data) : (!struct.type<@Data>) -> !felt.type<"bn128">
+    function.return %value : !felt.type<"bn128">
+  }
+}
+// CHECK-LABEL: function.def @OffsetTemplate_2_read(
+// CHECK:         struct.readm {{.*}} {tableOffset = 2 : index}
+// CHECK-LABEL: function.def @main(
+// CHECK:         function.call @OffsetTemplate_2_read(


### PR DESCRIPTION
Addresses the table-offset review feedback from #604.

Reject felt template values when materializing symbolic `struct.readm` table offsets; integer template offsets remain unchanged. Document the index-only rule.

Covers a rejected felt-valued offset and the existing accepted integer path.

Validation:
CI
