### PR TITLE
Add tests involving the `PLACEHOLDER` char and fix a couple bugs

### DIFF
--- a/lib/Dialect/Polymorphic/Transforms/TypeVarInferencePass.cpp
+++ b/lib/Dialect/Polymorphic/Transforms/TypeVarInferencePass.cpp
@@ -1190,7 +1190,7 @@ private:
   /// Convert struct parameters and instantiate the struct if all parameters are concrete.
   StructType convertStructType(StructType structTy) {
     ArrayAttr params = structTy.getParams();
-    if (!params) {
+    if (isNullOrEmpty(params)) {
       return structTy;
     }
 
@@ -2877,12 +2877,23 @@ static FailureOr<ArrayAttr> materializeResidualFunctionTvarWildcards(
       continue;
     }
 
-    FailureOr<Attribute> inferredAttr =
-        getInferredRhsTemplateArg(callableOp, targetOp, *unifyResult, paramName, "wildcard");
-    if (failed(inferredAttr)) {
-      return failure();
+    auto inferredIt = unifyResult->find({FlatSymbolRefAttr::get(paramName), Side::RHS});
+    if (inferredIt == unifyResult->end()) {
+      auto proofIt = info.functionReplacements.find(targetOp.getOperation());
+      if (proofIt == info.functionReplacements.end()) {
+        continue;
+      }
+      auto replacementIt = proofIt->second.find(paramName);
+      if (replacementIt == proofIt->second.end()) {
+        continue;
+      }
+      params[*index] = TypeAttr::get(replacementIt->second.type);
+      continue;
     }
-    params[*index] = *inferredAttr;
+    if (!inferredIt->second) {
+      return emitConflictingInferredTypes(callableOp, targetOp, paramName);
+    }
+    params[*index] = inferredIt->second;
   }
   return ArrayAttr::get(callableOp.getContext(), params);
 }
@@ -3161,9 +3172,7 @@ static FailureOr<bool> updateCallableTemplateParamsFor(
       modified = true;
     }
 
-    if (resolveTemplateSymbolArgs) {
-      updateCallableResultTypesIfNeeded(callableOp, *converter, modified);
-    }
+    updateCallableResultTypesIfNeeded(callableOp, *converter, modified);
   });
   if (failedConversion) {
     return failure();

--- a/lib/Util/TypeHelper.cpp
+++ b/lib/Util/TypeHelper.cpp
@@ -98,9 +98,6 @@ void BuildShortTypeString::appendSymRef(SymbolRefAttr sa) {
 }
 
 BuildShortTypeString &BuildShortTypeString::append(Type type) {
-  size_t position = ret.size();
-  (void)position; // tell compiler it's intentionally unused in builds without assertions
-
   struct Impl : LLZKTypeSwitch<Impl, void> {
     BuildShortTypeString &outer;
     Impl(BuildShortTypeString &outerRef) : outer(outerRef) {}
@@ -140,11 +137,6 @@ BuildShortTypeString &BuildShortTypeString::append(Type type) {
     }
   };
   Impl(*this).match(type);
-
-  assert(
-      ret.find(PLACEHOLDER, position) == std::string::npos &&
-      "formatting a Type should not produce the 'PLACEHOLDER' char"
-  );
   return *this;
 }
 
@@ -154,9 +146,6 @@ BuildShortTypeString &BuildShortTypeString::append(Attribute a) {
     ss << PLACEHOLDER;
     return *this;
   }
-
-  size_t position = ret.size();
-  (void)position; // tell compiler it's intentionally unused in builds without assertions
 
   // Adapted from AsmPrinter::Impl::printAttributeImpl()
   if (auto ia = llvm::dyn_cast<IntegerAttr>(a)) {
@@ -180,10 +169,6 @@ BuildShortTypeString &BuildShortTypeString::append(Attribute a) {
     // All valid/legal cases must be covered above
     assertValidAttrForParamOfType(a);
   }
-  assert(
-      ret.find(PLACEHOLDER, position) == std::string::npos &&
-      "formatting a non-null Attribute should not produce the 'PLACEHOLDER' char"
-  );
   return *this;
 }
 

--- a/test/Transforms/PlaceholderSanity/infer_tvar_and_flatten_1.llzk
+++ b/test/Transforms/PlaceholderSanity/infer_tvar_and_flatten_1.llzk
@@ -1,0 +1,59 @@
+// RUN: llzk-opt -split-input-file -llzk-infer-tvar -llzk-flatten -verify-diagnostics %s | FileCheck --enable-var-scope %s
+// RUN: llzk-opt -split-input-file -llzk-flatten -verify-diagnostics %s | FileCheck --enable-var-scope %s
+
+// TESTS: Ensures the placeholder `\1A` character added by one pass is properly interpreted by a later pass.
+// The `llzk-infer-tvar` pass converts the call to `function.call @"T_\1A_i"::@compute<[89]>() : () -> index`,
+// replacing the `@Ty` type parameter with `index`. Then, the `llzk-flatten` pass will replace the `\1A`
+// placeholder with the constant `89`. The same output is expected when ONLY the `llzk-flatten` pass runs.
+module attributes {llzk.lang} {
+  poly.template @A {
+    poly.param @Num
+    poly.param @Ty : !poly.tvar<@Ty>
+
+    function.def @compute() -> !poly.tvar<@Ty> {
+      %0 = poly.read_const @Num : !poly.tvar<@Ty>
+      function.return %0 : !poly.tvar<@Ty>
+    }
+  }
+
+  function.def @main() -> index {
+    %0 = function.call @A::@compute<[89, index]>() : () -> index
+    function.return %0 : index
+  }
+}
+// CHECK-LABEL: function.def @A_89_i_compute() -> index {
+// CHECK-NEXT:    %[[VAL_0:[0-9a-zA-Z_\.]+]] = arith.constant 89 : index
+// CHECK-NEXT:    function.return %[[VAL_0]] : index
+// CHECK-NEXT:  }
+// CHECK-LABEL: function.def @main() -> index {
+// CHECK-NEXT:    %[[VAL_2:[0-9a-zA-Z_\.]+]] = function.call @A_89_i_compute() : () -> index
+// CHECK-NEXT:    function.return %[[VAL_2]] : index
+// CHECK-NEXT:  }
+// -----
+
+// Similar to above but the type parameter is first.
+module attributes {llzk.lang} {
+  poly.template @B {
+    poly.param @A : !poly.tvar<@A>
+    poly.param @N
+
+    function.def @with_const(%arg: !poly.tvar<@A>) -> !poly.tvar<@A> {
+      %n = poly.read_const @N : index
+      function.return %arg : !poly.tvar<@A>
+    }
+  }
+
+  function.def @call_with_const(%arg: !felt.type) -> !felt.type {
+    %0 = function.call @B::@with_const<[!felt.type, 7]>(%arg) : (!felt.type) -> !felt.type
+    function.return %0 : !felt.type
+  }
+}
+// CHECK-LABEL: function.def @B_f_7_with_const(
+// CHECK-SAME: %[[VAL_0:[0-9a-zA-Z_\.]+]]: !felt.type) -> !felt.type {
+// CHECK-NEXT:    function.return %[[VAL_0]] : !felt.type
+// CHECK-NEXT:  }
+// CHECK-LABEL: function.def @call_with_const(
+// CHECK-SAME: %[[VAL_1:[0-9a-zA-Z_\.]+]]: !felt.type) -> !felt.type {
+// CHECK-NEXT:    %[[VAL_2:[0-9a-zA-Z_\.]+]] = function.call @B_f_7_with_const(%[[VAL_1]]) : (!felt.type) -> !felt.type
+// CHECK-NEXT:    function.return %[[VAL_2]] : !felt.type
+// CHECK-NEXT:  }

--- a/test/Transforms/PlaceholderSanity/infer_tvar_and_flatten_2.llzk
+++ b/test/Transforms/PlaceholderSanity/infer_tvar_and_flatten_2.llzk
@@ -1,0 +1,75 @@
+// RUN: llzk-opt -split-input-file -llzk-infer-tvar -llzk-flatten -verify-diagnostics %s | FileCheck --enable-var-scope %s
+
+module attributes {llzk.lang} {
+  poly.template @TBoxForWildcardName {
+    poly.param @N
+    poly.param @T : !poly.tvar<@T>
+
+    struct.def @Box {
+      struct.member @value : !poly.tvar<@T>
+
+      function.def @product(%arg: !poly.tvar<@T>) -> !struct.type<@TBoxForWildcardName::@Box<[@N, @T]>> attributes {function.allow_witness} {
+        %self = struct.new : !struct.type<@TBoxForWildcardName::@Box<[@N, @T]>>
+        struct.writem %self[@value] = %arg : !struct.type<@TBoxForWildcardName::@Box<[@N, @T]>>, !poly.tvar<@T>
+        function.return %self : !struct.type<@TBoxForWildcardName::@Box<[@N, @T]>>
+      }
+    }
+  }
+
+  poly.template @X {
+    poly.param @Y
+    struct.def @WildcardNameTarget {
+      function.def @compute(%arg: !array.type<? x !struct.type<@TBoxForWildcardName::@Box<[7, index]>>>) -> !struct.type<@X::@WildcardNameTarget<[@Y]>> {
+        %self = struct.new : !struct.type<@X::@WildcardNameTarget<[@Y]>>
+        function.return %self : !struct.type<@X::@WildcardNameTarget<[@Y]>>
+      }
+
+      function.def @constrain(%self: !struct.type<@X::@WildcardNameTarget<[@Y]>>, %arg: !array.type<? x !struct.type<@TBoxForWildcardName::@Box<[7, index]>>>) {
+        function.return
+      }
+    }
+  }
+
+  function.def @call_box_array(%arg: !array.type<1 x !struct.type<@TBoxForWildcardName::@Box<[7, index]>>>) -> index attributes {function.allow_witness} {
+    %0 = function.call @X::@WildcardNameTarget::@compute(%arg) :
+        (!array.type<1 x !struct.type<@TBoxForWildcardName::@Box<[7, index]>>>) -> !struct.type<@X::@WildcardNameTarget<[99]>>
+    %one = arith.constant 1 : index
+    function.return %one : index
+  }
+}
+// CHECK-LABEL: module attributes {llzk.lang} {
+// CHECK-NEXT:    struct.def @TBoxForWildcardName_7_i_Box {
+// CHECK-NEXT:      struct.member @value : index
+// CHECK-NEXT:      function.def @product(%[[VAL_0:[0-9a-zA-Z_\.]+]]: index) -> !struct.type<@TBoxForWildcardName_7_i_Box> attributes {function.allow_constraint, function.allow_witness} {
+// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = struct.new : <@TBoxForWildcardName_7_i_Box>
+// CHECK-NEXT:        struct.writem %[[VAL_1]][@value] = %[[VAL_0]] : <@TBoxForWildcardName_7_i_Box>, index
+// CHECK-NEXT:        function.return %[[VAL_1]] : !struct.type<@TBoxForWildcardName_7_i_Box>
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:    poly.template @TBoxForWildcardName {
+// CHECK-NEXT:      poly.param @N
+// CHECK-NEXT:      poly.param @T : !poly.tvar<@T>
+// CHECK-NEXT:      struct.def @Box {
+// CHECK-NEXT:        struct.member @value : !poly.tvar<@T>
+// CHECK-NEXT:        function.def @product(%[[VAL_2:[0-9a-zA-Z_\.]+]]: !poly.tvar<@T>) -> !struct.type<@TBoxForWildcardName::@Box<[@N, @T]>> attributes {function.allow_constraint, function.allow_witness} {
+// CHECK-NEXT:          %[[VAL_3:[0-9a-zA-Z_\.]+]] = struct.new : <@TBoxForWildcardName::@Box<[@N, @T]>>
+// CHECK-NEXT:          struct.writem %[[VAL_3]][@value] = %[[VAL_2]] : <@TBoxForWildcardName::@Box<[@N, @T]>>, !poly.tvar<@T>
+// CHECK-NEXT:          function.return %[[VAL_3]] : !struct.type<@TBoxForWildcardName::@Box<[@N, @T]>>
+// CHECK-NEXT:        }
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:    struct.def @X_99_WildcardNameTarget {
+// CHECK-NEXT:      function.def @compute(%[[VAL_4:[0-9a-zA-Z_\.]+]]: !array.type<? x !struct.type<@TBoxForWildcardName_7_i_Box>>) -> !struct.type<@X_99_WildcardNameTarget> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = struct.new : <@X_99_WildcardNameTarget>
+// CHECK-NEXT:        function.return %[[VAL_5]] : !struct.type<@X_99_WildcardNameTarget>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.def @constrain(%[[VAL_6:[0-9a-zA-Z_\.]+]]: !struct.type<@X_99_WildcardNameTarget>, %[[VAL_7:[0-9a-zA-Z_\.]+]]: !array.type<? x !struct.type<@TBoxForWildcardName_7_i_Box>>) attributes {function.allow_constraint} {
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:    function.def @call_box_array(%[[VAL_8:[0-9a-zA-Z_\.]+]]: !array.type<1 x !struct.type<@TBoxForWildcardName_7_i_Box>>) -> index attributes {function.allow_witness} {
+// CHECK-NEXT:      %[[VAL_9:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:      %[[VAL_10:[0-9a-zA-Z_\.]+]] = function.call @X_99_WildcardNameTarget::@compute(%[[VAL_8]]) : (!array.type<1 x !struct.type<@TBoxForWildcardName_7_i_Box>>) -> !struct.type<@X_99_WildcardNameTarget>
+// CHECK-NEXT:      function.return %[[VAL_9]] : index
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/test/Transforms/PlaceholderSanity/infer_tvar_and_wildcard.llzk
+++ b/test/Transforms/PlaceholderSanity/infer_tvar_and_wildcard.llzk
@@ -1,0 +1,136 @@
+// RUN: llzk-opt -split-input-file -llzk-infer-tvar -llzk-specialize-wildcard-arrays -verify-diagnostics %s | FileCheck --enable-var-scope %s
+
+// COM: Using only these passes without `llzk-flatten` is not fully effective but this
+// COM: test ensures `llzk-infer-tvar` can leave behind `?` without an error or crash.
+module attributes {llzk.lang} {
+  poly.template @FRT {
+    poly.param @T_return : !poly.tvar<@T_return>
+    function.def @free_ret() -> !poly.tvar<@T_return> {
+      %0 = felt.const  0 : <"bn128">
+      %1 = poly.unifiable_cast %0 : (!felt.type<"bn128">) -> !poly.tvar<@T_return>
+      function.return %1 : !poly.tvar<@T_return>
+    }
+  }
+
+  poly.template @synth {
+    poly.param @T_return : !poly.tvar<@T_return>
+    function.def @synth() {
+      %0 = function.call @FRT::@free_ret() : () -> !poly.tvar<@T_return>
+      function.return
+    }
+  }
+
+  poly.template @ComponentC {
+    struct.def @ComponentC {
+      function.def @compute() -> !struct.type<@ComponentC::@ComponentC<[]>> {
+        %self = struct.new : !struct.type<@ComponentC::@ComponentC<[]>>
+        function.call @synth::@synth<[?]>() : () -> ()
+        function.return %self : !struct.type<@ComponentC::@ComponentC<[]>>
+      }
+
+      function.def @constrain(%self: !struct.type<@ComponentC::@ComponentC<[]>>) { function.return }
+    }
+  }
+}
+// CHECK-LABEL: module attributes {llzk.lang} {
+// CHECK-NEXT:    poly.template @FRT {
+// CHECK-NEXT:      function.def @free_ret() -> !felt.type<"bn128"> {
+// CHECK-NEXT:        %[[VAL_0:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:        function.return %[[VAL_0]] : !felt.type<"bn128">
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:    poly.template @synth {
+// CHECK-NEXT:      poly.param @T_return : !poly.tvar<@T_return>
+// CHECK-NEXT:      function.def @synth() {
+// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = function.call @FRT::@free_ret() : () -> !felt.type<"bn128">
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:    poly.template @ComponentC {
+// CHECK-NEXT:      struct.def @ComponentC {
+// CHECK-NEXT:        function.def @compute() -> !struct.type<@ComponentC::@ComponentC<[]>> attributes {function.allow_witness} {
+// CHECK-NEXT:          %[[VAL_2:[0-9a-zA-Z_\.]+]] = struct.new : <@ComponentC::@ComponentC<[]>>
+// CHECK-NEXT:          function.call @synth::@synth<[?]>() : () -> ()
+// CHECK-NEXT:          function.return %[[VAL_2]] : !struct.type<@ComponentC::@ComponentC<[]>>
+// CHECK-NEXT:        }
+// CHECK-NEXT:        function.def @constrain(%[[VAL_3:[0-9a-zA-Z_\.]+]]: !struct.type<@ComponentC::@ComponentC<[]>>) attributes {function.allow_constraint} {
+// CHECK-NEXT:          function.return
+// CHECK-NEXT:        }
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }
+// -----
+
+module attributes {llzk.lang} {
+  poly.template @TBoxForWildcardName {
+    poly.param @N
+    poly.param @T : !poly.tvar<@T>
+
+    struct.def @Box {
+      struct.member @value : !poly.tvar<@T>
+
+      function.def @product(%arg: !poly.tvar<@T>) -> !struct.type<@TBoxForWildcardName::@Box<[@N, @T]>> attributes {function.allow_witness} {
+        %self = struct.new : !struct.type<@TBoxForWildcardName::@Box<[@N, @T]>>
+        struct.writem %self[@value] = %arg : !struct.type<@TBoxForWildcardName::@Box<[@N, @T]>>, !poly.tvar<@T>
+        function.return %self : !struct.type<@TBoxForWildcardName::@Box<[@N, @T]>>
+      }
+    }
+  }
+
+  struct.def @WildcardNameTarget {
+    function.def @compute(%arg: !array.type<? x !struct.type<@TBoxForWildcardName::@Box<[7, index]>>>) -> !struct.type<@WildcardNameTarget> {
+      %self = struct.new : !struct.type<@WildcardNameTarget>
+      function.return %self : !struct.type<@WildcardNameTarget>
+    }
+
+    function.def @constrain(%self: !struct.type<@WildcardNameTarget>, %arg: !array.type<? x !struct.type<@TBoxForWildcardName::@Box<[7, index]>>>) {
+      function.return
+    }
+  }
+
+  function.def @call_box_array(%arg: !array.type<1 x !struct.type<@TBoxForWildcardName::@Box<[7, index]>>>) -> index attributes {function.allow_witness} {
+    %0 = function.call @WildcardNameTarget::@compute(%arg) :
+        (!array.type<1 x !struct.type<@TBoxForWildcardName::@Box<[7, index]>>>) -> !struct.type<@WildcardNameTarget>
+    %one = arith.constant 1 : index
+    function.return %one : index
+  }
+}
+// CHECK-LABEL: module attributes {llzk.lang} {
+// CHECK-NEXT:    poly.template @"TBoxForWildcardName_\1A_i" {
+// CHECK-NEXT:      poly.param @N
+// CHECK-NEXT:      struct.def @Box {
+// CHECK-NEXT:        struct.member @value : index
+// CHECK-NEXT:        function.def @product(%[[VAL_0:[0-9a-zA-Z_\.]+]]: index) -> !struct.type<@"TBoxForWildcardName_\1A_i"::@Box<[@N]>> attributes {function.allow_constraint, function.allow_witness} {
+// CHECK-NEXT:          %[[VAL_1:[0-9a-zA-Z_\.]+]] = struct.new : <@"TBoxForWildcardName_\1A_i"::@Box<[@N]>>
+// CHECK-NEXT:          struct.writem %[[VAL_1]][@value] = %[[VAL_0]] : <@"TBoxForWildcardName_\1A_i"::@Box<[@N]>>, index
+// CHECK-NEXT:          function.return %[[VAL_1]] : !struct.type<@"TBoxForWildcardName_\1A_i"::@Box<[@N]>>
+// CHECK-NEXT:        }
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:    poly.template @TBoxForWildcardName {
+// CHECK-NEXT:      poly.param @N
+// CHECK-NEXT:      poly.param @T : !poly.tvar<@T>
+// CHECK-NEXT:      struct.def @Box {
+// CHECK-NEXT:        struct.member @value : !poly.tvar<@T>
+// CHECK-NEXT:        function.def @product(%[[VAL_2:[0-9a-zA-Z_\.]+]]: !poly.tvar<@T>) -> !struct.type<@TBoxForWildcardName::@Box<[@N, @T]>> attributes {function.allow_constraint, function.allow_witness} {
+// CHECK-NEXT:          %[[VAL_3:[0-9a-zA-Z_\.]+]] = struct.new : <@TBoxForWildcardName::@Box<[@N, @T]>>
+// CHECK-NEXT:          struct.writem %[[VAL_3]][@value] = %[[VAL_2]] : <@TBoxForWildcardName::@Box<[@N, @T]>>, !poly.tvar<@T>
+// CHECK-NEXT:          function.return %[[VAL_3]] : !struct.type<@TBoxForWildcardName::@Box<[@N, @T]>>
+// CHECK-NEXT:        }
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:    struct.def @"WildcardNameTarget_!a<!s<@TBoxForWildcardName_\1A_i::@Box_7>:1>" {
+// CHECK-NEXT:      function.def @compute(%[[VAL_4:[0-9a-zA-Z_\.]+]]: !array.type<1 x !struct.type<@"TBoxForWildcardName_\1A_i"::@Box<[7]>>>) -> !struct.type<@"WildcardNameTarget_!a<!s<@TBoxForWildcardName_\1A_i::@Box_7>:1>"> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = struct.new : <@"WildcardNameTarget_!a<!s<@TBoxForWildcardName_\1A_i::@Box_7>:1>">
+// CHECK-NEXT:        function.return %[[VAL_5]] : !struct.type<@"WildcardNameTarget_!a<!s<@TBoxForWildcardName_\1A_i::@Box_7>:1>">
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.def @constrain(%[[VAL_6:[0-9a-zA-Z_\.]+]]: !struct.type<@"WildcardNameTarget_!a<!s<@TBoxForWildcardName_\1A_i::@Box_7>:1>">, %[[VAL_7:[0-9a-zA-Z_\.]+]]: !array.type<1 x !struct.type<@"TBoxForWildcardName_\1A_i"::@Box<[7]>>>) attributes {function.allow_constraint} {
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:    function.def @call_box_array(%[[VAL_8:[0-9a-zA-Z_\.]+]]: !array.type<1 x !struct.type<@"TBoxForWildcardName_\1A_i"::@Box<[7]>>>) -> index attributes {function.allow_witness} {
+// CHECK-NEXT:      %[[VAL_9:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:      %[[VAL_10:[0-9a-zA-Z_\.]+]] = function.call @"WildcardNameTarget_!a<!s<@TBoxForWildcardName_\1A_i::@Box_7>:1>"::@compute(%[[VAL_8]]) : (!array.type<1 x !struct.type<@"TBoxForWildcardName_\1A_i"::@Box<[7]>>>) -> !struct.type<@"WildcardNameTarget_!a<!s<@TBoxForWildcardName_\1A_i::@Box_7>:1>">
+// CHECK-NEXT:      function.return %[[VAL_9]] : index
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/test/Transforms/PlaceholderSanity/infer_tvar_and_wildcard_and_flatten.llzk
+++ b/test/Transforms/PlaceholderSanity/infer_tvar_and_wildcard_and_flatten.llzk
@@ -1,0 +1,72 @@
+// RUN: llzk-opt -split-input-file -llzk-infer-tvar -llzk-specialize-wildcard-arrays -llzk-flatten -verify-diagnostics %s | FileCheck --enable-var-scope %s
+
+module attributes {llzk.lang} {
+  poly.template @TBoxForWildcardName {
+    poly.param @N
+    poly.param @T : !poly.tvar<@T>
+
+    struct.def @Box {
+      struct.member @value : !poly.tvar<@T>
+
+      function.def @product(%arg: !poly.tvar<@T>) -> !struct.type<@TBoxForWildcardName::@Box<[@N, @T]>> attributes {function.allow_witness} {
+        %self = struct.new : !struct.type<@TBoxForWildcardName::@Box<[@N, @T]>>
+        struct.writem %self[@value] = %arg : !struct.type<@TBoxForWildcardName::@Box<[@N, @T]>>, !poly.tvar<@T>
+        function.return %self : !struct.type<@TBoxForWildcardName::@Box<[@N, @T]>>
+      }
+    }
+  }
+
+  struct.def @WildcardNameTarget {
+    function.def @compute(%arg: !array.type<? x !struct.type<@TBoxForWildcardName::@Box<[7, index]>>>) -> !struct.type<@WildcardNameTarget> {
+      %self = struct.new : !struct.type<@WildcardNameTarget>
+      function.return %self : !struct.type<@WildcardNameTarget>
+    }
+
+    function.def @constrain(%self: !struct.type<@WildcardNameTarget>, %arg: !array.type<? x !struct.type<@TBoxForWildcardName::@Box<[7, index]>>>) {
+      function.return
+    }
+  }
+
+  function.def @call_box_array(%arg: !array.type<1 x !struct.type<@TBoxForWildcardName::@Box<[7, index]>>>) -> index attributes {function.allow_witness} {
+    %0 = function.call @WildcardNameTarget::@compute(%arg) :
+        (!array.type<1 x !struct.type<@TBoxForWildcardName::@Box<[7, index]>>>) -> !struct.type<@WildcardNameTarget>
+    %one = arith.constant 1 : index
+    function.return %one : index
+  }
+}
+// CHECK-LABEL: module attributes {llzk.lang} {
+// CHECK-NEXT:    struct.def @TBoxForWildcardName_7_i_Box {
+// CHECK-NEXT:      struct.member @value : index
+// CHECK-NEXT:      function.def @product(%[[VAL_0:[0-9a-zA-Z_\.]+]]: index) -> !struct.type<@TBoxForWildcardName_7_i_Box> attributes {function.allow_constraint, function.allow_witness} {
+// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = struct.new : <@TBoxForWildcardName_7_i_Box>
+// CHECK-NEXT:        struct.writem %[[VAL_1]][@value] = %[[VAL_0]] : <@TBoxForWildcardName_7_i_Box>, index
+// CHECK-NEXT:        function.return %[[VAL_1]] : !struct.type<@TBoxForWildcardName_7_i_Box>
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:    poly.template @TBoxForWildcardName {
+// CHECK-NEXT:      poly.param @N
+// CHECK-NEXT:      poly.param @T : !poly.tvar<@T>
+// CHECK-NEXT:      struct.def @Box {
+// CHECK-NEXT:        struct.member @value : !poly.tvar<@T>
+// CHECK-NEXT:        function.def @product(%[[VAL_2:[0-9a-zA-Z_\.]+]]: !poly.tvar<@T>) -> !struct.type<@TBoxForWildcardName::@Box<[@N, @T]>> attributes {function.allow_constraint, function.allow_witness} {
+// CHECK-NEXT:          %[[VAL_3:[0-9a-zA-Z_\.]+]] = struct.new : <@TBoxForWildcardName::@Box<[@N, @T]>>
+// CHECK-NEXT:          struct.writem %[[VAL_3]][@value] = %[[VAL_2]] : <@TBoxForWildcardName::@Box<[@N, @T]>>, !poly.tvar<@T>
+// CHECK-NEXT:          function.return %[[VAL_3]] : !struct.type<@TBoxForWildcardName::@Box<[@N, @T]>>
+// CHECK-NEXT:        }
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:    struct.def @"WildcardNameTarget_!a<!s<@TBoxForWildcardName_\1A_i::@Box_7>:1>" {
+// CHECK-NEXT:      function.def @compute(%[[VAL_4:[0-9a-zA-Z_\.]+]]: !array.type<1 x !struct.type<@TBoxForWildcardName_7_i_Box>>) -> !struct.type<@"WildcardNameTarget_!a<!s<@TBoxForWildcardName_\1A_i::@Box_7>:1>"> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = struct.new : <@"WildcardNameTarget_!a<!s<@TBoxForWildcardName_\1A_i::@Box_7>:1>">
+// CHECK-NEXT:        function.return %[[VAL_5]] : !struct.type<@"WildcardNameTarget_!a<!s<@TBoxForWildcardName_\1A_i::@Box_7>:1>">
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.def @constrain(%[[VAL_6:[0-9a-zA-Z_\.]+]]: !struct.type<@"WildcardNameTarget_!a<!s<@TBoxForWildcardName_\1A_i::@Box_7>:1>">, %[[VAL_7:[0-9a-zA-Z_\.]+]]: !array.type<1 x !struct.type<@TBoxForWildcardName_7_i_Box>>) attributes {function.allow_constraint} {
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:    function.def @call_box_array(%[[VAL_8:[0-9a-zA-Z_\.]+]]: !array.type<1 x !struct.type<@TBoxForWildcardName_7_i_Box>>) -> index attributes {function.allow_witness} {
+// CHECK-NEXT:      %[[VAL_9:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:      %[[VAL_10:[0-9a-zA-Z_\.]+]] = function.call @"WildcardNameTarget_!a<!s<@TBoxForWildcardName_\1A_i::@Box_7>:1>"::@compute(%[[VAL_8]]) : (!array.type<1 x !struct.type<@TBoxForWildcardName_7_i_Box>>) -> !struct.type<@"WildcardNameTarget_!a<!s<@TBoxForWildcardName_\1A_i::@Box_7>:1>">
+// CHECK-NEXT:      function.return %[[VAL_9]] : index
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/test/Transforms/PlaceholderSanity/placeholder_in_source.llzk
+++ b/test/Transforms/PlaceholderSanity/placeholder_in_source.llzk
@@ -1,0 +1,29 @@
+// RUN: llzk-opt -split-input-file -llzk-flatten %s | FileCheck --enable-var-scope %s
+// XFAIL:*
+
+#id = affine_map<(i)->(i)>
+module attributes {llzk.lang, llzk.main = !struct.type<@"A_\1A_B_\1A_C_\1A_D_\1A_E_\1A_F"::@Zip<[!felt.type, !felt.type, 4]>>} {
+  poly.template @"A_\1A_B_\1A_C_\1A_D_\1A_E_\1A_F" {
+    poly.param @Lhs
+    poly.param @Rhs
+    poly.param @N
+
+    struct.def @Zip {
+      struct.member @"$array" : !array.type<#id x !felt.type>
+
+      function.def @compute() -> !struct.type<@"A_\1A_B_\1A_C_\1A_D_\1A_E_\1A_F"::@Zip<[@Lhs, @Rhs, @N]>> {
+        %self = struct.new : !struct.type<@"A_\1A_B_\1A_C_\1A_D_\1A_E_\1A_F"::@Zip<[@Lhs, @Rhs, @N]>>
+        %1 = poly.read_const @N : index
+        %array = array.new{(%1)[]} : !array.type<#id x !felt.type>
+        struct.writem %self[@"$array"] = %array : !struct.type<@"A_\1A_B_\1A_C_\1A_D_\1A_E_\1A_F"::@Zip<[@Lhs, @Rhs, @N]>>, !array.type<#id x !felt.type>
+        function.return %self : !struct.type<@"A_\1A_B_\1A_C_\1A_D_\1A_E_\1A_F"::@Zip<[@Lhs, @Rhs, @N]>>
+      }
+
+      function.def @constrain(%arg0: !struct.type<@"A_\1A_B_\1A_C_\1A_D_\1A_E_\1A_F"::@Zip<[@Lhs, @Rhs, @N]>>) {
+        %1 = poly.read_const @N : index
+        %array = array.new{(%1)[]} : <#id x !felt.type>
+        function.return
+      }
+    }
+  }
+}


### PR DESCRIPTION
The new tests exercise scenarios where the `PLACEHOLDER` char is added by one pass and then replaced with an instantiated attribute value in a later pass. These scenarios must be treated differently than pre-existing `PLACEHOLDER` occurrences from the input IR.
Also adds a test where the `PLACEHOLDER` character appears in the input IR which currently causes an assertion when the flattening pass is run. This test motivates the need to sanitization of input IR or a different means to handle the job of the `PLACEHOLDER`.