### PR TITLE
Add pass to algebraize felt operations

### DIFF
--- a/changelogs/unreleased/krushimir__algebraize-felt-ops.yaml
+++ b/changelogs/unreleased/krushimir__algebraize-felt-ops.yaml
@@ -1,0 +1,2 @@
+added:
+  - "`llzk-algebraize-felt-ops` pass that rewrites non-native felt ops (bitwise, shifts, inv/div, uintdiv/umod) in `@constrain` bodies into felt arithmetic over `llzk.nondet` witnesses, with width-bucketed bit decompositions driven by asserted range guards"

--- a/include/llzk/Transforms/LLZKTransformationPasses.td
+++ b/include/llzk/Transforms/LLZKTransformationPasses.td
@@ -127,6 +127,40 @@ def EnforceNoMemberOverwritePass : LLZKPass<"llzk-enforce-no-overwrite"> {
   }];
 }
 
+def AlgebraizeFeltOpsPass : LLZKPass<"llzk-algebraize-felt-ops"> {
+  let summary = "Rewrite non-native felt ops in @constrain bodies into "
+                "algebraic constraints";
+  let description = [{
+    Rewrites felt operations that have no direct polynomial form —
+    `felt.bit_and`, `felt.bit_or`, `felt.bit_xor`, `felt.bit_not`,
+    `felt.shl`, `felt.shr`, `felt.inv`, `felt.div`, `felt.uintdiv`, and
+    `felt.umod` — inside constraint-bearing functions (those marked
+    `function.allow_constraint`, e.g. `@constrain` and `@product`) into
+    native felt arithmetic over `llzk.nondet` witnesses pinned by
+    `constrain.eq`.
+
+    Bitwise and shift operations are expressed through checked bit
+    decompositions (booleanity, weighted-sum equality, and a range check
+    against the prime when decomposing at full field width). A value proven
+    smaller than `2^k` — by an asserted range guard `x < c`, by constant or
+    integer-cast provenance, or by propagation through `felt.add`/`felt.mul`
+    — is decomposed with `k` bits instead of the full field width.
+    Decompositions are cached and shared between operations on the same
+    value.
+
+    `felt.inv`/`felt.div` introduce a witness `w` with `v*w == 1`
+    (unsatisfiable for `v == 0`). `felt.uintdiv`/`felt.umod` support only
+    constant power-of-two divisors, taken as slices of the dividend's
+    decomposition; a sound encoding for dynamic divisors would require a
+    multiprecision product argument.
+
+    Values are not analyzed across `function.call`s, so running after call
+    inlining gives the tightest decompositions. Run before a constraint
+    backend (e.g. `-llzk-to-pcl`), which then only sees native felt
+    arithmetic.
+  }];
+}
+
 def WhileToForPass : LLZKPass<"llzk-while-to-for"> {
   let summary =
       "Converts scf.while loops to equivalent scf.for loops when possible";

--- a/lib/Transforms/LLZKAlgebraizeFeltOpsPass.cpp
+++ b/lib/Transforms/LLZKAlgebraizeFeltOpsPass.cpp
@@ -1,0 +1,683 @@
+//===-- LLZKAlgebraizeFeltOpsPass.cpp ---------------------------*- C++ -*-===//
+//
+// Part of the LLZK Project, under the Apache License v2.0.
+// See LICENSE.txt for license information.
+// Copyright 2026 Project LLZK
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file implements the `-llzk-algebraize-felt-ops` pass.
+///
+//===----------------------------------------------------------------------===//
+
+#include "llzk/Dialect/Bool/IR/Ops.h"
+#include "llzk/Dialect/Cast/IR/Ops.h"
+#include "llzk/Dialect/Constrain/IR/Ops.h"
+#include "llzk/Dialect/Felt/IR/Attrs.h"
+#include "llzk/Dialect/Felt/IR/Ops.h"
+#include "llzk/Dialect/Function/IR/Ops.h"
+#include "llzk/Dialect/LLZK/IR/Ops.h"
+#include "llzk/Transforms/LLZKTransformationPasses.h"
+#include "llzk/Util/DynamicAPIntHelper.h"
+#include "llzk/Util/Field.h"
+
+#include <mlir/IR/BuiltinOps.h>
+#include <mlir/IR/Matchers.h>
+
+#include <llvm/ADT/APInt.h>
+#include <llvm/ADT/DenseMap.h>
+#include <llvm/ADT/STLExtras.h>
+#include <llvm/ADT/SmallVector.h>
+#include <llvm/ADT/TypeSwitch.h>
+
+#include <deque>
+#include <optional>
+#include <utility>
+
+namespace llzk {
+#define GEN_PASS_DEF_ALGEBRAIZEFELTOPSPASS
+#include "llzk/Transforms/LLZKTransformationPasses.h.inc"
+} // namespace llzk
+
+#define DEBUG_TYPE "llzk-algebraize-felt-ops"
+
+using namespace mlir;
+using namespace llzk;
+using namespace llzk::boolean;
+using namespace llzk::cast;
+using namespace llzk::constrain;
+using namespace llzk::felt;
+using namespace llzk::function;
+
+namespace {
+
+/// Rewrites the non-native felt ops of one constraint-bearing function into
+/// native felt arithmetic over `llzk.nondet` witnesses pinned by
+/// `constrain.eq`, with checked bit decompositions as the shared backbone
+/// (see the pass description in LLZKTransformationPasses.td).
+class ConstrainAlgebraizer {
+public:
+  explicit ConstrainAlgebraizer(FuncDefOp func) : fn(func), b(func) {}
+
+  LogicalResult run();
+
+private:
+  FuncDefOp fn;
+  OpBuilder b;
+
+  /// Prime modulus per felt type, at bitWidth(p) + 1 so the sign bit is
+  /// always clear.
+  llvm::DenseMap<Type, llvm::APInt> primes;
+
+  /// Pass-created constants, pooled per (type, value). They are materialized
+  /// in a prelude at the top of the entry block — anchored after
+  /// `lastPreludeOp` so emission order is preserved — which makes one
+  /// instance dominate every use, including uses in sibling regions.
+  llvm::DenseMap<std::pair<Type, llvm::APInt>, Value> constPool;
+  Operation *lastPreludeOp = nullptr;
+
+  /// Proven upper bounds (in bits) on values. Bounds must be implied by
+  /// already-asserted constraints or by op semantics, because a
+  /// decomposition at width `w` re-asserts `value < 2^w`; a wrong bound
+  /// would reject honest witnesses. Missing entry means full field width;
+  /// the tightest bound wins.
+  llvm::DenseMap<Value, unsigned> widthBound;
+
+  /// Cache of checked bit decompositions (low bit first). Rewritten ops also
+  /// record their results' bits (boolean by construction), so chains of
+  /// bitwise ops only decompose their leaves. Vectors live in `bitsStorage`
+  /// so returned refs survive later cache insertions.
+  std::deque<SmallVector<Value>> bitsStorage;
+  llvm::DenseMap<Value, SmallVector<Value> *> bitsCache;
+
+  enum class BitMix { And, Or, Xor };
+
+  const llvm::APInt &primeOf(Type type);
+  unsigned fullWidthOf(Type type) { return primeOf(type).getActiveBits(); }
+
+  void setPreludeInsertion();
+  Value feltConst(Location loc, Type type, const llvm::APInt &value);
+  Value feltConst(Location loc, Type type, uint64_t value);
+
+  /// The canonical (< p) integer value of a felt or integer constant.
+  /// `felt.const` does not enforce canonicality, so reduce mod p here; every
+  /// consumer (divisor checks, shift amounts, literal bits, guard limits)
+  /// must see the field element, not an unreduced representative.
+  std::optional<llvm::APInt> getCanonicalConst(Value v);
+
+  void setBound(Value v, unsigned bits);
+  unsigned boundOf(Value v);
+  void harvestRangeGuard(Value cmpSide, Value trueSide);
+
+  SmallVector<Value> decomposeBits(Location loc, Value v, unsigned width);
+  Value recomposeBits(Location loc, ArrayRef<Value> bits);
+  ArrayRef<Value> getBits(Location loc, Value v);
+  bool canCacheBits(Type type, size_t numBits) { return numBits < fullWidthOf(type); }
+  void cacheResultBits(Value result, SmallVector<Value> bits);
+  Value bitAt(Location loc, Type type, ArrayRef<Value> bits, unsigned i);
+  Value emitBitSlice(Location loc, Type type, ArrayRef<Value> slice);
+
+  Value emitInverse(Location loc, Value v);
+
+  FailureOr<Value> rewriteBitwiseBinary(Operation *op, BitMix mix);
+  FailureOr<Value> rewriteBitwiseNot(NotFeltOp op);
+  FailureOr<Value> rewriteShl(ShlFeltOp op);
+  FailureOr<Value> rewriteShr(ShrFeltOp op);
+  FailureOr<Value> rewriteDivModPow2(Operation *op, bool wantQuotient);
+};
+
+const llvm::APInt &ConstrainAlgebraizer::primeOf(Type type) {
+  auto [it, inserted] = primes.try_emplace(type);
+  if (inserted) {
+    FeltType feltType = llvm::cast<FeltType>(type);
+    const Field &field = feltType.getField();
+    it->second = toAPInt(field.prime(), field.bitWidth());
+  }
+  return it->second;
+}
+
+void ConstrainAlgebraizer::setPreludeInsertion() {
+  if (lastPreludeOp) {
+    b.setInsertionPointAfter(lastPreludeOp);
+  } else {
+    b.setInsertionPointToStart(&fn.getBody().front());
+  }
+}
+
+Value ConstrainAlgebraizer::feltConst(Location loc, Type type, const llvm::APInt &value) {
+  llvm::APInt norm = value.zextOrTrunc(primeOf(type).getBitWidth());
+  auto [it, inserted] = constPool.try_emplace({type, norm});
+  if (inserted) {
+    OpBuilder::InsertionGuard guard(b);
+    setPreludeInsertion();
+    auto attr = FeltConstAttr::get(b.getContext(), norm, llvm::cast<FeltType>(type));
+    it->second = b.create<FeltConstantOp>(loc, type, attr).getResult();
+    lastPreludeOp = it->second.getDefiningOp();
+  }
+  return it->second;
+}
+
+Value ConstrainAlgebraizer::feltConst(Location loc, Type type, uint64_t value) {
+  return feltConst(loc, type, llvm::APInt(primeOf(type).getBitWidth(), value));
+}
+
+std::optional<llvm::APInt> ConstrainAlgebraizer::getCanonicalConst(Value v) {
+  llvm::APInt value;
+  FeltConstAttr feltAttr;
+  if (matchPattern(v, m_Constant(&feltAttr))) {
+    value = feltAttr.getValue();
+  } else if (!matchPattern(v, m_ConstantInt(&value))) {
+    return std::nullopt;
+  }
+  auto feltType = llvm::dyn_cast<FeltType>(v.getType());
+  if (!feltType) {
+    // Integer constants (guard limits before `cast.tofelt`) are already
+    // canonical for any field wide enough to hold them.
+    return value;
+  }
+  const Field &field = feltType.getField();
+  return toAPInt(field.reduce(value), field.bitWidth());
+}
+
+void ConstrainAlgebraizer::setBound(Value v, unsigned bits) {
+  unsigned fullWidth = fullWidthOf(v.getType());
+  bits = std::max(1u, std::min(bits, fullWidth));
+  if (bits == fullWidth) {
+    return;
+  }
+  auto [it, inserted] = widthBound.try_emplace(v, bits);
+  if (!inserted && bits < it->second) {
+    it->second = bits;
+  }
+}
+
+unsigned ConstrainAlgebraizer::boundOf(Value v) {
+  if (auto it = widthBound.find(v); it != widthBound.end()) {
+    return it->second;
+  }
+  return fullWidthOf(v.getType());
+}
+
+/// Records the bound proven by an asserted range guard
+/// `constrain.eq(cast.tofelt(bool.cmp lt/le/gt/ge(x, c)), 1)` — the pattern
+/// frontends emit to pin blackbox input widths. Only guards at the top level
+/// of the body may be harvested: a guard inside a conditional region holds
+/// only on its branch.
+void ConstrainAlgebraizer::harvestRangeGuard(Value cmpSide, Value trueSide) {
+  if (auto castOp = llvm::dyn_cast_if_present<IntToFeltOp>(cmpSide.getDefiningOp())) {
+    cmpSide = castOp.getValue();
+  }
+  auto cmp = llvm::dyn_cast_if_present<CmpOp>(cmpSide.getDefiningOp());
+  if (!cmp) {
+    return;
+  }
+  auto pred = cmp.getPredicate();
+  Value bounded;
+  Value limitSide;
+  if (pred == FeltCmpPredicate::LT || pred == FeltCmpPredicate::LE) {
+    bounded = cmp.getLhs();
+    limitSide = cmp.getRhs();
+  } else if (pred == FeltCmpPredicate::GT || pred == FeltCmpPredicate::GE) {
+    bounded = cmp.getRhs();
+    limitSide = cmp.getLhs();
+  } else {
+    return;
+  }
+  auto trueConst = getCanonicalConst(trueSide);
+  if (!trueConst || !trueConst->isOne()) {
+    return;
+  }
+  auto limit = getCanonicalConst(limitSide);
+  if (!limit) {
+    return;
+  }
+  bool strict = pred == FeltCmpPredicate::LT || pred == FeltCmpPredicate::GT;
+  if (strict && limit->isZero()) {
+    return;
+  }
+  llvm::APInt maxVal = strict ? *limit - 1 : *limit;
+  setBound(bounded, maxVal.getActiveBits());
+}
+
+/// Bit-decomposes `v` into `width` fresh `llzk.nondet` bits, asserting:
+///   1. Booleanity: `b_i * (b_i - 1) == 0` for each bit.
+///   2. Weighted sum equality: `sum(b_i * 2^i) == v`.
+///   3. Range check: `sum < p`, via a bitwise comparison against `p`'s bits.
+/// The range check is only needed at full field width: for narrower widths
+/// the sum is at most `2^width - 1 < p` already. Callers must only pass a
+/// narrow `width` for values known to be `< 2^width`, since the sum equality
+/// then also asserts that bound. Returns the bits with the low bit at 0.
+SmallVector<Value> ConstrainAlgebraizer::decomposeBits(Location loc, Value v, unsigned width) {
+  Type type = v.getType();
+  const llvm::APInt &prime = primeOf(type);
+  unsigned fullWidth = prime.getActiveBits();
+  assert(width >= 1 && width <= fullWidth && "width must be in [1, bits(prime)]");
+
+  Value zero = feltConst(loc, type, 0);
+  Value one = feltConst(loc, type, 1);
+
+  SmallVector<Value> bits;
+  bits.reserve(width);
+  for (unsigned i = 0; i < width; ++i) {
+    Value bit = b.create<NonDetOp>(loc, type).getResult();
+    bits.push_back(bit);
+
+    Value bMinus1 = b.create<SubFeltOp>(loc, bit, one);
+    Value boolProd = b.create<MulFeltOp>(loc, bit, bMinus1);
+    b.create<EmitEqualityOp>(loc, boolProd, zero);
+  }
+
+  b.create<EmitEqualityOp>(loc, recomposeBits(loc, bits), v);
+
+  if (width < fullWidth) {
+    return bits;
+  }
+
+  // Range check: sum < p. Two accumulators, each in {0, 1}:
+  //   strictLess — the prefix seen so far is strictly less than p's prefix.
+  //   stillEqual — the prefix seen so far equals p's prefix.
+  // strictLess + stillEqual == 0 means the prefix already exceeded p; the
+  // final `strictLess == 1` assert catches that case.
+  Value strictLess = zero;
+  Value stillEqual = one;
+  for (int i = width - 1; i >= 0; --i) {
+    Value complement = b.create<SubFeltOp>(loc, one, bits[i]);
+    if (prime[i]) {
+      Value delta = b.create<MulFeltOp>(loc, stillEqual, complement);
+      strictLess = b.create<AddFeltOp>(loc, strictLess, delta);
+      stillEqual = b.create<MulFeltOp>(loc, stillEqual, bits[i]);
+    } else {
+      stillEqual = b.create<MulFeltOp>(loc, stillEqual, complement);
+    }
+  }
+  b.create<EmitEqualityOp>(loc, strictLess, one);
+
+  return bits;
+}
+
+/// Combinator inverse of `decomposeBits`: returns `sum(bits[i] * 2^i)`.
+/// Emits no assertions; callers are responsible for any booleanity or range
+/// constraints on the input bits. Precondition: `bits` is non-empty.
+Value ConstrainAlgebraizer::recomposeBits(Location loc, ArrayRef<Value> bits) {
+  assert(!bits.empty() && "recomposeBits requires at least one bit");
+  Type type = bits[0].getType();
+  llvm::APInt weight(primeOf(type).getBitWidth(), 1);
+
+  Value acc = bits[0];
+  weight <<= 1;
+  for (unsigned i = 1, e = bits.size(); i < e; ++i) {
+    Value term = b.create<MulFeltOp>(loc, bits[i], feltConst(loc, type, weight));
+    acc = b.create<AddFeltOp>(loc, acc, term);
+    weight <<= 1;
+  }
+  return acc;
+}
+
+ArrayRef<Value> ConstrainAlgebraizer::getBits(Location loc, Value v) {
+  auto [it, inserted] = bitsCache.try_emplace(v);
+  if (inserted) {
+    SmallVector<Value> &bits = bitsStorage.emplace_back();
+    if (auto c = getCanonicalConst(v)) {
+      // Literal 0/1 bits with no assertions.
+      for (unsigned i = 0, w = std::max(1u, c->getActiveBits()); i < w; ++i) {
+        bits.push_back(feltConst(loc, v.getType(), (*c)[i] ? 1 : 0));
+      }
+    } else {
+      // Emit the decomposition where the value is defined, not where it is
+      // first used: the cached bits may be reused from another region (e.g.
+      // a sibling scf.if branch), so they must dominate every potential use.
+      OpBuilder::InsertionGuard guard(b);
+      if (Operation *def = v.getDefiningOp()) {
+        b.setInsertionPointAfter(def);
+        bits = decomposeBits(loc, v, boundOf(v));
+      } else if (auto arg = llvm::dyn_cast<BlockArgument>(v);
+                 arg && arg.getOwner() != &fn.getBody().front()) {
+        // A nested-region block argument is only in scope inside its owner
+        // block. Function entry arguments, on the other hand, belong in the
+        // shared prelude so their decompositions can be reused everywhere.
+        b.setInsertionPointToStart(arg.getOwner());
+        bits = decomposeBits(loc, v, boundOf(v));
+      } else {
+        setPreludeInsertion();
+        bits = decomposeBits(loc, v, boundOf(v));
+        lastPreludeOp = &*std::prev(b.getInsertionPoint());
+      }
+    }
+    it->second = &bits;
+  }
+  return *it->second;
+}
+
+/// Bits may only be cached (reused as a value's decomposition) when their
+/// weighted sum is provably < p: any sum of fewer than fullWidth bits is
+/// < 2^(fullWidth-1) < p. At full width the sum of mixed bits can exceed p,
+/// in which case the bits describe a non-canonical representative.
+void ConstrainAlgebraizer::cacheResultBits(Value result, SmallVector<Value> bits) {
+  if (!canCacheBits(result.getType(), bits.size())) {
+    return;
+  }
+  setBound(result, bits.size());
+  bitsStorage.push_back(std::move(bits));
+  bitsCache[result] = &bitsStorage.back();
+}
+
+/// Reads bit `i` of a decomposition, treating bits past its width as
+/// constant zero.
+Value ConstrainAlgebraizer::bitAt(Location loc, Type type, ArrayRef<Value> bits, unsigned i) {
+  return i < bits.size() ? bits[i] : feltConst(loc, type, 0);
+}
+
+/// Recomposes a slice of a checked decomposition; an empty slice is the
+/// constant 0. The slice becomes the result's bits.
+Value ConstrainAlgebraizer::emitBitSlice(Location loc, Type type, ArrayRef<Value> slice) {
+  if (slice.empty()) {
+    return feltConst(loc, type, 0);
+  }
+  Value result = recomposeBits(loc, slice);
+  cacheResultBits(result, SmallVector<Value>(slice));
+  return result;
+}
+
+/// `v * w == 1` pins `w` to the unique inverse and is unsatisfiable for
+/// `v == 0`, matching the dialect's requirement that divisors be non-zero.
+Value ConstrainAlgebraizer::emitInverse(Location loc, Value v) {
+  Type type = v.getType();
+  Value w = b.create<NonDetOp>(loc, type).getResult();
+  Value prod = b.create<MulFeltOp>(loc, v, w);
+  b.create<EmitEqualityOp>(loc, prod, feltConst(loc, type, 1));
+  return w;
+}
+
+/// Shared scaffolding for bitwise binary felt ops. Operands may have
+/// different decomposition widths; for OR/XOR the shorter side is padded
+/// with constant zeros (sound: a width-w decomposition proves the value
+/// < 2^w), while AND truncates to the shorter width instead, since the
+/// upper bits are all `x_i * 0`.
+FailureOr<Value> ConstrainAlgebraizer::rewriteBitwiseBinary(Operation *op, BitMix mix) {
+  Location loc = op->getLoc();
+  ArrayRef<Value> lb = getBits(loc, op->getOperand(0));
+  ArrayRef<Value> rb = getBits(loc, op->getOperand(1));
+  unsigned n = mix == BitMix::And ? std::min(lb.size(), rb.size()) : std::max(lb.size(), rb.size());
+  Type type = op->getResult(0).getType();
+  SmallVector<Value> ob;
+  ob.reserve(n);
+  for (unsigned i = 0; i < n; ++i) {
+    Value av = bitAt(loc, type, lb, i);
+    Value bv = bitAt(loc, type, rb, i);
+    switch (mix) {
+    case BitMix::And:
+      // out_i = a_i * b_i
+      ob.push_back(b.create<MulFeltOp>(loc, av, bv));
+      break;
+    case BitMix::Or: {
+      // out_i = a_i + b_i - a_i * b_i
+      Value sum = b.create<AddFeltOp>(loc, av, bv);
+      Value prod = b.create<MulFeltOp>(loc, av, bv);
+      ob.push_back(b.create<SubFeltOp>(loc, sum, prod));
+      break;
+    }
+    case BitMix::Xor: {
+      // out_i = a_i + b_i - 2 * a_i * b_i
+      Value sum = b.create<AddFeltOp>(loc, av, bv);
+      Value prod = b.create<MulFeltOp>(loc, av, bv);
+      Value twoProd = b.create<AddFeltOp>(loc, prod, prod);
+      ob.push_back(b.create<SubFeltOp>(loc, sum, twoProd));
+      break;
+    }
+    }
+  }
+  Value result = recomposeBits(loc, ob);
+  cacheResultBits(result, std::move(ob));
+  return result;
+}
+
+/// NOT complements every felt bit: `out_i = 1 - a_i` at full field width
+/// (the one's-complement of the modulus-width representation).
+FailureOr<Value> ConstrainAlgebraizer::rewriteBitwiseNot(NotFeltOp op) {
+  Location loc = op.getLoc();
+  Type type = op.getType();
+  ArrayRef<Value> ab = getBits(loc, op.getOperand());
+  unsigned fullWidth = fullWidthOf(type);
+  Value one = feltConst(loc, type, 1);
+  SmallVector<Value> ob;
+  ob.reserve(fullWidth);
+  for (unsigned i = 0; i < fullWidth; ++i) {
+    ob.push_back(b.create<SubFeltOp>(loc, one, bitAt(loc, type, ab, i)));
+  }
+  return recomposeBits(loc, ob);
+}
+
+/// Lowers `felt.shl(a, s) = a * 2^s mod p`.
+///
+/// A constant `s` folds to a single multiplication by `2^s mod p`, with the
+/// result's bits reused from `a`'s when they are cached and the shifted
+/// value provably doesn't wrap.
+///
+/// Otherwise only `s` is bit-decomposed. Let c_i = 2^(2^i) mod p. Then
+///   2^s = prod_i (s_i * (c_i - 1) + 1)  (mod p),
+/// and the result is `a * 2^s`. Costs ~2 muls per bit plus one decomposition.
+FailureOr<Value> ConstrainAlgebraizer::rewriteShl(ShlFeltOp op) {
+  Location loc = op.getLoc();
+  Type type = op.getType();
+  const llvm::APInt &prime = primeOf(type);
+  unsigned fullWidth = prime.getActiveBits();
+  unsigned constBits = prime.getBitWidth();
+  Value lhs = op.getLhs();
+
+  if (auto shift = getCanonicalConst(op.getRhs())) {
+    llvm::APInt pow2s = toExactWidthAPInt(
+        modExp(llvm::DynamicAPInt(2), toDynamicAPInt(*shift), toDynamicAPInt(prime)), constBits
+    );
+    Value result = b.create<MulFeltOp>(loc, lhs, feltConst(loc, type, pow2s));
+    unsigned s = shift->getLimitedValue(fullWidth);
+    setBound(result, boundOf(lhs) + s);
+    // Reuse `a`'s cached bits shifted up by `s` when the product can't wrap
+    // mod p, so downstream bitwise ops skip a decomposition.
+    if (auto it = bitsCache.find(lhs);
+        it != bitsCache.end() && canCacheBits(type, it->second->size() + s)) {
+      SmallVector<Value> shifted(s, feltConst(loc, type, 0));
+      shifted.append(it->second->begin(), it->second->end());
+      cacheResultBits(result, std::move(shifted));
+    }
+    return result;
+  }
+
+  ArrayRef<Value> sBits = getBits(loc, op.getRhs());
+  Value one = feltConst(loc, type, 1);
+  llvm::DynamicAPInt primeDyn = toDynamicAPInt(prime);
+  llvm::DynamicAPInt curPow2(2);
+
+  Value pow2s = one;
+  for (unsigned i = 0, e = sBits.size(); i < e; ++i) {
+    llvm::APInt cMinus1 = toExactWidthAPInt(curPow2 - 1, constBits);
+    Value scaled = b.create<MulFeltOp>(loc, sBits[i], feltConst(loc, type, cMinus1));
+    Value factor = b.create<AddFeltOp>(loc, scaled, one);
+    pow2s = b.create<MulFeltOp>(loc, pow2s, factor);
+    curPow2 = (curPow2 * curPow2) % primeDyn;
+  }
+  return b.create<MulFeltOp>(loc, lhs, pow2s).getResult();
+}
+
+/// Lowers `felt.shr(a, s) = floor(a / 2^s)` on the unsigned integer
+/// representative of `a`, treating shifts of `a`'s width or more as 0.
+///
+/// A constant `s` is just a slice of `a`'s checked decomposition: bits
+/// [s..w). Otherwise the low `ceil(log2(w))` bits of `s` drive a barrel
+/// shifter over the bits of `a`; any higher bit of `s` being set forces the
+/// result to 0 via a multiplicative gate.
+FailureOr<Value> ConstrainAlgebraizer::rewriteShr(ShrFeltOp op) {
+  Location loc = op.getLoc();
+  Type type = op.getType();
+  ArrayRef<Value> aBits = getBits(loc, op.getLhs());
+
+  if (auto shift = getCanonicalConst(op.getRhs())) {
+    unsigned s = shift->getLimitedValue(aBits.size());
+    return emitBitSlice(loc, type, aBits.drop_front(s));
+  }
+
+  ArrayRef<Value> sBits = getBits(loc, op.getRhs());
+  unsigned lanes = aBits.size();
+  unsigned levels = llvm::Log2_32_Ceil(lanes);
+  Value zero = feltConst(loc, type, 0);
+
+  // Barrel shifter: at level i, conditionally shift right by 2^i controlled
+  // by sBits[i]. Positions past `a`'s decomposition width are zero.
+  SmallVector<Value> cur(aBits.begin(), aBits.end());
+  for (unsigned i = 0; i < levels && i < sBits.size(); ++i) {
+    unsigned shift = 1u << i;
+    Value ctrl = sBits[i];
+    SmallVector<Value> next(lanes);
+    for (unsigned j = 0; j < lanes; ++j) {
+      Value neighbor = (j + shift < lanes) ? cur[j + shift] : zero;
+      Value diff = b.create<SubFeltOp>(loc, neighbor, cur[j]);
+      Value scaled = b.create<MulFeltOp>(loc, ctrl, diff);
+      next[j] = b.create<AddFeltOp>(loc, cur[j], scaled);
+    }
+    cur = std::move(next);
+  }
+
+  // If any bit of `s` at index >= levels is set, the shift meets or exceeds
+  // the value's width, so gate every result bit to 0.
+  if (sBits.size() > levels) {
+    Value one = feltConst(loc, type, 1);
+    Value inRange = one;
+    for (unsigned i = levels, e = sBits.size(); i < e; ++i) {
+      Value complement = b.create<SubFeltOp>(loc, one, sBits[i]);
+      inRange = b.create<MulFeltOp>(loc, inRange, complement);
+    }
+    for (unsigned j = 0; j < lanes; ++j) {
+      cur[j] = b.create<MulFeltOp>(loc, inRange, cur[j]);
+    }
+  }
+
+  Value result = recomposeBits(loc, cur);
+  cacheResultBits(result, std::move(cur));
+  return result;
+}
+
+/// For a constant divisor c = 2^s, quotient and remainder are slices of the
+/// dividend's checked bit decomposition: bits [s..w) and [0..s). Dynamic and
+/// non-power-of-two divisors are rejected: a sound encoding of
+/// `a == q*b + r` for dynamic `b` needs a multiprecision product argument to
+/// rule out field wraparound (e.g. `b = p-1, a = 0` admits the forged
+/// `q = 1, r = 1`).
+FailureOr<Value> ConstrainAlgebraizer::rewriteDivModPow2(Operation *op, bool wantQuotient) {
+  auto divisor = getCanonicalConst(op->getOperand(1));
+  if (!divisor) {
+    return op->emitError("algebraization supports only constant divisors");
+  }
+  if (!divisor->isPowerOf2()) {
+    return op->emitError("algebraization supports only power-of-two divisors");
+  }
+  unsigned s = divisor->logBase2();
+  Location loc = op->getLoc();
+  Type type = op->getResult(0).getType();
+  ArrayRef<Value> bits = getBits(loc, op->getOperand(0));
+  // A shift of the value's full width or more leaves no quotient bits.
+  unsigned split = std::min<unsigned>(s, bits.size());
+  return emitBitSlice(loc, type, wantQuotient ? bits.drop_front(split) : bits.take_front(split));
+}
+
+LogicalResult ConstrainAlgebraizer::run() {
+  // Range guards may sit anywhere in the top-level body: constraints form
+  // one conjunction, so a guard bounds its value wherever the value is used.
+  for (Operation &op : fn.getBody().front()) {
+    if (auto eq = llvm::dyn_cast<EmitEqualityOp>(&op)) {
+      harvestRangeGuard(eq.getLhs(), eq.getRhs());
+      harvestRangeGuard(eq.getRhs(), eq.getLhs());
+    }
+  }
+
+  // One pass in program order: operands are defined before uses, so bounds
+  // are propagated before the ops consuming them are rewritten, and a
+  // rewritten op's result bound (set by cacheResultBits) feeds later ops.
+  // The snapshot keeps the loop off the ops the rewrites create.
+  SmallVector<Operation *> ops;
+  fn.walk([&](Operation *op) { ops.push_back(op); });
+
+  for (Operation *op : ops) {
+    b.setInsertionPoint(op);
+    // A null Value marks "nothing to replace".
+    FailureOr<Value> replacement =
+        llvm::TypeSwitch<Operation *, FailureOr<Value>>(op)
+            // Bound propagation for native ops.
+            .Case<FeltConstantOp>([&](FeltConstantOp c) -> FailureOr<Value> {
+      if (auto v = getCanonicalConst(c.getResult())) {
+        setBound(c.getResult(), std::max(1u, v->getActiveBits()));
+      }
+      return Value();
+    })
+            .Case<IntToFeltOp>([&](IntToFeltOp c) -> FailureOr<Value> {
+      // An N-bit integer operand bounds the felt value by 2^N.
+      if (auto intType = llvm::dyn_cast<IntegerType>(c.getValue().getType())) {
+        setBound(c.getResult(), intType.getWidth());
+      }
+      return Value();
+    })
+            .Case<AddFeltOp>([&](AddFeltOp a) -> FailureOr<Value> {
+      // No wrap while the bound stays below full width; the clamp in
+      // setBound covers the rest (any canonical felt is < 2^fullWidth).
+      setBound(a.getResult(), std::max(boundOf(a.getLhs()), boundOf(a.getRhs())) + 1);
+      return Value();
+    })
+            .Case<MulFeltOp>([&](MulFeltOp m) -> FailureOr<Value> {
+      setBound(m.getResult(), boundOf(m.getLhs()) + boundOf(m.getRhs()));
+      return Value();
+    })
+            // Rewrites for non-native ops.
+            .Case<AndFeltOp>([&](AndFeltOp o) { return rewriteBitwiseBinary(o, BitMix::And); })
+            .Case<OrFeltOp>([&](OrFeltOp o) { return rewriteBitwiseBinary(o, BitMix::Or); })
+            .Case<XorFeltOp>([&](XorFeltOp o) { return rewriteBitwiseBinary(o, BitMix::Xor); })
+            .Case<NotFeltOp>([&](NotFeltOp o) { return rewriteBitwiseNot(o); })
+            .Case<ShlFeltOp>([&](ShlFeltOp o) { return rewriteShl(o); })
+            .Case<ShrFeltOp>([&](ShrFeltOp o) { return rewriteShr(o); })
+            .Case<InvFeltOp>([&](InvFeltOp o) -> FailureOr<Value> {
+      return emitInverse(o.getLoc(), o.getOperand());
+    })
+            .Case<DivFeltOp>([&](DivFeltOp o) -> FailureOr<Value> {
+      // Not the cheaper `b * w == a` hint: that leaves `w` unconstrained
+      // when a == b == 0. Inverting `b` keeps the result determined and
+      // rejects b == 0.
+      Value invRhs = emitInverse(o.getLoc(), o.getRhs());
+      return b.create<MulFeltOp>(o.getLoc(), o.getLhs(), invRhs).getResult();
+    })
+            .Case<UnsignedIntDivFeltOp>([&](UnsignedIntDivFeltOp o) {
+      return rewriteDivModPow2(o, /*wantQuotient=*/true);
+    })
+            .Case<UnsignedModFeltOp>([&](UnsignedModFeltOp o) {
+      return rewriteDivModPow2(o, /*wantQuotient=*/false);
+    }).Default([](Operation *) -> FailureOr<Value> { return Value(); });
+    if (failed(replacement)) {
+      return failure();
+    }
+    if (!*replacement) {
+      continue;
+    }
+    op->getResult(0).replaceAllUsesWith(*replacement);
+    op->erase();
+  }
+  return success();
+}
+
+class PassImpl : public llzk::impl::AlgebraizeFeltOpsPassBase<PassImpl> {
+  using Base = AlgebraizeFeltOpsPassBase<PassImpl>;
+  using Base::Base;
+
+  void runOnOperation() override {
+    auto walkResult = getOperation()->walk([](FuncDefOp fn) -> WalkResult {
+      if (!fn.hasAllowConstraintAttr() || fn.getBody().empty()) {
+        return WalkResult::advance();
+      }
+      if (failed(ConstrainAlgebraizer(fn).run())) {
+        return WalkResult::interrupt();
+      }
+      return WalkResult::advance();
+    });
+    if (walkResult.wasInterrupted()) {
+      signalPassFailure();
+    }
+  }
+};
+} // namespace

--- a/test/Transforms/AlgebraizeFeltOps/algebraize_bitwise_pass.llzk
+++ b/test/Transforms/AlgebraizeFeltOps/algebraize_bitwise_pass.llzk
@@ -1,0 +1,152 @@
+// RUN: llzk-opt -split-input-file -llzk-algebraize-felt-ops -verify-diagnostics %s > %t
+// RUN: FileCheck --enable-var-scope %s < %t
+// RUN: FileCheck --enable-var-scope --check-prefix=BUDGET %s < %t
+
+// Bitwise felt ops become per-bit felt arithmetic over checked bit
+// decompositions (llzk.nondet bits with booleanity and weighted-sum
+// constraints). An asserted range guard `x < 2^k` lets `x` decompose with k
+// bits instead of the full field width (koalabear: 31), and a decomposition
+// narrower than the field skips the range check against the prime.
+
+// Both operands guarded to 8 bits: AND costs two 8-bit decompositions
+// (8 booleanity + 1 sum each) plus 2 guards and 1 output equality: 21.
+!F = !felt.type<"koalabear">
+
+module attributes {llzk.lang} {
+  struct.def @GuardedAnd {
+    struct.member @out : !F {llzk.pub}
+    function.def @compute(%a: !F, %b: !F) -> !struct.type<@GuardedAnd> {
+      %self = struct.new : <@GuardedAnd>
+      function.return %self : !struct.type<@GuardedAnd>
+    }
+    function.def @constrain(%self: !struct.type<@GuardedAnd>, %a: !F, %b: !F) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+      %bound = felt.const 256 : <"koalabear">
+      %one = felt.const 1 : <"koalabear">
+      %ga = bool.cmp lt(%a, %bound) : !F, !F
+      %gaf = cast.tofelt %ga : i1, !F
+      constrain.eq %gaf, %one : !F, !F
+      %gb = bool.cmp lt(%b, %bound) : !F, !F
+      %gbf = cast.tofelt %gb : i1, !F
+      constrain.eq %gbf, %one : !F, !F
+      %0 = felt.bit_and %a, %b : !F, !F
+      %1 = struct.readm %self[@out] : !struct.type<@GuardedAnd>, !F
+      constrain.eq %0, %1 : !F, !F
+      function.return
+    }
+  }
+}
+
+// The first decomposed bit: nondet, booleanity, and its weighted-sum term.
+// CHECK-LABEL: struct.def @GuardedAnd
+// CHECK:         %[[BIT:[0-9a-zA-Z_\.]+]] = llzk.nondet : !felt.type<"koalabear">
+// CHECK:         %[[BM1:[0-9a-zA-Z_\.]+]] = felt.sub %[[BIT]], %{{[0-9a-zA-Z_\.]+}}
+// CHECK:         %[[BPROD:[0-9a-zA-Z_\.]+]] = felt.mul %[[BIT]], %[[BM1]]
+// CHECK:         constrain.eq %[[BPROD]], %{{[0-9a-zA-Z_\.]+}}
+// The sum equality re-asserts the guarded bound against the operand.
+// CHECK:         constrain.eq %{{[0-9a-zA-Z_\.]+}}, %arg1
+// CHECK:         constrain.eq %{{[0-9a-zA-Z_\.]+}}, %arg2
+
+// BUDGET-LABEL:    struct.def @GuardedAnd
+// BUDGET-COUNT-21: constrain.eq
+// BUDGET-NOT:      constrain.eq
+
+// -----
+
+// Mixed widths: a < 16 (4 bits), b < 256 (8 bits). OR pads the shorter side
+// with constant zeros: 2 guards + (4+1) + (8+1) + 1 output = 17.
+!F = !felt.type<"koalabear">
+
+module attributes {llzk.lang} {
+  struct.def @MixedOr {
+    struct.member @out : !F {llzk.pub}
+    function.def @compute(%a: !F, %b: !F) -> !struct.type<@MixedOr> {
+      %self = struct.new : <@MixedOr>
+      function.return %self : !struct.type<@MixedOr>
+    }
+    function.def @constrain(%self: !struct.type<@MixedOr>, %a: !F, %b: !F) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+      %bound_a = felt.const 16 : <"koalabear">
+      %bound_b = felt.const 256 : <"koalabear">
+      %one = felt.const 1 : <"koalabear">
+      %ga = bool.cmp lt(%a, %bound_a) : !F, !F
+      %gaf = cast.tofelt %ga : i1, !F
+      constrain.eq %gaf, %one : !F, !F
+      %gb = bool.cmp lt(%b, %bound_b) : !F, !F
+      %gbf = cast.tofelt %gb : i1, !F
+      constrain.eq %gbf, %one : !F, !F
+      %0 = felt.bit_or %a, %b : !F, !F
+      %1 = struct.readm %self[@out] : !struct.type<@MixedOr>, !F
+      constrain.eq %0, %1 : !F, !F
+      function.return
+    }
+  }
+}
+
+// BUDGET-LABEL:    struct.def @MixedOr
+// BUDGET-COUNT-17: constrain.eq
+// BUDGET-NOT:      constrain.eq
+
+// -----
+
+// XOR has the same shape and budget as OR.
+!F = !felt.type<"koalabear">
+
+module attributes {llzk.lang} {
+  struct.def @MixedXor {
+    struct.member @out : !F {llzk.pub}
+    function.def @compute(%a: !F, %b: !F) -> !struct.type<@MixedXor> {
+      %self = struct.new : <@MixedXor>
+      function.return %self : !struct.type<@MixedXor>
+    }
+    function.def @constrain(%self: !struct.type<@MixedXor>, %a: !F, %b: !F) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+      %bound_a = felt.const 16 : <"koalabear">
+      %bound_b = felt.const 256 : <"koalabear">
+      %one = felt.const 1 : <"koalabear">
+      %ga = bool.cmp lt(%a, %bound_a) : !F, !F
+      %gaf = cast.tofelt %ga : i1, !F
+      constrain.eq %gaf, %one : !F, !F
+      %gb = bool.cmp lt(%b, %bound_b) : !F, !F
+      %gbf = cast.tofelt %gb : i1, !F
+      constrain.eq %gbf, %one : !F, !F
+      %0 = felt.bit_xor %a, %b : !F, !F
+      %1 = struct.readm %self[@out] : !struct.type<@MixedXor>, !F
+      constrain.eq %0, %1 : !F, !F
+      function.return
+    }
+  }
+}
+
+// BUDGET-LABEL:    struct.def @MixedXor
+// BUDGET-COUNT-17: constrain.eq
+// BUDGET-NOT:      constrain.eq
+
+// -----
+
+// NOT complements at full field width (one's-complement of the modulus
+// width), but the operand still decomposes narrowly: 1 guard + (8+1) + 1
+// output = 11.
+!F = !felt.type<"koalabear">
+
+module attributes {llzk.lang} {
+  struct.def @GuardedNot {
+    struct.member @out : !F {llzk.pub}
+    function.def @compute(%a: !F) -> !struct.type<@GuardedNot> {
+      %self = struct.new : <@GuardedNot>
+      function.return %self : !struct.type<@GuardedNot>
+    }
+    function.def @constrain(%self: !struct.type<@GuardedNot>, %a: !F) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+      %bound = felt.const 256 : <"koalabear">
+      %one = felt.const 1 : <"koalabear">
+      %ga = bool.cmp lt(%a, %bound) : !F, !F
+      %gaf = cast.tofelt %ga : i1, !F
+      constrain.eq %gaf, %one : !F, !F
+      %0 = felt.bit_not %a : !F
+      %1 = struct.readm %self[@out] : !struct.type<@GuardedNot>, !F
+      constrain.eq %0, %1 : !F, !F
+      function.return
+    }
+  }
+}
+
+// BUDGET-LABEL:    struct.def @GuardedNot
+// BUDGET-COUNT-11: constrain.eq
+// BUDGET-NOT:      constrain.eq

--- a/test/Transforms/AlgebraizeFeltOps/algebraize_fail.llzk
+++ b/test/Transforms/AlgebraizeFeltOps/algebraize_fail.llzk
@@ -1,0 +1,70 @@
+// RUN: llzk-opt -split-input-file -llzk-algebraize-felt-ops -verify-diagnostics %s
+
+// A sound encoding of `a == q*b + r` for a dynamic divisor `b` needs a
+// multiprecision product argument to rule out field wraparound, so dynamic
+// and non-power-of-two divisors are rejected.
+
+!F = !felt.type<"koalabear">
+
+module attributes {llzk.lang} {
+  struct.def @DynDiv {
+    struct.member @out : !F {llzk.pub}
+    function.def @compute(%a: !F, %b: !F) -> !struct.type<@DynDiv> {
+      %self = struct.new : <@DynDiv>
+      function.return %self : !struct.type<@DynDiv>
+    }
+    function.def @constrain(%self: !struct.type<@DynDiv>, %a: !F, %b: !F) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+      // expected-error@+1 {{algebraization supports only constant divisors}}
+      %0 = felt.uintdiv %a, %b : !F, !F
+      %1 = struct.readm %self[@out] : !struct.type<@DynDiv>, !F
+      constrain.eq %0, %1 : !F, !F
+      function.return
+    }
+  }
+}
+
+// -----
+
+!F = !felt.type<"koalabear">
+
+module attributes {llzk.lang} {
+  struct.def @NonPow2Mod {
+    struct.member @out : !F {llzk.pub}
+    function.def @compute(%a: !F) -> !struct.type<@NonPow2Mod> {
+      %self = struct.new : <@NonPow2Mod>
+      function.return %self : !struct.type<@NonPow2Mod>
+    }
+    function.def @constrain(%self: !struct.type<@NonPow2Mod>, %a: !F) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+      %d = felt.const 3 : <"koalabear">
+      // expected-error@+1 {{algebraization supports only power-of-two divisors}}
+      %0 = felt.umod %a, %d : !F, !F
+      %1 = struct.readm %self[@out] : !struct.type<@NonPow2Mod>, !F
+      constrain.eq %0, %1 : !F, !F
+      function.return
+    }
+  }
+}
+
+// -----
+
+// A raw power of two that is NOT a power of two mod p must be rejected:
+// 2^31 mod koalabear = 2^31 - p = 16777215 (not a power of two).
+!F = !felt.type<"koalabear">
+
+module attributes {llzk.lang} {
+  struct.def @RawPow2AbovePrime {
+    struct.member @out : !F {llzk.pub}
+    function.def @compute(%a: !F) -> !struct.type<@RawPow2AbovePrime> {
+      %self = struct.new : <@RawPow2AbovePrime>
+      function.return %self : !struct.type<@RawPow2AbovePrime>
+    }
+    function.def @constrain(%self: !struct.type<@RawPow2AbovePrime>, %a: !F) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+      %d = felt.const 2147483648 : <"koalabear">
+      // expected-error@+1 {{algebraization supports only power-of-two divisors}}
+      %0 = felt.uintdiv %a, %d : !F, !F
+      %1 = struct.readm %self[@out] : !struct.type<@RawPow2AbovePrime>, !F
+      constrain.eq %0, %1 : !F, !F
+      function.return
+    }
+  }
+}

--- a/test/Transforms/AlgebraizeFeltOps/algebraize_inv_div_divmod_pass.llzk
+++ b/test/Transforms/AlgebraizeFeltOps/algebraize_inv_div_divmod_pass.llzk
@@ -1,0 +1,131 @@
+// RUN: llzk-opt -split-input-file -llzk-algebraize-felt-ops -verify-diagnostics %s > %t
+// RUN: FileCheck --enable-var-scope %s < %t
+// RUN: FileCheck --enable-var-scope --check-prefix=BUDGET %s < %t
+
+// `felt.inv` becomes a witness `w` pinned by `v*w == 1` (unsatisfiable for
+// v == 0). No bit decomposition: 1 pin + 1 output equality.
+!F = !felt.type<"koalabear">
+
+module attributes {llzk.lang} {
+  struct.def @Inv {
+    struct.member @out : !F {llzk.pub}
+    function.def @compute(%a: !F) -> !struct.type<@Inv> {
+      %self = struct.new : <@Inv>
+      function.return %self : !struct.type<@Inv>
+    }
+    function.def @constrain(%self: !struct.type<@Inv>, %a: !F) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+      %0 = felt.inv %a : !F
+      %1 = struct.readm %self[@out] : !struct.type<@Inv>, !F
+      constrain.eq %0, %1 : !F, !F
+      function.return
+    }
+  }
+}
+
+// CHECK-LABEL: struct.def @Inv
+// CHECK:         %[[W:[0-9a-zA-Z_\.]+]] = llzk.nondet : !felt.type<"koalabear">
+// CHECK:         %[[PROD:[0-9a-zA-Z_\.]+]] = felt.mul %arg1, %[[W]]
+// CHECK:         constrain.eq %[[PROD]], %{{[0-9a-zA-Z_\.]+}}
+// The witness itself is the op result; it lands in the output equality.
+// CHECK:         constrain.eq %[[W]], %{{[0-9a-zA-Z_\.]+}}
+
+// BUDGET-LABEL:   struct.def @Inv
+// BUDGET-COUNT-2: constrain.eq
+// BUDGET-NOT:     constrain.eq
+
+// -----
+
+// `felt.div` inverts the divisor and multiplies (not the cheaper
+// `b*w == a` hint, which underconstrains when a == b == 0).
+!F = !felt.type<"koalabear">
+
+module attributes {llzk.lang} {
+  struct.def @Div {
+    struct.member @out : !F {llzk.pub}
+    function.def @compute(%a: !F, %b: !F) -> !struct.type<@Div> {
+      %self = struct.new : <@Div>
+      function.return %self : !struct.type<@Div>
+    }
+    function.def @constrain(%self: !struct.type<@Div>, %a: !F, %b: !F) attributes {function.allow_constraint} {
+      %0 = felt.div %a, %b : !F, !F
+      %1 = struct.readm %self[@out] : !struct.type<@Div>, !F
+      constrain.eq %0, %1 : !F, !F
+      function.return
+    }
+  }
+}
+
+// CHECK-LABEL: struct.def @Div
+// CHECK:         %[[W:[0-9a-zA-Z_\.]+]] = llzk.nondet : !felt.type<"koalabear">
+// CHECK:         %[[PROD:[0-9a-zA-Z_\.]+]] = felt.mul %arg2, %[[W]]
+// CHECK:         constrain.eq %[[PROD]], %{{[0-9a-zA-Z_\.]+}}
+// CHECK:         %[[RES:[0-9a-zA-Z_\.]+]] = felt.mul %arg1, %[[W]]
+// CHECK:         constrain.eq %[[RES]], %{{[0-9a-zA-Z_\.]+}}
+
+// BUDGET-LABEL:   struct.def @Div
+// BUDGET-COUNT-2: constrain.eq
+// BUDGET-NOT:     constrain.eq
+
+// -----
+
+// uintdiv and umod by the same power of two share one decomposition of the
+// dividend (the bits are cached): 1 guard + (8+1) + 2 outputs = 12, not 21.
+!F = !felt.type<"koalabear">
+
+module attributes {llzk.lang} {
+  struct.def @DivModPair {
+    struct.member @q : !F {llzk.pub}
+    struct.member @r : !F {llzk.pub}
+    function.def @compute(%a: !F) -> !struct.type<@DivModPair> {
+      %self = struct.new : <@DivModPair>
+      function.return %self : !struct.type<@DivModPair>
+    }
+    function.def @constrain(%self: !struct.type<@DivModPair>, %a: !F) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+      %bound = felt.const 256 : <"koalabear">
+      %one = felt.const 1 : <"koalabear">
+      %ga = bool.cmp lt(%a, %bound) : !F, !F
+      %gaf = cast.tofelt %ga : i1, !F
+      constrain.eq %gaf, %one : !F, !F
+      %d = felt.const 4 : <"koalabear">
+      %q = felt.uintdiv %a, %d : !F, !F
+      %r = felt.umod %a, %d : !F, !F
+      %oq = struct.readm %self[@q] : !struct.type<@DivModPair>, !F
+      %or = struct.readm %self[@r] : !struct.type<@DivModPair>, !F
+      constrain.eq %q, %oq : !F, !F
+      constrain.eq %r, %or : !F, !F
+      function.return
+    }
+  }
+}
+
+// BUDGET-LABEL:    struct.def @DivModPair
+// BUDGET-COUNT-12: constrain.eq
+// BUDGET-NOT:      constrain.eq
+
+// -----
+
+// A divisor of p + 4 IS a division by 4: the power-of-two check must see
+// the canonical value (felt.const does not enforce < p). The unguarded
+// dividend decomposes at full width: (31+1+1 range check) + 1 output = 34.
+!F = !felt.type<"koalabear">
+
+module attributes {llzk.lang} {
+  struct.def @NonCanonPow2Div {
+    struct.member @out : !F {llzk.pub}
+    function.def @compute(%a: !F) -> !struct.type<@NonCanonPow2Div> {
+      %self = struct.new : <@NonCanonPow2Div>
+      function.return %self : !struct.type<@NonCanonPow2Div>
+    }
+    function.def @constrain(%self: !struct.type<@NonCanonPow2Div>, %a: !F) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+      %d = felt.const 2130706437 : <"koalabear">
+      %q = felt.uintdiv %a, %d : !F, !F
+      %r = struct.readm %self[@out] : !struct.type<@NonCanonPow2Div>, !F
+      constrain.eq %q, %r : !F, !F
+      function.return
+    }
+  }
+}
+
+// BUDGET-LABEL:    struct.def @NonCanonPow2Div
+// BUDGET-COUNT-34: constrain.eq
+// BUDGET-NOT:      constrain.eq

--- a/test/Transforms/AlgebraizeFeltOps/algebraize_pcl_e2e.llzk
+++ b/test/Transforms/AlgebraizeFeltOps/algebraize_pcl_e2e.llzk
@@ -1,0 +1,35 @@
+// REQUIRES: with-pcl
+// RUN: llzk-opt -llzk-algebraize-felt-ops -llzk-to-pcl %s | FileCheck --enable-var-scope %s
+
+// End-to-end: after algebraization the PCL conversion only sees native felt
+// arithmetic, nondets, and equality constraints. Every constrain.eq becomes
+// one pcl.assert: 2 guards + 2 8-bit decompositions (8+1 each) + 1 output.
+!F = !felt.type<"koalabear">
+
+module attributes {llzk.lang} {
+  struct.def @Main {
+    struct.member @out : !F {llzk.pub}
+    function.def @compute(%a: !F, %b: !F) -> !struct.type<@Main> {
+      %self = struct.new : <@Main>
+      function.return %self : !struct.type<@Main>
+    }
+    function.def @constrain(%self: !struct.type<@Main>, %a: !F, %b: !F) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+      %bound = felt.const 256 : <"koalabear">
+      %one = felt.const 1 : <"koalabear">
+      %ga = bool.cmp lt(%a, %bound) : !F, !F
+      %gaf = cast.tofelt %ga : i1, !F
+      constrain.eq %gaf, %one : !F, !F
+      %gb = bool.cmp lt(%b, %bound) : !F, !F
+      %gbf = cast.tofelt %gb : i1, !F
+      constrain.eq %gbf, %one : !F, !F
+      %0 = felt.bit_and %a, %b : !F, !F
+      %1 = struct.readm %self[@out] : !struct.type<@Main>, !F
+      constrain.eq %0, %1 : !F, !F
+      function.return
+    }
+  }
+}
+
+// CHECK-LABEL:     func.func @Main(
+// CHECK-COUNT-21:  pcl.assert
+// CHECK-NOT:       pcl.assert

--- a/test/Transforms/AlgebraizeFeltOps/algebraize_region_block_arg.llzk
+++ b/test/Transforms/AlgebraizeFeltOps/algebraize_region_block_arg.llzk
@@ -1,0 +1,29 @@
+// RUN: llzk-opt -llzk-algebraize-felt-ops %s > /dev/null
+
+// A nested-region block argument is not in scope in the function entry
+// block. Its decomposition must be emitted inside the owning block.
+
+!F = !felt.type<"koalabear">
+
+module attributes {llzk.lang} {
+  struct.def @LoopArg {
+    struct.member @out : !F {llzk.pub}
+    function.def @compute(%a: !F) -> !struct.type<@LoopArg> {
+      %self = struct.new : <@LoopArg>
+      function.return %self : !struct.type<@LoopArg>
+    }
+    function.def @constrain(%self: !struct.type<@LoopArg>, %a: !F) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+      %lb = arith.constant 0 : index
+      %ub = arith.constant 2 : index
+      %step = arith.constant 1 : index
+      %one = felt.const 1 : <"koalabear">
+      %result = scf.for %iv = %lb to %ub step %step iter_args(%acc = %a) -> !F {
+        %masked = felt.bit_and %acc, %one : !F, !F
+        scf.yield %masked : !F
+      }
+      %out = struct.readm %self[@out] : !struct.type<@LoopArg>, !F
+      constrain.eq %result, %out : !F, !F
+      function.return
+    }
+  }
+}

--- a/test/Transforms/AlgebraizeFeltOps/algebraize_shift_pass.llzk
+++ b/test/Transforms/AlgebraizeFeltOps/algebraize_shift_pass.llzk
@@ -1,0 +1,142 @@
+// RUN: llzk-opt -split-input-file -llzk-algebraize-felt-ops -verify-diagnostics %s > %t
+// RUN: FileCheck --enable-var-scope %s < %t
+// RUN: FileCheck --enable-var-scope --check-prefix=BUDGET %s < %t
+
+// A constant shl folds to a single multiplication by 2^s mod p: 1 guard + 1
+// output equality, no decomposition at all.
+!F = !felt.type<"koalabear">
+
+module attributes {llzk.lang} {
+  struct.def @ShlConst {
+    struct.member @out : !F {llzk.pub}
+    function.def @compute(%a: !F) -> !struct.type<@ShlConst> {
+      %self = struct.new : <@ShlConst>
+      function.return %self : !struct.type<@ShlConst>
+    }
+    function.def @constrain(%self: !struct.type<@ShlConst>, %a: !F) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+      %bound = felt.const 256 : <"koalabear">
+      %one = felt.const 1 : <"koalabear">
+      %ga = bool.cmp lt(%a, %bound) : !F, !F
+      %gaf = cast.tofelt %ga : i1, !F
+      constrain.eq %gaf, %one : !F, !F
+      %s = felt.const 3 : <"koalabear">
+      %0 = felt.shl %a, %s : !F, !F
+      %1 = struct.readm %self[@out] : !struct.type<@ShlConst>, !F
+      constrain.eq %0, %1 : !F, !F
+      function.return
+    }
+  }
+}
+
+// CHECK-LABEL: struct.def @ShlConst
+// CHECK:         %[[POW:[0-9a-zA-Z_\.]+]] = felt.const  8
+// CHECK:         %[[RES:[0-9a-zA-Z_\.]+]] = felt.mul %arg1, %[[POW]]
+// CHECK:         constrain.eq %[[RES]], %{{[0-9a-zA-Z_\.]+}}
+// CHECK-NOT:     llzk.nondet
+
+// BUDGET-LABEL:   struct.def @ShlConst
+// BUDGET-COUNT-2: constrain.eq
+// BUDGET-NOT:     constrain.eq
+
+// -----
+
+// A dynamic shl decomposes only the shift amount: with s < 8 (3 bits),
+// 2^s = prod(s_i * (2^(2^i) - 1) + 1), so the factor constants are 1, 3,
+// and 15. 1 guard + (3+1) + 1 output = 6.
+!F = !felt.type<"koalabear">
+
+module attributes {llzk.lang} {
+  struct.def @ShlDyn {
+    struct.member @out : !F {llzk.pub}
+    function.def @compute(%a: !F, %s: !F) -> !struct.type<@ShlDyn> {
+      %self = struct.new : <@ShlDyn>
+      function.return %self : !struct.type<@ShlDyn>
+    }
+    function.def @constrain(%self: !struct.type<@ShlDyn>, %a: !F, %s: !F) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+      %bound = felt.const 8 : <"koalabear">
+      %one = felt.const 1 : <"koalabear">
+      %gs = bool.cmp lt(%s, %bound) : !F, !F
+      %gsf = cast.tofelt %gs : i1, !F
+      constrain.eq %gsf, %one : !F, !F
+      %0 = felt.shl %a, %s : !F, !F
+      %1 = struct.readm %self[@out] : !struct.type<@ShlDyn>, !F
+      constrain.eq %0, %1 : !F, !F
+      function.return
+    }
+  }
+}
+
+// CHECK-LABEL: struct.def @ShlDyn
+// CHECK:         felt.const  3
+// CHECK:         felt.const  15
+
+// BUDGET-LABEL:   struct.def @ShlDyn
+// BUDGET-COUNT-6: constrain.eq
+// BUDGET-NOT:     constrain.eq
+
+// -----
+
+// A constant shr is a slice of the operand's decomposition, bits [2..8):
+// 1 guard + (8+1) + 1 output = 11.
+!F = !felt.type<"koalabear">
+
+module attributes {llzk.lang} {
+  struct.def @ShrConst {
+    struct.member @out : !F {llzk.pub}
+    function.def @compute(%a: !F) -> !struct.type<@ShrConst> {
+      %self = struct.new : <@ShrConst>
+      function.return %self : !struct.type<@ShrConst>
+    }
+    function.def @constrain(%self: !struct.type<@ShrConst>, %a: !F) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+      %bound = felt.const 256 : <"koalabear">
+      %one = felt.const 1 : <"koalabear">
+      %ga = bool.cmp lt(%a, %bound) : !F, !F
+      %gaf = cast.tofelt %ga : i1, !F
+      constrain.eq %gaf, %one : !F, !F
+      %s = felt.const 2 : <"koalabear">
+      %0 = felt.shr %a, %s : !F, !F
+      %1 = struct.readm %self[@out] : !struct.type<@ShrConst>, !F
+      constrain.eq %0, %1 : !F, !F
+      function.return
+    }
+  }
+}
+
+// BUDGET-LABEL:    struct.def @ShrConst
+// BUDGET-COUNT-11: constrain.eq
+// BUDGET-NOT:      constrain.eq
+
+// -----
+
+// A dynamic shr decomposes both operands and drives a barrel shifter over
+// the value's bits: 2 guards + (8+1) + (2+1) + 1 output = 15.
+!F = !felt.type<"koalabear">
+
+module attributes {llzk.lang} {
+  struct.def @ShrDyn {
+    struct.member @out : !F {llzk.pub}
+    function.def @compute(%a: !F, %s: !F) -> !struct.type<@ShrDyn> {
+      %self = struct.new : <@ShrDyn>
+      function.return %self : !struct.type<@ShrDyn>
+    }
+    function.def @constrain(%self: !struct.type<@ShrDyn>, %a: !F, %s: !F) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+      %bound_a = felt.const 256 : <"koalabear">
+      %bound_s = felt.const 4 : <"koalabear">
+      %one = felt.const 1 : <"koalabear">
+      %ga = bool.cmp lt(%a, %bound_a) : !F, !F
+      %gaf = cast.tofelt %ga : i1, !F
+      constrain.eq %gaf, %one : !F, !F
+      %gs = bool.cmp lt(%s, %bound_s) : !F, !F
+      %gsf = cast.tofelt %gs : i1, !F
+      constrain.eq %gsf, %one : !F, !F
+      %0 = felt.shr %a, %s : !F, !F
+      %1 = struct.readm %self[@out] : !struct.type<@ShrDyn>, !F
+      constrain.eq %0, %1 : !F, !F
+      function.return
+    }
+  }
+}
+
+// BUDGET-LABEL:    struct.def @ShrDyn
+// BUDGET-COUNT-15: constrain.eq
+// BUDGET-NOT:      constrain.eq

--- a/test/Transforms/AlgebraizeFeltOps/algebraize_width_bucketing_pass.llzk
+++ b/test/Transforms/AlgebraizeFeltOps/algebraize_width_bucketing_pass.llzk
@@ -1,0 +1,136 @@
+// RUN: llzk-opt -split-input-file -llzk-algebraize-felt-ops -verify-diagnostics %s > %t
+// RUN: FileCheck --enable-var-scope --check-prefix=BUDGET %s < %t
+
+// Width inference beyond the basic `lt` guard: other predicates, bound
+// propagation through native ops, integer-cast provenance, and reuse of one
+// decomposition across operations.
+
+// `x <= 255` and a reversed guard `256 > y` prove the same 8-bit bound.
+// AND of the two: 2 guards + (8+1)*2 + 1 output = 21.
+!F = !felt.type<"koalabear">
+
+module attributes {llzk.lang} {
+  struct.def @LeAndReversedGt {
+    struct.member @out : !F {llzk.pub}
+    function.def @compute(%a: !F, %b: !F) -> !struct.type<@LeAndReversedGt> {
+      %self = struct.new : <@LeAndReversedGt>
+      function.return %self : !struct.type<@LeAndReversedGt>
+    }
+    function.def @constrain(%self: !struct.type<@LeAndReversedGt>, %a: !F, %b: !F) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+      %c255 = felt.const 255 : <"koalabear">
+      %c256 = felt.const 256 : <"koalabear">
+      %one = felt.const 1 : <"koalabear">
+      %ga = bool.cmp le(%a, %c255) : !F, !F
+      %gaf = cast.tofelt %ga : i1, !F
+      constrain.eq %gaf, %one : !F, !F
+      %gb = bool.cmp gt(%c256, %b) : !F, !F
+      %gbf = cast.tofelt %gb : i1, !F
+      constrain.eq %gbf, %one : !F, !F
+      %0 = felt.bit_and %a, %b : !F, !F
+      %1 = struct.readm %self[@out] : !struct.type<@LeAndReversedGt>, !F
+      constrain.eq %0, %1 : !F, !F
+      function.return
+    }
+  }
+}
+
+// BUDGET-LABEL:    struct.def @LeAndReversedGt
+// BUDGET-COUNT-21: constrain.eq
+// BUDGET-NOT:      constrain.eq
+
+// -----
+
+// Bounds propagate through native ops: a < 16 and b < 16, so a + b < 32
+// (5 bits). AND with a constant truncates to the shorter side:
+// 2 guards + (5+1) + 1 output = 9.
+!F = !felt.type<"koalabear">
+
+module attributes {llzk.lang} {
+  struct.def @AddPropagation {
+    struct.member @out : !F {llzk.pub}
+    function.def @compute(%a: !F, %b: !F) -> !struct.type<@AddPropagation> {
+      %self = struct.new : <@AddPropagation>
+      function.return %self : !struct.type<@AddPropagation>
+    }
+    function.def @constrain(%self: !struct.type<@AddPropagation>, %a: !F, %b: !F) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+      %bound = felt.const 16 : <"koalabear">
+      %one = felt.const 1 : <"koalabear">
+      %ga = bool.cmp lt(%a, %bound) : !F, !F
+      %gaf = cast.tofelt %ga : i1, !F
+      constrain.eq %gaf, %one : !F, !F
+      %gb = bool.cmp lt(%b, %bound) : !F, !F
+      %gbf = cast.tofelt %gb : i1, !F
+      constrain.eq %gbf, %one : !F, !F
+      %sum = felt.add %a, %b : !F, !F
+      %mask = felt.const 255 : <"koalabear">
+      %0 = felt.bit_and %sum, %mask : !F, !F
+      %1 = struct.readm %self[@out] : !struct.type<@AddPropagation>, !F
+      constrain.eq %0, %1 : !F, !F
+      function.return
+    }
+  }
+}
+
+// BUDGET-LABEL:   struct.def @AddPropagation
+// BUDGET-COUNT-9: constrain.eq
+// BUDGET-NOT:     constrain.eq
+
+// -----
+
+// A felt cast from an i1 is bounded by 2^1 with no guard at all: the cast
+// result decomposes as a single bit. (1+1) + 1 output = 3.
+!F = !felt.type<"koalabear">
+
+module attributes {llzk.lang} {
+  struct.def @BoolCastAnd {
+    struct.member @out : !F {llzk.pub}
+    function.def @compute(%a: !F, %b: !F) -> !struct.type<@BoolCastAnd> {
+      %self = struct.new : <@BoolCastAnd>
+      function.return %self : !struct.type<@BoolCastAnd>
+    }
+    function.def @constrain(%self: !struct.type<@BoolCastAnd>, %a: !F, %b: !F) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+      %one = felt.const 1 : <"koalabear">
+      %c = bool.cmp lt(%a, %b) : !F, !F
+      %cf = cast.tofelt %c : i1, !F
+      %0 = felt.bit_and %cf, %one : !F, !F
+      %1 = struct.readm %self[@out] : !struct.type<@BoolCastAnd>, !F
+      constrain.eq %0, %1 : !F, !F
+      function.return
+    }
+  }
+}
+
+// BUDGET-LABEL:   struct.def @BoolCastAnd
+// BUDGET-COUNT-3: constrain.eq
+// BUDGET-NOT:     constrain.eq
+
+// -----
+
+// The same value used by both operands decomposes once:
+// 1 guard + (8+1) + 1 output = 11, not 20.
+!F = !felt.type<"koalabear">
+
+module attributes {llzk.lang} {
+  struct.def @SharedDecomposition {
+    struct.member @out : !F {llzk.pub}
+    function.def @compute(%a: !F) -> !struct.type<@SharedDecomposition> {
+      %self = struct.new : <@SharedDecomposition>
+      function.return %self : !struct.type<@SharedDecomposition>
+    }
+    function.def @constrain(%self: !struct.type<@SharedDecomposition>, %a: !F) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+      %bound = felt.const 256 : <"koalabear">
+      %one = felt.const 1 : <"koalabear">
+      %ga = bool.cmp lt(%a, %bound) : !F, !F
+      %gaf = cast.tofelt %ga : i1, !F
+      constrain.eq %gaf, %one : !F, !F
+      %0 = felt.bit_xor %a, %a : !F, !F
+      %1 = struct.readm %self[@out] : !struct.type<@SharedDecomposition>, !F
+      constrain.eq %0, %1 : !F, !F
+      function.return
+    }
+  }
+}
+
+// BUDGET-LABEL:    struct.def @SharedDecomposition
+// BUDGET-COUNT-11: constrain.eq
+// BUDGET-NOT:      constrain.eq


### PR DESCRIPTION
Implements stage 2 of #585.

Adds `-llzk-algebraize-felt-ops`, an LLZK pre-lowering pass for functions marked `function.allow_constraint`. It lowers unsupported felt bitwise, shift, inverse, division, unsigned division, and modulo operations into basic felt arithmetic, nondeterministic witnesses, bit decompositions, and equality constraints.

The pass reuses decompositions, uses known width bounds where available, and rejects unsupported division/modulo cases rather than producing unsound constraints.

Tested with the AlgebraizeFeltOps and PCLLowering lit suites (15 tests).