### PR TITLE
SourceRef and lattice primitives

### DIFF
--- a/changelogs/unreleased/codex__circom-analysis-1-primitives.yaml
+++ b/changelogs/unreleased/codex__circom-analysis-1-primitives.yaml
@@ -1,0 +1,2 @@
+fixed:
+  - Preserve aggregate SourceRef lattice shape and support precise element and prefix updates

--- a/include/llzk/Analysis/SourceRef.h
+++ b/include/llzk/Analysis/SourceRef.h
@@ -389,7 +389,7 @@ public:
   }
   llvm::ArrayRef<SourceRefIndex> getPath() const { return path; }
 
-  /// Print this reference using source-style names. The first argument of a
+  /// Print this reference using source-style names. The entry self argument of a
   /// struct constrain function is printed as `%self`.
   void print(mlir::raw_ostream &os) const;
   void dump() const { print(llvm::errs()); }

--- a/include/llzk/Analysis/SourceRef.h
+++ b/include/llzk/Analysis/SourceRef.h
@@ -239,6 +239,7 @@ public:
     return isConstant() &&
            llvm::isa_and_present<mlir::arith::ConstantIndexOp>(value.getDefiningOp());
   }
+  /// Return whether this reference originates from a template constant read.
   bool isTemplateConstant() const {
     return isConstant() && llvm::isa_and_present<polymorphic::ConstReadOp>(value.getDefiningOp());
   }
@@ -255,6 +256,7 @@ public:
   }
 
   bool isRooted() const { return !constant; }
+
   bool isBlockArgument() const { return isRooted() && llvm::isa<mlir::BlockArgument>(value); }
   mlir::FailureOr<mlir::Value> getRoot() const {
     if (isRooted()) {
@@ -326,6 +328,15 @@ public:
   /// Return true when both references select overlapping storage at the same path depth.
   bool overlaps(const SourceRef &rhs) const;
 
+  /// Return a copy with ranged array indices narrowed by concrete indices from `rhs`.
+  ///
+  /// Array indices are paired by dimension order; member and POD-record path components are
+  /// ignored when pairing dimensions. A range is replaced only when the corresponding component
+  /// in `rhs` is a concrete index contained in that range. Other path components remain unchanged.
+  /// For example, narrowing `%self.out[0:4].values[0:8]` with `%arg0[2][5]` produces
+  /// `%self.out[2].values[5]`.
+  SourceRef narrowRanges(const SourceRef &rhs) const;
+
   /// @brief If `prefix` is a valid prefix of this reference, return the suffix that
   /// remains after removing the prefix. I.e., `this` = `prefix` + `suffix`
   /// @param prefix
@@ -378,6 +389,8 @@ public:
   }
   llvm::ArrayRef<SourceRefIndex> getPath() const { return path; }
 
+  /// Print this reference using source-style names. The first argument of a
+  /// struct constrain function is printed as `%self`.
   void print(mlir::raw_ostream &os) const;
   void dump() const { print(llvm::errs()); }
 

--- a/include/llzk/Analysis/SourceRefLattice.h
+++ b/include/llzk/Analysis/SourceRefLattice.h
@@ -56,15 +56,36 @@ public:
     return *getScalarValue().begin();
   }
 
+  /// Return the dimensions of this array-shaped value.
+  using Base::getArrayShape;
+
   /// @brief Directly insert the ref into this value. If this is a scalar value,
   /// insert the ref into the value's set. If this is an array value, the array
   /// is folded into a single scalar, then the ref is inserted.
   mlir::ChangeResult insert(const SourceRef &rhs);
 
-  /// @brief For the refs contained in this value, translate them given the `translation`
-  /// map and return the transformed value.
+  /// @brief Remove `ref` from this value's reference set or, for an array, from every element.
+  mlir::ChangeResult remove(const SourceRef &ref);
+
+  /// @brief Translate contained references using `translation` and return the transformed value.
+  ///
+  /// References that do not match a prefix in `translation` are discarded.
   std::pair<SourceRefLatticeValue, mlir::ChangeResult>
   translate(const TranslationMap &translation) const;
+
+  /// @brief Replace matching SourceRef prefixes and leave unmatched references unchanged.
+  std::pair<SourceRefLatticeValue, mlir::ChangeResult>
+  replacePrefixes(const TranslationMap &translation) const;
+
+  /// @brief Update the element or subarray selected by `indices`.
+  ///
+  /// When `joinWithExisting` is true, the selected values are conservatively joined with `rhs`;
+  /// otherwise they are replaced. A ranged index always joins because any individual selected
+  /// element may retain its old value.
+  mlir::ChangeResult write(
+      const std::vector<SourceRefIndex> &indices, const SourceRefLatticeValue &rhs,
+      bool joinWithExisting = false
+  );
 
   /// @brief Add the given `memberRef` to the `SourceRef`s contained within this value.
   /// For example, if `memberRef` is a member reference `@foo` and this value represents `%self`,
@@ -90,6 +111,9 @@ protected:
   /// @brief Translate this value using the translation map, assuming this value
   /// is a scalar.
   mlir::ChangeResult translateScalar(const TranslationMap &translation);
+
+  /// @brief Replace matching prefixes in a scalar value without dropping unmatched references.
+  mlir::ChangeResult replacePrefixesScalar(const TranslationMap &translation);
 
   /// @brief Perform a recursive transformation over all elements of this value and
   /// return a new value with the modifications.

--- a/include/llzk/Util/Compare.h
+++ b/include/llzk/Util/Compare.h
@@ -46,6 +46,11 @@ struct LocationComparator {
   }
 };
 
+/// Compare the source locations of two operations.
+///
+/// Returns failure unless both operations have `FileLineColLoc` locations. A successful `false`
+/// result means only that `l` is not before `r`; the locations may be equal. This comparison is
+/// therefore not a total order.
 template <OpComparable Op> mlir::FailureOr<bool> isLocationLess(const Op &l, const Op &r) {
   mlir::Location lhsLoc = l->getLoc(), rhsLoc = r->getLoc();
   // We cannot make judgments on unknown locations.
@@ -65,11 +70,19 @@ template <OpComparable Op> struct OpLocationLess {
   bool operator()(const Op &l, const Op &r) const { return isLocationLess(l, r).value_or(false); }
 };
 
+/// Order named operations by source location, using the symbol name to break ties or when source
+/// locations cannot be compared.
 template <NamedOpComparable Op> struct NamedOpLocationLess {
   bool operator()(const Op &l, const Op &r) const {
     auto res = isLocationLess(l, r);
-    if (mlir::succeeded(res)) {
-      return res.value();
+    auto reverseRes = isLocationLess(r, l);
+    // A successful false result may mean either equal locations or that the operands are reversed.
+    // Check both directions before using the symbol name as the deterministic tie-breaker.
+    if (mlir::succeeded(res) && res.value()) {
+      return true;
+    }
+    if (mlir::succeeded(reverseRes) && reverseRes.value()) {
+      return false;
     }
 
     Op &lhs = const_cast<Op &>(l);

--- a/lib/Analysis/SourceRef.cpp
+++ b/lib/Analysis/SourceRef.cpp
@@ -394,11 +394,13 @@ bool SourceRef::overlaps(const SourceRef &rhs) const {
       return func->getParentOfType<StructDefOp>();
     }
     auto blockArg = ref.getBlockArgument();
-    if (failed(blockArg) || blockArg->getArgNumber() != 0) {
+    if (failed(blockArg)) {
       return nullptr;
     }
     auto func = dyn_cast_if_present<FuncDefOp>(blockArg->getOwner()->getParentOp());
-    return func && func.isStructConstrain() ? func->getParentOfType<StructDefOp>() : nullptr;
+    return func && func.isStructConstrain() && func.getSelfValueFromConstrain() == *blockArg
+               ? func->getParentOfType<StructDefOp>()
+               : nullptr;
   };
   bool sameRoot = value == rhs.value;
   if (!sameRoot) {

--- a/lib/Analysis/SourceRef.cpp
+++ b/lib/Analysis/SourceRef.cpp
@@ -385,12 +385,50 @@ bool SourceRef::isValidPrefix(const SourceRef &prefix) const {
 }
 
 bool SourceRef::overlaps(const SourceRef &rhs) const {
-  if (isConstant() || rhs.isConstant() || value != rhs.value || path.size() != rhs.path.size()) {
+  auto getSelfStruct = [](const SourceRef &ref) -> StructDefOp {
+    if (ref.isCreateStructOp()) {
+      return ref.value.getDefiningOp()->getParentOfType<StructDefOp>();
+    }
+    auto blockArg = ref.getBlockArgument();
+    if (failed(blockArg) || blockArg->getArgNumber() != 0) {
+      return nullptr;
+    }
+    auto func = dyn_cast_if_present<FuncDefOp>(blockArg->getOwner()->getParentOp());
+    return func && func.isStructConstrain() ? func->getParentOfType<StructDefOp>() : nullptr;
+  };
+  bool sameRoot = value == rhs.value;
+  if (!sameRoot) {
+    StructDefOp lhsStruct = getSelfStruct(*this);
+    StructDefOp rhsStruct = getSelfStruct(rhs);
+    sameRoot = lhsStruct && lhsStruct == rhsStruct;
+  }
+  if (isConstant() || rhs.isConstant() || !sameRoot || path.size() != rhs.path.size()) {
     return false;
   }
   return llvm::all_of(llvm::zip(path, rhs.path), [](const auto &indices) {
     return std::get<0>(indices).overlaps(std::get<1>(indices));
   });
+}
+
+SourceRef SourceRef::narrowRanges(const SourceRef &rhs) const {
+  llvm::SmallVector<SourceRefIndex> selections;
+  llvm::copy_if(rhs.getPath(), std::back_inserter(selections), [](const SourceRefIndex &index) {
+    return index.isIndex() || index.isIndexRange();
+  });
+
+  SourceRef result = *this;
+  size_t dimension = 0;
+  for (SourceRefIndex &index : result.getPathMut()) {
+    if (!index.isIndex() && !index.isIndexRange()) {
+      continue;
+    }
+    if (dimension < selections.size() && index.isIndexRange() && selections[dimension].isIndex() &&
+        index.overlaps(selections[dimension])) {
+      index = selections[dimension];
+    }
+    ++dimension;
+  }
+  return result;
 }
 
 FailureOr<SourceRef::Path> SourceRef::getSuffix(const SourceRef &prefix) const {
@@ -564,11 +602,20 @@ void SourceRef::print(raw_ostream &os) const {
     } else if (isBlockArgument()) {
       auto blockArg = *getBlockArgument();
       auto funcOp = llvm::dyn_cast<FuncDefOp>(blockArg.getOwner()->getParentOp());
-      auto argName = funcOp ? funcOp.getArgNameAttr(blockArg.getArgNumber()) : nullptr;
-      if (argName) {
-        os << argName->getValue();
+      // The first argument of a struct constrain function is its self value,
+      // matching the struct value returned by the corresponding compute function.
+      if (funcOp && funcOp.isStructConstrain() && blockArg.getArgNumber() == 0) {
+        os << "%self";
       } else {
-        os << "%arg" << *getInputNum();
+        std::optional<StringAttr> argName;
+        if (funcOp) {
+          argName = funcOp.getArgNameAttr(blockArg.getArgNumber());
+        }
+        if (argName) {
+          os << argName->getValue();
+        } else {
+          os << "%arg" << *getInputNum();
+        }
       }
     } else if (isNonDetOp()) {
       os << '<' << *getNonDetOp() << '>';

--- a/lib/Analysis/SourceRef.cpp
+++ b/lib/Analysis/SourceRef.cpp
@@ -386,8 +386,12 @@ bool SourceRef::isValidPrefix(const SourceRef &prefix) const {
 
 bool SourceRef::overlaps(const SourceRef &rhs) const {
   auto getSelfStruct = [](const SourceRef &ref) -> StructDefOp {
-    if (ref.isCreateStructOp()) {
-      return ref.value.getDefiningOp()->getParentOfType<StructDefOp>();
+    if (auto createOp = dyn_cast_if_present<CreateStructOp>(ref.value.getDefiningOp())) {
+      auto func = createOp->getParentOfType<FuncDefOp>();
+      if (!func || !func.isStructCompute() || func.getSelfValueFromCompute() != ref.value) {
+        return nullptr;
+      }
+      return func->getParentOfType<StructDefOp>();
     }
     auto blockArg = ref.getBlockArgument();
     if (failed(blockArg) || blockArg->getArgNumber() != 0) {

--- a/lib/Analysis/SourceRef.cpp
+++ b/lib/Analysis/SourceRef.cpp
@@ -608,9 +608,9 @@ void SourceRef::print(raw_ostream &os) const {
     } else if (isBlockArgument()) {
       auto blockArg = *getBlockArgument();
       auto funcOp = llvm::dyn_cast<FuncDefOp>(blockArg.getOwner()->getParentOp());
-      // The first argument of a struct constrain function is its self value,
-      // matching the struct value returned by the corresponding compute function.
-      if (funcOp && funcOp.isStructConstrain() && blockArg.getArgNumber() == 0) {
+      // The entry self argument of a struct constrain function matches the struct value
+      // returned by the corresponding compute function.
+      if (funcOp && funcOp.isStructConstrain() && funcOp.getSelfValueFromConstrain() == blockArg) {
         os << "%self";
       } else {
         std::optional<StringAttr> argName;

--- a/lib/Analysis/SourceRefLattice.cpp
+++ b/lib/Analysis/SourceRefLattice.cpp
@@ -126,12 +126,15 @@ mlir::ChangeResult SourceRefLatticeValue::write(
     selected = std::move(next);
   }
 
+  ArrayRef<int64_t> selectedShape(getArrayShape());
+  selectedShape = selectedShape.drop_front(indices.size());
   size_t chunkSize = 1;
-  for (size_t dimIdx = indices.size(); dimIdx < getNumArrayDims(); ++dimIdx) {
-    chunkSize *= getArrayDim(dimIdx);
+  for (int64_t dim : selectedShape) {
+    chunkSize *= static_cast<size_t>(dim);
   }
   ensure(
-      (chunkSize == 1 && rhs.isScalar()) || (rhs.isArray() && rhs.getArraySize() == chunkSize),
+      (selectedShape.empty() && rhs.isScalar()) ||
+          (rhs.isArray() && ArrayRef<int64_t>(rhs.getArrayShape()) == selectedShape),
       "SourceRef array write value shape does not match selected storage"
   );
 

--- a/lib/Analysis/SourceRefLattice.cpp
+++ b/lib/Analysis/SourceRefLattice.cpp
@@ -13,6 +13,7 @@
 #include "llzk/Dialect/Array/IR/Ops.h"
 #include "llzk/Dialect/Felt/IR/Ops.h"
 #include "llzk/Dialect/Function/IR/Ops.h"
+#include "llzk/Dialect/Global/IR/Ops.h"
 #include "llzk/Dialect/POD/IR/Ops.h"
 #include "llzk/Util/Hash.h"
 #include "llzk/Util/SymbolHelper.h"
@@ -48,6 +49,19 @@ mlir::ChangeResult SourceRefLatticeValue::insert(const SourceRef &rhs) {
   }
 }
 
+mlir::ChangeResult SourceRefLatticeValue::remove(const SourceRef &ref) {
+  if (isScalar()) {
+    return getScalarValue().erase(ref) != 0 ? mlir::ChangeResult::Change
+                                            : mlir::ChangeResult::NoChange;
+  }
+
+  mlir::ChangeResult changed = mlir::ChangeResult::NoChange;
+  for (auto &element : getArrayValue()) {
+    changed |= element->remove(ref);
+  }
+  return changed;
+}
+
 std::pair<SourceRefLatticeValue, mlir::ChangeResult>
 SourceRefLatticeValue::translate(const TranslationMap &translation) const {
   auto newVal = *this;
@@ -62,6 +76,75 @@ SourceRefLatticeValue::translate(const TranslationMap &translation) const {
     }
   }
   return {newVal, res};
+}
+
+std::pair<SourceRefLatticeValue, mlir::ChangeResult>
+SourceRefLatticeValue::replacePrefixes(const TranslationMap &translation) const {
+  auto newVal = *this;
+  auto res = mlir::ChangeResult::NoChange;
+  if (newVal.isScalar()) {
+    res = newVal.replacePrefixesScalar(translation);
+  } else {
+    for (auto &elem : newVal.getArrayValue()) {
+      auto [newElem, elemRes] = elem->replacePrefixes(translation);
+      *elem = std::move(newElem);
+      res |= elemRes;
+    }
+  }
+  return {newVal, res};
+}
+
+mlir::ChangeResult SourceRefLatticeValue::write(
+    const std::vector<SourceRefIndex> &indices, const SourceRefLatticeValue &rhs,
+    bool joinWithExisting
+) {
+  ensure(isArray(), "SourceRef array write requires an array-shaped value");
+  ensure(indices.size() <= getNumArrayDims(), "invalid SourceRef array write indices");
+
+  std::vector<size_t> selected {0};
+  bool hasRangedIndex = false;
+  for (unsigned dimIdx = 0; dimIdx < indices.size(); ++dimIdx) {
+    const SourceRefIndex &idx = indices[dimIdx];
+    const int64_t dim = getArrayDim(dimIdx);
+    std::vector<size_t> next;
+    if (idx.isIndex()) {
+      const int64_t indexValue(idx.getIndex());
+      for (size_t prefix : selected) {
+        next.push_back(prefix * dim + indexValue);
+      }
+    } else {
+      ensure(idx.isIndexRange(), "wrong type of index for SourceRef array write");
+      hasRangedIndex = true;
+      auto [low, high] = idx.getIndexRange();
+      const int64_t lowValue(low), highValue(high);
+      for (int64_t indexValue = lowValue; indexValue < highValue; ++indexValue) {
+        for (size_t prefix : selected) {
+          next.push_back(prefix * dim + indexValue);
+        }
+      }
+    }
+    selected = std::move(next);
+  }
+
+  size_t chunkSize = 1;
+  for (size_t dimIdx = indices.size(); dimIdx < getNumArrayDims(); ++dimIdx) {
+    chunkSize *= getArrayDim(dimIdx);
+  }
+  ensure(
+      (chunkSize == 1 && rhs.isScalar()) || (rhs.isArray() && rhs.getArraySize() == chunkSize),
+      "SourceRef array write value shape does not match selected storage"
+  );
+
+  ChangeResult changed = ChangeResult::NoChange;
+  const bool join = joinWithExisting || hasRangedIndex || selected.size() > 1;
+  for (size_t chunkStart : selected) {
+    for (size_t offset = 0; offset < chunkSize; ++offset) {
+      SourceRefLatticeValue &dest = getElemFlatIdx(chunkStart * chunkSize + offset);
+      const SourceRefLatticeValue &source = rhs.isScalar() ? rhs : rhs.getElemFlatIdx(offset);
+      changed |= join ? dest.update(source) : dest.setValue(source);
+    }
+  }
+  return changed;
 }
 
 mlir::FailureOr<std::pair<SourceRefLatticeValue, mlir::ChangeResult>>
@@ -133,7 +216,7 @@ SourceRefLatticeValue::extract(const std::vector<SourceRefIndex> &indices) const
       SourceRefLatticeValue extractedVal(newArrayDims);
       for (auto chunkStart : currIdxs) {
         for (size_t i = 0; i < chunkSz; i++) {
-          (void)extractedVal.getElemFlatIdx(i).update(getElemFlatIdx(chunkStart + i));
+          (void)extractedVal.getElemFlatIdx(i).update(getElemFlatIdx(chunkStart * chunkSz + i));
         }
       }
       return std::make_pair(extractedVal, mlir::ChangeResult::Change);
@@ -179,6 +262,34 @@ mlir::ChangeResult SourceRefLatticeValue::translateScalar(const TranslationMap &
     }
   }
   return res;
+}
+
+mlir::ChangeResult SourceRefLatticeValue::replacePrefixesScalar(const TranslationMap &translation) {
+  const ScalarTy current = getScalarValue();
+  ScalarTy replaced;
+  for (const SourceRef &currentRef : current) {
+    bool matched = false;
+    for (const auto &[prefix, replacementVal] : translation) {
+      if (!currentRef.isValidPrefix(prefix)) {
+        continue;
+      }
+      matched = true;
+      for (const SourceRef &replacementPrefix : replacementVal.foldToScalar()) {
+        auto translated = currentRef.translate(prefix, replacementPrefix);
+        if (succeeded(translated)) {
+          replaced.insert(*translated);
+        }
+      }
+    }
+    if (!matched) {
+      replaced.insert(currentRef);
+    }
+  }
+  if (replaced == current) {
+    return ChangeResult::NoChange;
+  }
+  getValue() = std::move(replaced);
+  return ChangeResult::Change;
 }
 
 mlir::FailureOr<std::pair<SourceRefLatticeValue, mlir::ChangeResult>>
@@ -235,6 +346,8 @@ mlir::FailureOr<SourceRef> SourceRefLattice::getSourceRef(mlir::Value val) {
       return SourceRef(structNew);
     } else if (auto nonDet = llvm::dyn_cast<NonDetOp>(defOp)) {
       return SourceRef(nonDet);
+    } else if (llvm::isa<global::GlobalReadOp>(defOp)) {
+      return SourceRef(llvm::cast<mlir::OpResult>(val));
     } else if (auto createArray = llvm::dyn_cast<CreateArrayOp>(defOp)) {
       return SourceRef(createArray->getResult(0));
     } else if (auto newPod = llvm::dyn_cast<NewPodOp>(defOp)) {
@@ -259,7 +372,18 @@ SourceRefLatticeValue SourceRefLattice::getDefaultValue(SourceRefLattice::ValueT
 }
 
 ChangeResult SourceRefLattice::join(const AbstractSparseLattice &rhs) {
-  return value.update(static_cast<const SourceRefLattice &>(rhs).value);
+  const auto &rhsValue = static_cast<const SourceRefLattice &>(rhs).value;
+  // Region-branch block arguments and results start with an empty scalar state (bottom) so their
+  // identity can come from incoming values. Do not let a join with bottom fold an array to a
+  // scalar, regardless of which side was initialized first. Preserving the shape is necessary
+  // for element-sensitive reads after an scf.for/scf.while join.
+  if (rhsValue.isScalar() && rhsValue.getScalarValue().empty()) {
+    return ChangeResult::NoChange;
+  }
+  if (value.isScalar() && value.getScalarValue().empty()) {
+    return value.setValue(rhsValue);
+  }
+  return value.update(rhsValue);
 }
 
 ChangeResult SourceRefLattice::meet(const AbstractSparseLattice & /*rhs*/) {

--- a/test/Analysis/constraint_dependency_graph_pass.llzk
+++ b/test/Analysis/constraint_dependency_graph_pass.llzk
@@ -45,10 +45,10 @@ module attributes {llzk.lang} {
 }
 
 // CHECK-LABEL: @Adder ConstraintDependencyGraph {
-// CHECK-NEXT:     { %arg0.sum, %arg1, %arg2 }
+// CHECK-NEXT:     { %self.sum, %arg1, %arg2 }
 // CHECK-NEXT: }
 // INTRA-LABEL: @Adder ConstraintDependencyGraph {
-// INTRA-NEXT:     { %arg0.sum, %arg1, %arg2 }
+// INTRA-NEXT:     { %self.sum, %arg1, %arg2 }
 // INTRA-NEXT: }
 // -----
 
@@ -80,10 +80,10 @@ module attributes {llzk.lang} {
 }
 
 // CHECK-LABEL: @Adder2 ConstraintDependencyGraph {
-// CHECK-NEXT:     { %arg0.sum, %arg1, %arg2 }
+// CHECK-NEXT:     { %self.sum, %arg1, %arg2 }
 // CHECK-NEXT: }
 // INTRA-LABEL: @Adder2 ConstraintDependencyGraph {
-// INTRA-NEXT:     { %arg0.sum, %arg1, %arg2 }
+// INTRA-NEXT:     { %self.sum, %arg1, %arg2 }
 // INTRA-NEXT: }
 // -----
 
@@ -197,17 +197,17 @@ module attributes {llzk.lang} {
 }
 
 // CHECK-LABEL: @Passthrough ConstraintDependencyGraph {
-// CHECK-NEXT:     { %arg0.out, %arg1 }
+// CHECK-NEXT:     { %self.out, %arg1 }
 // CHECK-NEXT: }
 // CHECK-NEXT: @EnsureIsZero ConstraintDependencyGraph {
-// CHECK-NEXT:     { %arg0.p.out, %arg1 },
-// CHECK-NEXT:     { %arg0.p.out, <felt.const: 0> }
+// CHECK-NEXT:     { %self.p.out, %arg1 },
+// CHECK-NEXT:     { %self.p.out, <felt.const: 0> }
 // CHECK-NEXT: }
 // INTRA-LABEL: @Passthrough ConstraintDependencyGraph {
-// INTRA-NEXT:     { %arg0.out, %arg1 }
+// INTRA-NEXT:     { %self.out, %arg1 }
 // INTRA-NEXT: }
 // INTRA-NEXT: @EnsureIsZero ConstraintDependencyGraph {
-// INTRA-NEXT:     { %arg0.p.out, %arg1 }
+// INTRA-NEXT:     { %self.p.out, %arg1 }
 // INTRA-NEXT: }
 // -----
 
@@ -588,7 +588,7 @@ module attributes {llzk.lang} {
 // CHECK-NEXT:     { %arg1[1], <felt.const: 7> }
 // CHECK-NEXT: }
 // CHECK-NEXT: @MatrixConstrain ConstraintDependencyGraph {
-// CHECK-NEXT:     { %arg0.b, <felt.const: 7> }
+// CHECK-NEXT:     { %self.b, <felt.const: 7> }
 // CHECK-NEXT: }
 // INTRA-LABEL: @ArrayConstrain ConstraintDependencyGraph {
 // INTRA-NEXT:     { %arg1[1], <felt.const: 7> }
@@ -686,20 +686,20 @@ module attributes {llzk.lang} {
 
 // CHECK-LABEL: @zir::@risc0::@ValU32 ConstraintDependencyGraph { }
 // CHECK-NEXT: @zir::@risc0::@Reg ConstraintDependencyGraph {
-// CHECK-NEXT:     { %arg0.reg, %arg1 }
+// CHECK-NEXT:     { %self.reg, %arg1 }
 // CHECK-NEXT: }
 // CHECK-NEXT: @zir::@risc0::@Div ConstraintDependencyGraph {
-// CHECK-NEXT:     { %arg0.reciprocal, %arg0.synthetic_return, %arg1, %arg2 },
-// CHECK-NEXT:     { %arg0.reciprocal, <felt.const: 1> },
+// CHECK-NEXT:     { %self.reciprocal, %self.synthetic_return, %arg1, %arg2 },
+// CHECK-NEXT:     { %self.reciprocal, <felt.const: 1> },
 // CHECK-NEXT:     { %arg2, <felt.const: 1> }
 // CHECK-NEXT: }
 // INTRA-LABEL: @zir::@risc0::@ValU32 ConstraintDependencyGraph { }
 // INTRA-NEXT: @zir::@risc0::@Reg ConstraintDependencyGraph {
-// INTRA-NEXT:     { %arg0.reg, %arg1 }
+// INTRA-NEXT:     { %self.reg, %arg1 }
 // INTRA-NEXT: }
 // INTRA-NEXT: @zir::@risc0::@Div ConstraintDependencyGraph {
-// INTRA-NEXT:     { %arg0.reciprocal, %arg0.synthetic_return, %arg1, %arg2 },
-// INTRA-NEXT:     { %arg0.reciprocal, <felt.const: 1> },
+// INTRA-NEXT:     { %self.reciprocal, %self.synthetic_return, %arg1, %arg2 },
+// INTRA-NEXT:     { %self.reciprocal, <felt.const: 1> },
 // INTRA-NEXT:     { %arg2, <felt.const: 1> }
 // INTRA-NEXT: }
 // -----
@@ -710,32 +710,32 @@ module attributes {llzk.lang} {
 
 // CHECK-LABEL: @zir::@std::@risc0::@ValU32 ConstraintDependencyGraph { }
 // CHECK-NEXT: @zir::@std::@risc0::@Reg ConstraintDependencyGraph {
-// CHECK-NEXT:     { %arg0.reg, %arg1 }
+// CHECK-NEXT:     { %self.reg, %arg1 }
 // CHECK-NEXT: }
 // CHECK-NEXT: @zir::@std::@risc0::@Div ConstraintDependencyGraph {
-// CHECK-NEXT:     { %arg0.reciprocal, %arg0.synthetic_return, %arg1, %arg2 },
-// CHECK-NEXT:     { %arg0.reciprocal, <felt.const: 1> },
+// CHECK-NEXT:     { %self.reciprocal, %self.synthetic_return, %arg1, %arg2 },
+// CHECK-NEXT:     { %self.reciprocal, <felt.const: 1> },
 // CHECK-NEXT:     { %arg2, <felt.const: 1> }
 // CHECK-NEXT: }
 // CHECK-NEXT: @zir::@C1 ConstraintDependencyGraph {
-// CHECK-NEXT:     { %arg0.z.reg, %arg1, %arg2 }
+// CHECK-NEXT:     { %self.z.reg, %arg1, %arg2 }
 // CHECK-NEXT: }
 // CHECK-NEXT: @zir::@C2 ConstraintDependencyGraph {
-// CHECK-NEXT:     { %arg0.fc1.z.reg, %arg1.low, %arg1.high },
-// CHECK-NEXT:     { %arg0.fc1.z.reg, <felt.const: 0> }
+// CHECK-NEXT:     { %self.fc1.z.reg, %arg1.low, %arg1.high },
+// CHECK-NEXT:     { %self.fc1.z.reg, <felt.const: 0> }
 // CHECK-NEXT: }
 // INTRA-LABEL: @zir::@std::@risc0::@ValU32 ConstraintDependencyGraph { }
 // INTRA-NEXT: @zir::@std::@risc0::@Reg ConstraintDependencyGraph {
-// INTRA-NEXT:     { %arg0.reg, %arg1 }
+// INTRA-NEXT:     { %self.reg, %arg1 }
 // INTRA-NEXT: }
 // INTRA-NEXT: @zir::@std::@risc0::@Div ConstraintDependencyGraph {
-// INTRA-NEXT:     { %arg0.reciprocal, %arg0.synthetic_return, %arg1, %arg2 },
-// INTRA-NEXT:     { %arg0.reciprocal, <felt.const: 1> },
+// INTRA-NEXT:     { %self.reciprocal, %self.synthetic_return, %arg1, %arg2 },
+// INTRA-NEXT:     { %self.reciprocal, <felt.const: 1> },
 // INTRA-NEXT:     { %arg2, <felt.const: 1> }
 // INTRA-NEXT: }
 // INTRA-NEXT: @zir::@C1 ConstraintDependencyGraph { }
 // INTRA-NEXT: @zir::@C2 ConstraintDependencyGraph {
-// INTRA-NEXT:     { %arg0.fc1.z.reg, <felt.const: 0> }
+// INTRA-NEXT:     { %self.fc1.z.reg, <felt.const: 0> }
 // INTRA-NEXT: }
 // -----
 
@@ -745,43 +745,43 @@ module attributes {llzk.lang} {
 
 // CHECK-LABEL: @zir::@std::@risc0::@ValU32 ConstraintDependencyGraph { }
 // CHECK-NEXT: @zir::@std::@risc0::@Reg ConstraintDependencyGraph {
-// CHECK-NEXT:     { %arg0.reg, %arg1 }
+// CHECK-NEXT:     { %self.reg, %arg1 }
 // CHECK-NEXT: }
 // CHECK-NEXT: @zir::@std::@risc0::@Div ConstraintDependencyGraph {
-// CHECK-NEXT:     { %arg0.reciprocal, %arg0.synthetic_return, %arg1, %arg2 },
-// CHECK-NEXT:     { %arg0.reciprocal, <felt.const: 1> },
+// CHECK-NEXT:     { %self.reciprocal, %self.synthetic_return, %arg1, %arg2 },
+// CHECK-NEXT:     { %self.reciprocal, <felt.const: 1> },
 // CHECK-NEXT:     { %arg2, <felt.const: 1> }
 // CHECK-NEXT: }
 // CHECK-NEXT: @zir::@AssertBit ConstraintDependencyGraph {
 // CHECK-NEXT:     { %arg1, <felt.const: 0>, <felt.const: 1> }
 // CHECK-NEXT: }
 // CHECK-NEXT: @zir::@NondetBitReg ConstraintDependencyGraph {
-// CHECK-NEXT:     { %arg0.reg, %arg0.synthetic_return },
-// CHECK-NEXT:     { %arg0.reg, <felt.const: 0>, <felt.const: 1> }
+// CHECK-NEXT:     { %self.reg, %self.synthetic_return },
+// CHECK-NEXT:     { %self.reg, <felt.const: 0>, <felt.const: 1> }
 // CHECK-NEXT: }
 // CHECK-NEXT: @zir::@ArgU16 ConstraintDependencyGraph { }
 // CHECK-NEXT: @zir::@NondetU16Reg ConstraintDependencyGraph {
-// CHECK-NEXT:     { %arg0.arg.count, <felt.const: 1> },
-// CHECK-NEXT:     { %arg0.arg.val, %arg0.synthetic_return }
+// CHECK-NEXT:     { %self.arg.count, <felt.const: 1> },
+// CHECK-NEXT:     { %self.arg.val, %self.synthetic_return }
 // CHECK-NEXT: }
 // CHECK-NEXT: @zir::@U16Reg ConstraintDependencyGraph {
-// CHECK-NEXT:     { %arg0.ret.arg.count, <felt.const: 1> },
-// CHECK-NEXT:     { %arg0.ret.arg.val, %arg0.ret.synthetic_return, %arg0.synthetic_return, %arg1 }
+// CHECK-NEXT:     { %self.ret.arg.count, <felt.const: 1> },
+// CHECK-NEXT:     { %self.ret.arg.val, %self.ret.synthetic_return, %self.synthetic_return, %arg1 }
 // CHECK-NEXT: }
 // CHECK-NEXT: @zir::@AddrDecomposeBits ConstraintDependencyGraph {
-// CHECK-NEXT:     { %arg0.low0.reg, %arg0.low0.synthetic_return, %arg0.low1.reg, %arg0.low1.synthetic_return, %arg0.low2, %arg0.upperDiff.ret.arg.val, %arg0.upperDiff.ret.synthetic_return, %arg0.upperDiff.synthetic_return, %arg0.med14.arg.val, %arg0.med14.synthetic_return, %arg0.addr, %arg0.synthetic_return, %arg1.low, %arg1.high, %arg2 },
-// CHECK-NEXT:     { %arg0.low0.reg, <felt.const: 0>, <felt.const: 1> },
-// CHECK-NEXT:     { %arg0.low0.synthetic_return, <felt.const: 0>, <felt.const: 1>, <felt.const: 2> },
-// CHECK-NEXT:     { %arg0.low1.reg, <felt.const: 0>, <felt.const: 1> },
-// CHECK-NEXT:     { %arg0.low1.synthetic_return, <felt.const: 0>, <felt.const: 1>, <felt.const: 2> },
-// CHECK-NEXT:     { %arg0.low2, <felt.const: 2>, <felt.const: 4> },
-// CHECK-NEXT:     { %arg0.upperDiff.ret.arg.count, <felt.const: 1> },
-// CHECK-NEXT:     { %arg0.upperDiff.ret.arg.val, <felt.const: 1>, <felt.const: 49151>, <felt.const: 65535> },
-// CHECK-NEXT:     { %arg0.upperDiff.ret.synthetic_return, <felt.const: 1>, <felt.const: 49151>, <felt.const: 65535> },
-// CHECK-NEXT:     { %arg0.upperDiff.synthetic_return, <felt.const: 1>, <felt.const: 49151>, <felt.const: 65535> },
-// CHECK-NEXT:     { %arg0.med14.arg.count, <felt.const: 1> },
-// CHECK-NEXT:     { %arg0.med14.synthetic_return, <felt.const: 4>, <felt.const: 16384> },
-// CHECK-NEXT:     { %arg0.addr, <felt.const: 16384> },
+// CHECK-NEXT:     { %self.low0.reg, %self.low0.synthetic_return, %self.low1.reg, %self.low1.synthetic_return, %self.low2, %self.upperDiff.ret.arg.val, %self.upperDiff.ret.synthetic_return, %self.upperDiff.synthetic_return, %self.med14.arg.val, %self.med14.synthetic_return, %self.addr, %self.synthetic_return, %arg1.low, %arg1.high, %arg2 },
+// CHECK-NEXT:     { %self.low0.reg, <felt.const: 0>, <felt.const: 1> },
+// CHECK-NEXT:     { %self.low0.synthetic_return, <felt.const: 0>, <felt.const: 1>, <felt.const: 2> },
+// CHECK-NEXT:     { %self.low1.reg, <felt.const: 0>, <felt.const: 1> },
+// CHECK-NEXT:     { %self.low1.synthetic_return, <felt.const: 0>, <felt.const: 1>, <felt.const: 2> },
+// CHECK-NEXT:     { %self.low2, <felt.const: 2>, <felt.const: 4> },
+// CHECK-NEXT:     { %self.upperDiff.ret.arg.count, <felt.const: 1> },
+// CHECK-NEXT:     { %self.upperDiff.ret.arg.val, <felt.const: 1>, <felt.const: 49151>, <felt.const: 65535> },
+// CHECK-NEXT:     { %self.upperDiff.ret.synthetic_return, <felt.const: 1>, <felt.const: 49151>, <felt.const: 65535> },
+// CHECK-NEXT:     { %self.upperDiff.synthetic_return, <felt.const: 1>, <felt.const: 49151>, <felt.const: 65535> },
+// CHECK-NEXT:     { %self.med14.arg.count, <felt.const: 1> },
+// CHECK-NEXT:     { %self.med14.synthetic_return, <felt.const: 4>, <felt.const: 16384> },
+// CHECK-NEXT:     { %self.addr, <felt.const: 16384> },
 // CHECK-NEXT:     { %arg1.low, <felt.const: 4> },
 // CHECK-NEXT:     { %arg1.high, <felt.const: 1>, <felt.const: 16384>, <felt.const: 49151>, <felt.const: 65535> },
 // CHECK-NEXT:     { %arg2, <felt.const: 1>, <felt.const: 49151>, <felt.const: 65535> }
@@ -796,17 +796,17 @@ module attributes {llzk.lang} {
 // COM: @zir::@B now tracks the empty array.new allocation site as a root in the
 // COM: interprocedural graph, but remains empty intraprocedurally.
 // CHECK-LABEL: @zir::@THead::@Head ConstraintDependencyGraph {
-// CHECK-NEXT:     { %arg0.$super, %arg1[0] }
+// CHECK-NEXT:     { %self.$super, %arg1[0] }
 // CHECK-NEXT: }
 // CHECK-NEXT: @zir::@TA::@A ConstraintDependencyGraph {
-// CHECK-NEXT:     { %arg0.$super.$super, @A<[@N]> }
+// CHECK-NEXT:     { %self.$super.$super, @A<[@N]> }
 // CHECK-NEXT: }
 // CHECK-NEXT: @zir::@B ConstraintDependencyGraph {
-// CHECK-NEXT:     { %arg0.$super.$super, %array[0] }
+// CHECK-NEXT:     { %self.$super.$super, %array[0] }
 // CHECK-NEXT: }
 // CHECK-NEXT: @zir::@Top ConstraintDependencyGraph {
-// CHECK-NEXT:     { %arg0.a.$super.$super, %arg0.b.$super.$super.$super.$super },
-// CHECK-NEXT:     { %arg0.a.$super.$super, @A<[@N]> }
+// CHECK-NEXT:     { %self.a.$super.$super, %self.b.$super.$super.$super.$super },
+// CHECK-NEXT:     { %self.a.$super.$super, @A<[@N]> }
 // CHECK-NEXT: }
 // CHECK-NEXT: @zir::@VoidComponent ConstraintDependencyGraph { }
 
@@ -823,13 +823,13 @@ module attributes {llzk.lang} {
 // CHECK-NEXT: @bits::@NondetExtReg ConstraintDependencyGraph { }
 // CHECK-NEXT: @bits::@EqzExt ConstraintDependencyGraph { }
 // CHECK-NEXT: @bits::@Reg ConstraintDependencyGraph {
-// CHECK-NEXT:     { %arg0.reg.$super, %arg1 }
+// CHECK-NEXT:     { %self.reg.$super, %arg1 }
 // CHECK-NEXT: }
 // COM: ExtReg is unconstrained due to a front-end bug
 // CHECK-NEXT: @bits::@ExtReg ConstraintDependencyGraph { }
 // CHECK-NEXT: @bits::@Div ConstraintDependencyGraph {
-// CHECK-NEXT:     { %arg0.reciprocal, %arg2 },
-// CHECK-NEXT:     { %arg0.reciprocal, <felt.const: 1> },
+// CHECK-NEXT:     { %self.reciprocal, %arg2 },
+// CHECK-NEXT:     { %self.reciprocal, <felt.const: 1> },
 // CHECK-NEXT:     { %arg2, <felt.const: 1> }
 // CHECK-NEXT: }
 // CHECK-NEXT: @bits::@Log ConstraintDependencyGraph { }
@@ -839,47 +839,47 @@ module attributes {llzk.lang} {
 // CHECK-NEXT:     { %arg1, <felt.const: 0>, <felt.const: 1> }
 // CHECK-NEXT: }
 // CHECK-NEXT: @bits::@NondetBitReg ConstraintDependencyGraph {
-// CHECK-NEXT:     { %arg0.reg.$super, <felt.const: 0>, <felt.const: 1> }
+// CHECK-NEXT:     { %self.reg.$super, <felt.const: 0>, <felt.const: 1> }
 // CHECK-NEXT: }
 // CHECK-NEXT: @bits::@BitReg ConstraintDependencyGraph {
-// CHECK-NEXT:     { %arg0.reg.$super.$super, %arg1 },
-// CHECK-NEXT:     { %arg0.reg.reg.$super, <felt.const: 0>, <felt.const: 1> }
+// CHECK-NEXT:     { %self.reg.$super.$super, %arg1 },
+// CHECK-NEXT:     { %self.reg.reg.$super, <felt.const: 0>, <felt.const: 1> }
 // CHECK-NEXT: }
 // CHECK-NEXT: @bits::@AssertTwit ConstraintDependencyGraph {
 // CHECK-NEXT:     { %arg1, <felt.const: 0>, <felt.const: 1>, <felt.const: 2>, <felt.const: 3> }
 // CHECK-NEXT: }
 // CHECK-NEXT: @bits::@BitAnd ConstraintDependencyGraph {
-// CHECK-NEXT:     { %arg0.$temp.reg.$super, %arg1, %arg2 }
+// CHECK-NEXT:     { %self.$temp.reg.$super, %arg1, %arg2 }
 // CHECK-NEXT: }
 // CHECK-NEXT: @bits::@BitOr ConstraintDependencyGraph {
-// CHECK-NEXT:     { %arg0.$temp.reg.$super, %arg1, %arg2 },
-// CHECK-NEXT:     { %arg0.$temp.reg.$super, <felt.const: 1> },
+// CHECK-NEXT:     { %self.$temp.reg.$super, %arg1, %arg2 },
+// CHECK-NEXT:     { %self.$temp.reg.$super, <felt.const: 1> },
 // CHECK-NEXT:     { %arg1, <felt.const: 1> },
 // CHECK-NEXT:     { %arg2, <felt.const: 1> }
 // CHECK-NEXT: }
 // CHECK-NEXT: @bits::@NondetTwitReg ConstraintDependencyGraph {
-// CHECK-NEXT:     { %arg0.reg.$super, <felt.const: 0>, <felt.const: 1>, <felt.const: 2>, <felt.const: 3> }
+// CHECK-NEXT:     { %self.reg.$super, <felt.const: 0>, <felt.const: 1>, <felt.const: 2>, <felt.const: 3> }
 // CHECK-NEXT: }
 // CHECK-NEXT: @bits::@NondetFakeTwitReg ConstraintDependencyGraph {
-// CHECK-NEXT:     { %arg0.reg1.reg.$super, <felt.const: 0>, <felt.const: 1> },
-// CHECK-NEXT:     { %arg0.$temp_1.reciprocal, <felt.const: 1>, <felt.const: 2> },
-// CHECK-NEXT:     { %arg0.$temp_0.$temp.reg.$super, %arg0.$temp.$temp.reg.$super, %arg1 },
-// CHECK-NEXT:     { %arg0.$temp_0.$temp.reg.$super, <felt.const: 2> },
-// CHECK-NEXT:     { %arg0.reg0.reg.$super, <felt.const: 0>, <felt.const: 1> },
-// CHECK-NEXT:     { %arg0.$temp.$temp.reg.$super, <felt.const: 1> },
+// CHECK-NEXT:     { %self.reg1.reg.$super, <felt.const: 0>, <felt.const: 1> },
+// CHECK-NEXT:     { %self.$temp_1.reciprocal, <felt.const: 1>, <felt.const: 2> },
+// CHECK-NEXT:     { %self.$temp_0.$temp.reg.$super, %self.$temp.$temp.reg.$super, %arg1 },
+// CHECK-NEXT:     { %self.$temp_0.$temp.reg.$super, <felt.const: 2> },
+// CHECK-NEXT:     { %self.reg0.reg.$super, <felt.const: 0>, <felt.const: 1> },
+// CHECK-NEXT:     { %self.$temp.$temp.reg.$super, <felt.const: 1> },
 // CHECK-NEXT:     { %arg1, <felt.const: 1>, <felt.const: 2> }
 // CHECK-NEXT: }
 // CHECK-NEXT: @bits::@TwitReg ConstraintDependencyGraph {
-// CHECK-NEXT:     { %arg0.reg.$super.$super, %arg1 },
-// CHECK-NEXT:     { %arg0.reg.reg.$super, <felt.const: 0>, <felt.const: 1>, <felt.const: 2>, <felt.const: 3> }
+// CHECK-NEXT:     { %self.reg.$super.$super, %arg1 },
+// CHECK-NEXT:     { %self.reg.reg.$super, <felt.const: 0>, <felt.const: 1>, <felt.const: 2>, <felt.const: 3> }
 // CHECK-NEXT: }
 // CHECK-NEXT: @bits::@FakeTwitReg ConstraintDependencyGraph {
-// CHECK-NEXT:     { %arg0.reg.$super, %arg0.reg.$temp_0.$temp.reg.$super, %arg0.reg.$temp.$temp.reg.$super, %arg1 },
-// CHECK-NEXT:     { %arg0.reg.reg1.reg.$super, <felt.const: 0>, <felt.const: 1> },
-// CHECK-NEXT:     { %arg0.reg.$temp_1.reciprocal, <felt.const: 1>, <felt.const: 2> },
-// CHECK-NEXT:     { %arg0.reg.$temp_0.$temp.reg.$super, <felt.const: 1>, <felt.const: 2> },
-// CHECK-NEXT:     { %arg0.reg.reg0.reg.$super, <felt.const: 0>, <felt.const: 1> },
-// CHECK-NEXT:     { %arg0.reg.$temp.$temp.reg.$super, <felt.const: 1>, <felt.const: 2> },
+// CHECK-NEXT:     { %self.reg.$super, %self.reg.$temp_0.$temp.reg.$super, %self.reg.$temp.$temp.reg.$super, %arg1 },
+// CHECK-NEXT:     { %self.reg.reg1.reg.$super, <felt.const: 0>, <felt.const: 1> },
+// CHECK-NEXT:     { %self.reg.$temp_1.reciprocal, <felt.const: 1>, <felt.const: 2> },
+// CHECK-NEXT:     { %self.reg.$temp_0.$temp.reg.$super, <felt.const: 1>, <felt.const: 2> },
+// CHECK-NEXT:     { %self.reg.reg0.reg.$super, <felt.const: 0>, <felt.const: 1> },
+// CHECK-NEXT:     { %self.reg.$temp.$temp.reg.$super, <felt.const: 1>, <felt.const: 2> },
 // CHECK-NEXT:     { %arg1, <felt.const: 1>, <felt.const: 2> }
 // CHECK-NEXT: }
 
@@ -912,7 +912,7 @@ module attributes {llzk.lang} {
 }
 
 // CHECK-LABEL: @ExternAdder ConstraintDependencyGraph {
-// CHECK-NEXT:     { %arg0.sum, <call @extern_add %[[ADD_RESULT:[0-9]+]]> }
+// CHECK-NEXT:     { %self.sum, <call @extern_add %[[ADD_RESULT:[0-9]+]]> }
 // CHECK-NEXT: }
 
 // -----
@@ -954,7 +954,7 @@ module attributes {llzk.lang} {
 }
 
 // CHECK-LABEL: @ExternMemberDependency ConstraintDependencyGraph {
-// CHECK-NEXT:     { %arg0.value, payload.value }
+// CHECK-NEXT:     { %self.value, payload.value }
 // CHECK-NEXT: }
 
 // -----
@@ -1001,8 +1001,8 @@ module attributes {llzk.lang} {
 }
 
 // CHECK-LABEL: @ExternRepeatedMemberDependency ConstraintDependencyGraph {
-// CHECK-NEXT:     { %arg0.lhs, <call @extern_wrap %[[LEFT_WRAP_RESULT:[0-9]+]]>.value }
-// CHECK-NEXT:     { %arg0.rhs, <call @extern_wrap %[[RIGHT_WRAP_RESULT:[0-9]+]]>.value }
+// CHECK-NEXT:     { %self.lhs, <call @extern_wrap %[[LEFT_WRAP_RESULT:[0-9]+]]>.value }
+// CHECK-NEXT:     { %self.rhs, <call @extern_wrap %[[RIGHT_WRAP_RESULT:[0-9]+]]>.value }
 // CHECK-NEXT: }
 
 // -----
@@ -1032,8 +1032,8 @@ module attributes {llzk.lang} {
 }
 
 // CHECK-LABEL: @ExternPairDependency ConstraintDependencyGraph {
-// CHECK-NEXT:     { %arg0.lhs, left }
-// CHECK-NEXT:     { %arg0.rhs, right }
+// CHECK-NEXT:     { %self.lhs, left }
+// CHECK-NEXT:     { %self.rhs, right }
 // CHECK-NEXT: }
 
 // -----
@@ -1069,7 +1069,7 @@ module attributes {llzk.lang} {
 }
 
 // CHECK-LABEL: @Adder2 ConstraintDependencyGraph {
-// CHECK-NEXT:     { %arg0.sum, %arg1, %arg2 }
+// CHECK-NEXT:     { %self.sum, %arg1, %arg2 }
 // CHECK-NEXT: }
 
 // -----
@@ -1293,7 +1293,7 @@ module attributes {llzk.lang} {
 }
 
 // CHECK-LABEL: @CallTranslatedIntervals ConstraintDependencyGraph {
-// CHECK-NEXT:      { %arg0.out, <felt.const: 7> }
+// CHECK-NEXT:      { %self.out, <felt.const: 7> }
 // CHECK-NEXT:  }
 
 // -----
@@ -1322,8 +1322,8 @@ module attributes {llzk.lang} {
 }
 
 // CHECK-LABEL: @PodInitializedRoot ConstraintDependencyGraph {
-// CHECK-NEXT:     { %arg0.out, %pod.value }
+// CHECK-NEXT:     { %self.out, %pod.value }
 // CHECK-NEXT: }
 // INTRA-LABEL: @PodInitializedRoot ConstraintDependencyGraph {
-// INTRA-NEXT:     { %arg0.out, %pod.value }
+// INTRA-NEXT:     { %self.out, %pod.value }
 // INTRA-NEXT: }

--- a/test/Analysis/interval_analysis/edwards2montgomery.llzk
+++ b/test/Analysis/interval_analysis/edwards2montgomery.llzk
@@ -336,28 +336,28 @@ module attributes {llzk.lang} {
 }
 
 // CHECK-LABEL: @Div StructIntervals {
-// CHECK-NEXT:     %arg0.$super in Entire
-// CHECK-NEXT:     %arg0.reciprocal in TypeC:[ 1, 2013265920 ]
+// CHECK-NEXT:     %self.$super in Entire
+// CHECK-NEXT:     %self.reciprocal in TypeC:[ 1, 2013265920 ]
 // CHECK-NEXT:     %arg1 in Entire
 // CHECK-NEXT:     %arg2 in TypeC:[ 1, 2013265920 ]
 // CHECK-NEXT: }
 // CHECK-LABEL: @Edwards2Montgomery StructIntervals {
-// CHECK-NEXT:     %arg0.$super[0].$super in Entire
-// CHECK-NEXT:     %arg0.$super[0].reg in Entire
-// CHECK-NEXT:     %arg0.$super[1].$super in Entire
-// CHECK-NEXT:     %arg0.$super[1].reg in Entire
-// CHECK-NEXT:     %arg0.out[0].$super in Entire
-// CHECK-NEXT:     %arg0.out[0].reg in Entire
-// CHECK-NEXT:     %arg0.out[1].$super in Entire
-// CHECK-NEXT:     %arg0.out[1].reg in Entire
-// CHECK-NEXT:     %arg0.$temp_1.$super in Entire
-// CHECK-NEXT:     %arg0.$temp_1.reg in Entire
-// CHECK-NEXT:     %arg0.$temp_0.$super in Entire
-// CHECK-NEXT:     %arg0.$temp_0.reciprocal in TypeC:[ 1, 2013265920 ]
-// CHECK-NEXT:     %arg0.$temp.$super in Entire
-// CHECK-NEXT:     %arg0.$temp.reg in Entire
-// CHECK-NEXT:     %arg0.v.$super in Entire
-// CHECK-NEXT:     %arg0.v.reciprocal in TypeC:[ 1, 2013265920 ]
+// CHECK-NEXT:     %self.$super[0].$super in Entire
+// CHECK-NEXT:     %self.$super[0].reg in Entire
+// CHECK-NEXT:     %self.$super[1].$super in Entire
+// CHECK-NEXT:     %self.$super[1].reg in Entire
+// CHECK-NEXT:     %self.out[0].$super in Entire
+// CHECK-NEXT:     %self.out[0].reg in Entire
+// CHECK-NEXT:     %self.out[1].$super in Entire
+// CHECK-NEXT:     %self.out[1].reg in Entire
+// CHECK-NEXT:     %self.$temp_1.$super in Entire
+// CHECK-NEXT:     %self.$temp_1.reg in Entire
+// CHECK-NEXT:     %self.$temp_0.$super in Entire
+// CHECK-NEXT:     %self.$temp_0.reciprocal in TypeC:[ 1, 2013265920 ]
+// CHECK-NEXT:     %self.$temp.$super in Entire
+// CHECK-NEXT:     %self.$temp.reg in Entire
+// CHECK-NEXT:     %self.v.$super in Entire
+// CHECK-NEXT:     %self.v.reciprocal in TypeC:[ 1, 2013265920 ]
 // CHECK-NEXT:     %arg1[0] in TypeC:[ 1, 2013265920 ]
 // CHECK-NEXT:     %arg1[1] in Entire
 // CHECK-NEXT: }
@@ -370,8 +370,8 @@ module attributes {llzk.lang} {
 // CMP-NEXT:         %self.reciprocal in Entire
 // CMP-NEXT:     }
 // CMP-NEXT:     constrain {
-// CMP-NEXT:         %arg0.$super in Entire
-// CMP-NEXT:         %arg0.reciprocal in TypeC:[ 1, 2013265920 ]
+// CMP-NEXT:         %self.$super in Entire
+// CMP-NEXT:         %self.reciprocal in TypeC:[ 1, 2013265920 ]
 // CMP-NEXT:         %arg1 in Entire
 // CMP-NEXT:         %arg2 in TypeC:[ 1, 2013265920 ]
 // CMP-NEXT:     }
@@ -385,8 +385,8 @@ module attributes {llzk.lang} {
 // PROP-NEXT:         %self.reciprocal in Entire
 // PROP-NEXT:     }
 // PROP-NEXT:     constrain {
-// PROP-NEXT:         %arg0.$super in Entire
-// PROP-NEXT:         %arg0.reciprocal in TypeC:[ 1, 2013265920 ]
+// PROP-NEXT:         %self.$super in Entire
+// PROP-NEXT:         %self.reciprocal in TypeC:[ 1, 2013265920 ]
 // PROP-NEXT:         %arg1 in Entire
 // PROP-NEXT:         %arg2 in TypeC:[ 1, 2013265920 ]
 // PROP-NEXT:     }

--- a/test/Analysis/interval_analysis/interprocedural_subcomponent.llzk
+++ b/test/Analysis/interval_analysis/interprocedural_subcomponent.llzk
@@ -34,11 +34,11 @@ module attributes {llzk.lang} {
 }
 
 // CHECK-LABEL: @Child StructIntervals {
-// CHECK-NEXT:     %arg0.out in Degenerate(7)
+// CHECK-NEXT:     %self.out in Degenerate(7)
 // CHECK-NEXT: }
 
 // CHECK-LABEL: @Parent StructIntervals {
-// CHECK-NEXT:     %arg0.child.out in Degenerate(7)
+// CHECK-NEXT:     %self.child.out in Degenerate(7)
 // CHECK-NEXT: }
 
 // -----
@@ -112,12 +112,12 @@ module attributes {llzk.lang} {
 }
 
 // CHECK-LABEL: @ArrayChild StructIntervals {
-// CHECK-NEXT:     %arg0.out in Degenerate(7)
+// CHECK-NEXT:     %self.out in Degenerate(7)
 // CHECK-NEXT: }
 
 // CHECK-LABEL: @DynamicArrayParent StructIntervals {
-// CHECK-NEXT:     %arg0.children[0].out in Entire
-// CHECK-NEXT:     %arg0.children[1].out in Entire
+// CHECK-NEXT:     %self.children[0].out in Entire
+// CHECK-NEXT:     %self.children[1].out in Entire
 // CHECK-NEXT:     %arg1 in Entire
 // CHECK-NEXT: }
 
@@ -127,8 +127,8 @@ module attributes {llzk.lang} {
 // CHECK: }
 
 // CHECK-LABEL: @ArrayValueParent StructIntervals {
-// CHECK-DAG:     %arg0.left.out in Degenerate(7)
-// CHECK-DAG:     %arg0.right.out in Entire
+// CHECK-DAG:     %self.left.out in Degenerate(7)
+// CHECK-DAG:     %self.right.out in Entire
 // CHECK: }
 
 // -----
@@ -171,11 +171,11 @@ module attributes {llzk.lang} {
 }
 
 // CHECK-LABEL: @SkippedChild StructIntervals {
-// CHECK-NEXT:     %arg0.out in Degenerate(7)
+// CHECK-NEXT:     %self.out in Degenerate(7)
 // CHECK-NEXT: }
 
 // CHECK-LABEL: @FreeFunctionParent StructIntervals {
-// CHECK-DAG:     %arg0.child.out in Entire
+// CHECK-DAG:     %self.child.out in Entire
 // CHECK: }
 
 // -----
@@ -211,12 +211,12 @@ module attributes {llzk.lang} {
 }
 
 // CHECK-LABEL: @CycleA StructIntervals {
-// CHECK-DAG:     %arg0.out in Entire
+// CHECK-DAG:     %self.out in Entire
 // CHECK-DAG:     %arg1.out in Entire
 // CHECK: }
 
 // CHECK-LABEL: @CycleB StructIntervals {
-// CHECK-DAG:     %arg0.out in Entire
+// CHECK-DAG:     %self.out in Entire
 // CHECK-DAG:     %arg1.out in Entire
 // CHECK: }
 
@@ -264,11 +264,11 @@ module attributes {llzk.lang} {
 }
 
 // CHECK-LABEL: @Child StructIntervals {
-// CHECK-NEXT:     %arg0.out in TypeA:[ 0, 7 ]
+// CHECK-NEXT:     %self.out in TypeA:[ 0, 7 ]
 // CHECK-NEXT: }
 
 // CHECK-LABEL: @Parent StructIntervals {
-// CHECK-NEXT:     %arg0.child.out in TypeA:[ 1, 7 ]
+// CHECK-NEXT:     %self.child.out in TypeA:[ 1, 7 ]
 // CHECK-NEXT: }
 
 // -----
@@ -318,13 +318,13 @@ module attributes {llzk.lang} {
 }
 
 // CHECK-LABEL: @Child StructIntervals {
-// CHECK-NEXT:     %arg0.out in TypeA:[ 0, 7 ]
+// CHECK-NEXT:     %self.out in TypeA:[ 0, 7 ]
 // CHECK-NEXT:     %arg1 in TypeA:[ 0, 7 ]
 // CHECK-NEXT: }
 
 // CHECK-LABEL: @Parent StructIntervals {
-// CHECK-NEXT:     %arg0.child_in in TypeA:[ 3, 7 ]
-// CHECK-NEXT:     %arg0.child.out in TypeA:[ 3, 7 ]
+// CHECK-NEXT:     %self.child_in in TypeA:[ 3, 7 ]
+// CHECK-NEXT:     %self.child.out in TypeA:[ 3, 7 ]
 // CHECK-NEXT: }
 
 // -----
@@ -375,11 +375,11 @@ module attributes {llzk.lang} {
 }
 
 // CHECK-LABEL: @Child StructIntervals {
-// CHECK-NEXT:     %arg0.out in TypeA:[ 0, 7 ]
+// CHECK-NEXT:     %self.out in TypeA:[ 0, 7 ]
 // CHECK-NEXT:     %arg1 in TypeA:[ 0, 7 ]
 // CHECK-NEXT: }
 
 // CHECK-LABEL: @Parent StructIntervals {
-// CHECK-NEXT:     %arg0.child_in in TypeC:[ 3, 21888242871839275222246405745257275088548364400416034343698204186575808495616 ]
-// CHECK-NEXT:     %arg0.child.out in TypeA:[ 1, 7 ]
+// CHECK-NEXT:     %self.child_in in TypeC:[ 3, 21888242871839275222246405745257275088548364400416034343698204186575808495616 ]
+// CHECK-NEXT:     %self.child.out in TypeA:[ 1, 7 ]
 // CHECK-NEXT: }

--- a/test/Analysis/interval_analysis/interval_analysis_pass.llzk
+++ b/test/Analysis/interval_analysis/interval_analysis_pass.llzk
@@ -77,8 +77,8 @@ module attributes {llzk.lang} {
 }
 
 // CHECK-LABEL: @MemberRangeConstraint StructIntervals {
-// CHECK-NEXT:     %arg0.foo in Degenerate(1)
-// CHECK-NEXT:     %arg0.bar in TypeA:[ 0, 2 ]
+// CHECK-NEXT:     %self.foo in Degenerate(1)
+// CHECK-NEXT:     %self.bar in TypeA:[ 0, 2 ]
 // CHECK-NEXT:     %arg1 in TypeC:[ 2, 21888242871839275222246405745257275088548364400416034343698204186575808495616 ]
 // CHECK-NEXT:     %arg2 in TypeA:[ 0, 2 ]
 // CHECK-NEXT: }
@@ -123,9 +123,9 @@ module attributes {llzk.lang} {
 }
 
 // CHECK-LABEL: @ArrayConstraint StructIntervals {
-// CHECK-NEXT:     %arg0.arr[0] in TypeA:[ 5, 7 ]
-// CHECK-NEXT:     %arg0.arr[1] in TypeA:[ 7, 11 ]
-// CHECK-NEXT:     %arg0.arr[2] in TypeA:[ 5, 7 ]
+// CHECK-NEXT:     %self.arr[0] in TypeA:[ 5, 7 ]
+// CHECK-NEXT:     %self.arr[1] in TypeA:[ 7, 11 ]
+// CHECK-NEXT:     %self.arr[2] in TypeA:[ 5, 7 ]
 // CHECK-NEXT: }
 
 // -----
@@ -152,7 +152,7 @@ module attributes {llzk.lang} {
 }
 
 // CHECK-LABEL: @JoinedReadIntervals StructIntervals {
-// CHECK-NEXT:     %arg0.x in TypeA:[ 0, 9 ]
+// CHECK-NEXT:     %self.x in TypeA:[ 0, 9 ]
 // CHECK-NEXT: }
 
 // -----
@@ -186,8 +186,8 @@ module attributes {llzk.lang} {
 }
 
 // CHECK-LABEL: @Div StructIntervals {
-// CHECK-NEXT:     %arg0.$super in Entire
-// CHECK-NEXT:     %arg0.reciprocal in TypeC:[ 1, 21888242871839275222246405745257275088548364400416034343698204186575808495616 ]
+// CHECK-NEXT:     %self.$super in Entire
+// CHECK-NEXT:     %self.reciprocal in TypeC:[ 1, 21888242871839275222246405745257275088548364400416034343698204186575808495616 ]
 // CHECK-NEXT:     %arg1 in Entire
 // CHECK-NEXT:     %arg2 in TypeC:[ 1, 21888242871839275222246405745257275088548364400416034343698204186575808495616 ]
 // CHECK-NEXT: }
@@ -273,18 +273,18 @@ module attributes {llzk.lang} {
 }
 
 // CHECK-LABEL: @ByteDecompCorrect StructIntervals {
-// CHECK-NEXT:     %arg0.b1 in TypeA:[ 0, 255 ]
-// CHECK-NEXT:     %arg0.b0 in TypeA:[ 0, 255 ]
+// CHECK-NEXT:     %self.b1 in TypeA:[ 0, 255 ]
+// CHECK-NEXT:     %self.b0 in TypeA:[ 0, 255 ]
 // CHECK-NEXT:     %arg1 in TypeA:[ 0, 65535 ]
 // CHECK-NEXT: }
 // CHECK-NEXT: @ByteDecompIncorrect StructIntervals {
-// CHECK-NEXT:     %arg0.b1 in Entire
-// CHECK-NEXT:     %arg0.b0 in Entire
+// CHECK-NEXT:     %self.b1 in Entire
+// CHECK-NEXT:     %self.b0 in Entire
 // CHECK-NEXT:     %arg1 in Entire
 // CHECK-NEXT: }
 // CHECK-NEXT: @ByteDecompPartial StructIntervals {
-// CHECK-NEXT:     %arg0.b1 in Entire
-// CHECK-NEXT:     %arg0.b0 in Entire
+// CHECK-NEXT:     %self.b1 in Entire
+// CHECK-NEXT:     %self.b0 in Entire
 // CHECK-NEXT:     %arg1 in TypeA:[ 0, 65535 ]
 // CHECK-NEXT: }
 
@@ -312,7 +312,7 @@ module attributes {llzk.lang} {
 }
 
 // CHECK-LABEL: @BitConstraint StructIntervals {
-// CHECK-NEXT:    %arg0.bit in TypeA:[ 0, 1 ]
+// CHECK-NEXT:    %self.bit in TypeA:[ 0, 1 ]
 // CHECK-NEXT: }
 
 // -----
@@ -345,7 +345,7 @@ module attributes {llzk.lang} {
 }
 
 // CHECK-LABEL: @BitConstraint StructIntervals {
-// CHECK-NEXT:    %arg0.bit in TypeA:[ 0, 3 ]
+// CHECK-NEXT:    %self.bit in TypeA:[ 0, 3 ]
 // CHECK-NEXT: }
 
 // -----
@@ -372,7 +372,7 @@ module attributes {llzk.lang} {
 }
 
 // CHECK-LABEL: @BitConstraint StructIntervals {
-// CHECK-NEXT:    %arg0.bit in TypeA:[ 0, 3 ]
+// CHECK-NEXT:    %self.bit in TypeA:[ 0, 3 ]
 // CHECK-NEXT: }
 
 // -----
@@ -452,8 +452,8 @@ module attributes {llzk.lang} {
 }
 
 // CHECK-LABEL: @IntTest StructIntervals {
-// CHECK-NEXT:     %arg0.x in TypeA:[ 0, 511 ]
-// CHECK-NEXT:     %arg0.y in TypeF:[ 21888242871839275222246405745257275088548364400416034343698204186575808495106, 65535 ]
+// CHECK-NEXT:     %self.x in TypeA:[ 0, 511 ]
+// CHECK-NEXT:     %self.y in TypeF:[ 21888242871839275222246405745257275088548364400416034343698204186575808495106, 65535 ]
 // CHECK-NEXT: }
 
 // -----
@@ -500,9 +500,9 @@ module attributes {llzk.lang} {
 
 // TODO: Refine multiplication range
 // CHECK-LABEL: @IntTest StructIntervals {
-// CHECK-NEXT:     %arg0.x in TypeA:[ 0, 511 ]
-// CHECK-NEXT:     %arg0.y in TypeA:[ 256, 511 ]
-// CHECK-NEXT:     %arg0.z in TypeA:[ 65536, 131327 ]
+// CHECK-NEXT:     %self.x in TypeA:[ 0, 511 ]
+// CHECK-NEXT:     %self.y in TypeA:[ 256, 511 ]
+// CHECK-NEXT:     %self.z in TypeA:[ 65536, 131327 ]
 // CHECK-NEXT: }
 
 // -----
@@ -544,8 +544,8 @@ module attributes {llzk.lang} {
 }
 
 // CHECK-LABEL: @IntTest StructIntervals {
-// CHECK-NEXT:     %arg0.x in TypeA:[ 0, 511 ]
-// CHECK-NEXT:     %arg0.y in Entire
+// CHECK-NEXT:     %self.x in TypeA:[ 0, 511 ]
+// CHECK-NEXT:     %self.y in Entire
 // CHECK-NEXT: }
 
 // -----
@@ -587,8 +587,8 @@ module attributes {llzk.lang} {
 }
 
 // CHECK-LABEL: @IntTest StructIntervals {
-// CHECK-NEXT:     %arg0.x in TypeA:[ 0, 511 ]
-// CHECK-NEXT:     %arg0.y in TypeA:[ 32257, 65535 ]
+// CHECK-NEXT:     %self.x in TypeA:[ 0, 511 ]
+// CHECK-NEXT:     %self.y in TypeA:[ 32257, 65535 ]
 // CHECK-NEXT: }
 
 // -----
@@ -625,9 +625,9 @@ module attributes {llzk.lang} {
 }
 
 // CHECK-LABEL: @SubTest StructIntervals {
-// CHECK-NEXT:     %arg0.x in TypeA:[ 0, 255 ]
-// CHECK-NEXT:     %arg0.y in TypeA:[ 0, 255 ]
-// CHECK-NEXT:     %arg0.z in Entire
+// CHECK-NEXT:     %self.x in TypeA:[ 0, 255 ]
+// CHECK-NEXT:     %self.y in TypeA:[ 0, 255 ]
+// CHECK-NEXT:     %self.z in Entire
 // CHECK-NEXT: }
 
 // -----
@@ -663,9 +663,9 @@ module attributes {llzk.lang} {
 }
 
 // CHECK-LABEL: @SubTest StructIntervals {
-// CHECK-NEXT:     %arg0.x in TypeA:[ 0, 255 ]
-// CHECK-NEXT:     %arg0.y in TypeA:[ 0, 255 ]
-// CHECK-NEXT:     %arg0.z in TypeF:[ 21888242871839275222246405745257275088548364400416034343698204186575808495362, 255 ]
+// CHECK-NEXT:     %self.x in TypeA:[ 0, 255 ]
+// CHECK-NEXT:     %self.y in TypeA:[ 0, 255 ]
+// CHECK-NEXT:     %self.z in TypeF:[ 21888242871839275222246405745257275088548364400416034343698204186575808495362, 255 ]
 // CHECK-NEXT: }
 
 // -----

--- a/test/Analysis/interval_analysis/interval_analysis_pass_compute.llzk
+++ b/test/Analysis/interval_analysis/interval_analysis_pass_compute.llzk
@@ -457,7 +457,7 @@ module attributes {llzk.lang} {
 // CHECK-NEXT:         %self.bit in TypeA:[ 0, 1 ]
 // CHECK-NEXT:     }
 // CHECK-NEXT:     constrain {
-// CHECK-NEXT:         %arg0.bit in TypeA:[ 0, 1 ]
+// CHECK-NEXT:         %self.bit in TypeA:[ 0, 1 ]
 // CHECK-NEXT:         %arg1 in Entire
 // CHECK-NEXT:     }
 // CHECK-NEXT: }

--- a/test/Analysis/interval_analysis/interval_analysis_pass_unreduced.llzk
+++ b/test/Analysis/interval_analysis/interval_analysis_pass_unreduced.llzk
@@ -125,7 +125,7 @@ module attributes {llzk.lang} {
 // CHECK-NEXT:    %self.sig in Entire ( Unreduced:[ 0, 2013265920 ] )
 // CHECK-NEXT:  }
 // CHECK: constrain {
-// CHECK-NEXT:    %arg0.sig in Entire ( Unreduced:[ 0, 2013265920 ] )
+// CHECK-NEXT:    %self.sig in Entire ( Unreduced:[ 0, 2013265920 ] )
 // CHECK-NEXT:  }
 
 // -----
@@ -172,8 +172,8 @@ module @Comparators attributes {llzk.lang = "llzk"} {
 // CHECK-NEXT:    %self.inv in Entire ( Unreduced:[ 0, 2013265920 ] )
 // CHECK-NEXT:  }
 // CHECK-NEXT:  constrain {
-// CHECK-NEXT:    %arg0.out in Entire ( Unreduced:[ 0, 2013265920 ] )
-// CHECK-NEXT:    %arg0.inv in Entire ( Unreduced:[ 0, 2013265920 ] )
+// CHECK-NEXT:    %self.out in Entire ( Unreduced:[ 0, 2013265920 ] )
+// CHECK-NEXT:    %self.inv in Entire ( Unreduced:[ 0, 2013265920 ] )
 // CHECK-NEXT:    %arg1 in Entire ( Unreduced:[ 0, 2013265920 ] )
 // CHECK-NEXT:  }
 

--- a/unittests/Analysis/IntervalTests.cpp
+++ b/unittests/Analysis/IntervalTests.cpp
@@ -14,7 +14,6 @@
 #include "llzk/Analysis/Intervals.h"
 #include "llzk/Dialect/Bool/IR/Ops.h"
 #include "llzk/Dialect/Felt/IR/Ops.h"
-#include "llzk/Dialect/Function/IR/Ops.h"
 #include "llzk/Dialect/Struct/IR/Ops.h"
 #include "llzk/Util/Debug.h"
 #include "llzk/Util/StreamHelper.h"
@@ -58,105 +57,6 @@ TEST_F(IntervalTests, UnreducedIntervalOverlap) {
   ASSERT_FALSE(a.overlaps(c));
   ASSERT_TRUE(b.overlaps(c));
   ASSERT_FALSE(d.overlaps(a));
-}
-
-TEST_F(IntervalTests, SourceRefIndexHalfOpenOverlap) {
-  SourceRefIndex range(APInt(64, 2), APInt(64, 5));
-  SourceRefIndex overlappingRange(APInt(64, 4), APInt(64, 7));
-  SourceRefIndex adjacentRange(APInt(64, 5), APInt(64, 8));
-
-  EXPECT_FALSE(range.overlaps(SourceRefIndex(1)));
-  EXPECT_TRUE(range.overlaps(SourceRefIndex(2)));
-  EXPECT_TRUE(range.overlaps(SourceRefIndex(4)));
-  EXPECT_FALSE(range.overlaps(SourceRefIndex(5)));
-  EXPECT_TRUE(range.overlaps(overlappingRange));
-  EXPECT_FALSE(range.overlaps(adjacentRange));
-}
-
-class SourceRefTests : public LLZKTest {
-protected:
-  static constexpr auto kModule = R"mlir(
-module attributes {llzk.lang} {
-  struct.def @SourceRefs {
-    struct.member @storage : !pod.type<[@value: !felt.type]>
-
-    function.def @compute() -> !struct.type<@SourceRefs> {
-      %self = struct.new : !struct.type<@SourceRefs>
-      %pod = pod.new : !pod.type<[@storage: !felt.type]>
-      function.return %self : !struct.type<@SourceRefs>
-    }
-
-    function.def @constrain(%self: !struct.type<@SourceRefs>) {
-      function.return
-    }
-  }
-}
-)mlir";
-};
-
-TEST_F(SourceRefTests, PodRecordsAndMembersRemainDistinct) {
-  auto mod = parseSourceString<ModuleOp>(kModule, ParserConfig(&ctx));
-  ASSERT_TRUE(mod);
-  auto structDef = *mod->getOps<StructDefOp>().begin();
-  auto computeFn = structDef.getComputeFuncOp();
-  auto storage = *structDef.getOps<MemberDefOp>().begin();
-  pod::NewPodOp newPod;
-  computeFn.walk([&](pod::NewPodOp op) { newPod = op; });
-  ASSERT_TRUE(newPod);
-  SourceRef root(mlir::cast<OpResult>(computeFn.getSelfValueFromCompute()));
-  SourceRef memberRef(
-      mlir::cast<OpResult>(computeFn.getSelfValueFromCompute()), {SourceRefIndex(storage)}
-  );
-  SourceRef podRef(
-      mlir::cast<OpResult>(computeFn.getSelfValueFromCompute()),
-      {SourceRefIndex(StringAttr::get(&ctx, "storage"))}
-  );
-
-  EXPECT_FALSE(memberRef.isValidPrefix(podRef));
-  EXPECT_FALSE(podRef.isValidPrefix(memberRef));
-  EXPECT_FALSE(memberRef.overlaps(podRef));
-  EXPECT_FALSE(podRef.overlaps(memberRef));
-  EXPECT_TRUE(memberRef.isValidPrefix(root));
-
-  SourceRef arbitraryPodRef(
-      mlir::cast<OpResult>(newPod.getResult()), {SourceRefIndex(StringAttr::get(&ctx, "storage"))}
-  );
-  EXPECT_FALSE(memberRef.isValidPrefix(arbitraryPodRef));
-  EXPECT_FALSE(memberRef.overlaps(arbitraryPodRef));
-}
-
-TEST_F(SourceRefTests, ComputeSelfRebasesToConstrainSelfWithoutChangingPath) {
-  auto mod = parseSourceString<ModuleOp>(kModule, ParserConfig(&ctx));
-  ASSERT_TRUE(mod);
-  auto structDef = *mod->getOps<StructDefOp>().begin();
-  auto computeFn = structDef.getComputeFuncOp();
-  auto constrainFn = structDef.getConstrainFuncOp();
-  auto storage = *structDef.getOps<MemberDefOp>().begin();
-  auto valueName = StringAttr::get(&ctx, "value");
-
-  SourceRef computeSelf(mlir::cast<OpResult>(computeFn.getSelfValueFromCompute()));
-  auto constrainSelfArg = mlir::cast<BlockArgument>(constrainFn.getSelfValueFromConstrain());
-  SourceRef constrainSelf(constrainSelfArg);
-  SourceRef computeValue(
-      mlir::cast<OpResult>(computeFn.getSelfValueFromCompute()),
-      {SourceRefIndex(storage), SourceRefIndex(valueName)}
-  );
-  SourceRef expectedConstrainValue(
-      constrainSelfArg, {SourceRefIndex(storage), SourceRefIndex(valueName)}
-  );
-
-  auto translated = computeValue.translate(computeSelf, constrainSelf);
-  ASSERT_TRUE(succeeded(translated));
-  EXPECT_EQ(*translated, expectedConstrainValue);
-
-  SourceRef mismatchedComputeValue(
-      mlir::cast<OpResult>(computeFn.getSelfValueFromCompute()),
-      {SourceRefIndex(StringAttr::get(&ctx, "storage")), SourceRefIndex(valueName)}
-  );
-  auto mismatchedTranslation = mismatchedComputeValue.translate(computeSelf, constrainSelf);
-  ASSERT_TRUE(succeeded(mismatchedTranslation));
-  EXPECT_NE(*mismatchedTranslation, expectedConstrainValue);
-  EXPECT_TRUE(mismatchedTranslation->getPath().front().isPodRecord());
 }
 
 TEST_F(IntervalTests, UnreducedIntervalWidth) {

--- a/unittests/Analysis/SourceRefTests.cpp
+++ b/unittests/Analysis/SourceRefTests.cpp
@@ -213,6 +213,36 @@ TEST_F(SourceRefTests, OnlyReturnedComputeStructOverlapsConstrainSelf) {
   EXPECT_FALSE(constrainMember.overlaps(temporaryMember));
 }
 
+TEST_F(SourceRefTests, OnlyConstrainEntryArgumentOverlapsComputeSelf) {
+  auto mod = parseSourceString<ModuleOp>(kModule, ParserConfig(&ctx));
+  ASSERT_TRUE(mod);
+  auto structDef = *mod->getOps<StructDefOp>().begin();
+  auto computeFn = structDef.getComputeFuncOp();
+  auto constrainFn = structDef.getConstrainFuncOp();
+  auto storage = *structDef.getOps<MemberDefOp>().begin();
+  auto constrainSelf = mlir::cast<BlockArgument>(constrainFn.getSelfValueFromConstrain());
+
+  auto *successor = new Block();
+  constrainFn.getBody().push_back(successor);
+  auto successorArg = successor->addArgument(constrainSelf.getType(), loc);
+  OpBuilder builder(&ctx);
+  builder.setInsertionPointToEnd(successor);
+  builder.create<llzk::function::ReturnOp>(loc);
+
+  SourceRef computeMember(
+      mlir::cast<OpResult>(computeFn.getSelfValueFromCompute()), {SourceRefIndex(storage)}
+  );
+  SourceRef constrainMember(constrainSelf, {SourceRefIndex(storage)});
+  SourceRef successorMember(successorArg, {SourceRefIndex(storage)});
+
+  EXPECT_TRUE(computeMember.overlaps(constrainMember));
+  EXPECT_TRUE(constrainMember.overlaps(computeMember));
+  EXPECT_FALSE(successorMember.overlaps(computeMember));
+  EXPECT_FALSE(computeMember.overlaps(successorMember));
+  EXPECT_FALSE(successorMember.overlaps(constrainMember));
+  EXPECT_FALSE(constrainMember.overlaps(successorMember));
+}
+
 TEST_F(SourceRefTests, PodRecordsAndMembersRemainDistinct) {
   auto mod = parseSourceString<ModuleOp>(kModule, ParserConfig(&ctx));
   ASSERT_TRUE(mod);

--- a/unittests/Analysis/SourceRefTests.cpp
+++ b/unittests/Analysis/SourceRefTests.cpp
@@ -1,0 +1,309 @@
+//===-- SourceRefTests.cpp - Unit tests for SourceRef analysis -*- C++ -*-===//
+//
+// Part of the LLZK Project, under the Apache License v2.0.
+// See LICENSE.txt for license information.
+// Copyright 2026 Project LLZK
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#include "../LLZKTestBase.h"
+#include "../LLZKTestUtils.h"
+
+#include "llzk/Analysis/SourceRef.h"
+#include "llzk/Analysis/SourceRefLattice.h"
+#include "llzk/Dialect/Function/IR/Ops.h"
+#include "llzk/Dialect/Global/IR/Ops.h"
+#include "llzk/Dialect/POD/IR/Ops.h"
+#include "llzk/Dialect/Struct/IR/Ops.h"
+#include "llzk/Util/Compare.h"
+#include "llzk/Util/StreamHelper.h"
+
+#include <mlir/Dialect/Arith/IR/Arith.h>
+#include <mlir/Dialect/SCF/IR/SCF.h>
+#include <mlir/Parser/Parser.h>
+
+#include <gtest/gtest.h>
+
+using namespace mlir;
+using namespace llzk;
+using namespace llzk::component;
+
+class SourceRefTests : public LLZKTest {
+protected:
+  static constexpr auto kModule = R"mlir(
+module attributes {llzk.lang} {
+  struct.def @SourceRefs {
+    struct.member @storage : !pod.type<[@value: !felt.type]>
+    struct.member @other : !felt.type
+
+    function.def @compute() -> !struct.type<@SourceRefs> {
+      %self = struct.new : !struct.type<@SourceRefs>
+      %pod = pod.new : !pod.type<[@storage: !felt.type]>
+      function.return %self : !struct.type<@SourceRefs>
+    }
+
+    function.def @constrain(%self: !struct.type<@SourceRefs>) {
+      function.return
+    }
+  }
+}
+)mlir";
+};
+
+TEST_F(SourceRefTests, IndexHalfOpenOverlap) {
+  SourceRefIndex range(APInt(64, 2), APInt(64, 5));
+  SourceRefIndex overlappingRange(APInt(64, 4), APInt(64, 7));
+  SourceRefIndex adjacentRange(APInt(64, 5), APInt(64, 8));
+
+  EXPECT_FALSE(range.overlaps(SourceRefIndex(1)));
+  EXPECT_TRUE(range.overlaps(SourceRefIndex(2)));
+  EXPECT_TRUE(range.overlaps(SourceRefIndex(4)));
+  EXPECT_FALSE(range.overlaps(SourceRefIndex(5)));
+  EXPECT_TRUE(range.overlaps(overlappingRange));
+  EXPECT_FALSE(range.overlaps(adjacentRange));
+}
+
+TEST_F(SourceRefTests, MemberOrderingUsesNamesToBreakEqualLocations) {
+  auto mod = parseSourceString<ModuleOp>(kModule, ParserConfig(&ctx));
+  ASSERT_TRUE(mod);
+  auto structDef = *mod->getOps<StructDefOp>().begin();
+  auto members = llvm::to_vector(structDef.getOps<MemberDefOp>());
+  ASSERT_EQ(members.size(), 2);
+  members[0]->setLoc(FileLineColLoc::get(&ctx, "same.llzk", 1, 1));
+  members[1]->setLoc(FileLineColLoc::get(&ctx, "same.llzk", 1, 1));
+
+  auto forwardLocation = isLocationLess(members[0], members[1]);
+  auto reverseLocation = isLocationLess(members[1], members[0]);
+  ASSERT_TRUE(succeeded(forwardLocation));
+  ASSERT_TRUE(succeeded(reverseLocation));
+  EXPECT_FALSE(*forwardLocation);
+  EXPECT_FALSE(*reverseLocation);
+
+  EXPECT_TRUE(NamedOpLocationLess<MemberDefOp> {}(members[1], members[0]));
+  EXPECT_FALSE(NamedOpLocationLess<MemberDefOp> {}(members[0], members[1]));
+}
+
+TEST_F(SourceRefTests, LatticePrefixReplacementPreservesUnmatchedRefs) {
+  auto mod = parseSourceString<ModuleOp>(kModule, ParserConfig(&ctx));
+  ASSERT_TRUE(mod);
+  auto structDef = *mod->getOps<StructDefOp>().begin();
+  auto computeFn = structDef.getComputeFuncOp();
+  auto constrainFn = structDef.getConstrainFuncOp();
+  auto storage = *structDef.getOps<MemberDefOp>().begin();
+  pod::NewPodOp newPod;
+  computeFn.walk([&](pod::NewPodOp op) { newPod = op; });
+  ASSERT_TRUE(newPod);
+
+  SourceRef computeRoot(mlir::cast<OpResult>(computeFn.getSelfValueFromCompute()));
+  SourceRef constrainRoot(mlir::cast<BlockArgument>(constrainFn.getSelfValueFromConstrain()));
+  SourceRef computeMember(
+      mlir::cast<OpResult>(computeFn.getSelfValueFromCompute()), {SourceRefIndex(storage)}
+  );
+  SourceRef expectedMember(
+      mlir::cast<BlockArgument>(constrainFn.getSelfValueFromConstrain()), {SourceRefIndex(storage)}
+  );
+  SourceRef unrelated(mlir::cast<OpResult>(newPod.getResult()));
+
+  SourceRefLatticeValue value;
+  EXPECT_EQ(value.insert(computeMember), ChangeResult::Change);
+  EXPECT_EQ(value.insert(unrelated), ChangeResult::Change);
+  TranslationMap replacements {{computeRoot, SourceRefLatticeValue(constrainRoot)}};
+  auto [replaced, changed] = value.replacePrefixes(replacements);
+
+  EXPECT_EQ(changed, ChangeResult::Change);
+  EXPECT_TRUE(replaced.getScalarValue().contains(expectedMember));
+  EXPECT_TRUE(replaced.getScalarValue().contains(unrelated));
+  EXPECT_FALSE(replaced.getScalarValue().contains(computeMember));
+
+  auto [translated, translatedChanged] = value.translate(replacements);
+  EXPECT_EQ(translatedChanged, ChangeResult::Change);
+  EXPECT_TRUE(translated.getScalarValue().contains(expectedMember));
+  EXPECT_FALSE(translated.getScalarValue().contains(unrelated));
+}
+
+TEST_F(SourceRefTests, LatticeWritesPointsSubarraysAndRanges) {
+  auto mod = parseSourceString<ModuleOp>(kModule, ParserConfig(&ctx));
+  ASSERT_TRUE(mod);
+  auto structDef = *mod->getOps<StructDefOp>().begin();
+  auto computeFn = structDef.getComputeFuncOp();
+  auto constrainFn = structDef.getConstrainFuncOp();
+  SourceRef computeRoot(mlir::cast<OpResult>(computeFn.getSelfValueFromCompute()));
+  SourceRef constrainRoot(mlir::cast<BlockArgument>(constrainFn.getSelfValueFromConstrain()));
+
+  SourceRefLatticeValue matrix(llvm::ArrayRef<int64_t>({2, 2}));
+  EXPECT_EQ(
+      matrix.write(
+          {SourceRefIndex(APInt(64, 0)), SourceRefIndex(APInt(64, 1))},
+          SourceRefLatticeValue(computeRoot)
+      ),
+      ChangeResult::Change
+  );
+  auto point = matrix.extract({SourceRefIndex(APInt(64, 0)), SourceRefIndex(APInt(64, 1))});
+  ASSERT_TRUE(succeeded(point));
+  EXPECT_EQ(point->first.getSingleValue(), computeRoot);
+
+  SourceRefLatticeValue row(llvm::ArrayRef<int64_t>({2}));
+  EXPECT_EQ(
+      row.getElemFlatIdx(0).setValue(SourceRefLatticeValue(constrainRoot)), ChangeResult::Change
+  );
+  EXPECT_EQ(
+      row.getElemFlatIdx(1).setValue(SourceRefLatticeValue(computeRoot)), ChangeResult::Change
+  );
+  EXPECT_EQ(matrix.write({SourceRefIndex(APInt(64, 1))}, row), ChangeResult::Change);
+  auto writtenRow = matrix.extract({SourceRefIndex(APInt(64, 1))});
+  ASSERT_TRUE(succeeded(writtenRow));
+  ASSERT_TRUE(writtenRow->first.isArray());
+  EXPECT_EQ(writtenRow->first.getElemFlatIdx(0).getSingleValue(), constrainRoot);
+  EXPECT_EQ(writtenRow->first.getElemFlatIdx(1).getSingleValue(), computeRoot);
+
+  SourceRefLatticeValue vector(llvm::ArrayRef<int64_t>({3}));
+  EXPECT_EQ(
+      vector.write(
+          {SourceRefIndex(APInt(64, 1), APInt(64, 3))}, SourceRefLatticeValue(constrainRoot)
+      ),
+      ChangeResult::Change
+  );
+  for (uint64_t index = 1; index < 3; ++index) {
+    auto ranged = vector.extract({SourceRefIndex(APInt(64, index))});
+    ASSERT_TRUE(succeeded(ranged));
+    EXPECT_TRUE(ranged->first.getScalarValue().contains(constrainRoot));
+  }
+}
+
+TEST_F(SourceRefTests, PodRecordsAndMembersRemainDistinct) {
+  auto mod = parseSourceString<ModuleOp>(kModule, ParserConfig(&ctx));
+  ASSERT_TRUE(mod);
+  auto structDef = *mod->getOps<StructDefOp>().begin();
+  auto computeFn = structDef.getComputeFuncOp();
+  auto storage = *structDef.getOps<MemberDefOp>().begin();
+  pod::NewPodOp newPod;
+  computeFn.walk([&](pod::NewPodOp op) { newPod = op; });
+  ASSERT_TRUE(newPod);
+  SourceRef root(mlir::cast<OpResult>(computeFn.getSelfValueFromCompute()));
+  SourceRef memberRef(
+      mlir::cast<OpResult>(computeFn.getSelfValueFromCompute()), {SourceRefIndex(storage)}
+  );
+  SourceRef podRef(
+      mlir::cast<OpResult>(computeFn.getSelfValueFromCompute()),
+      {SourceRefIndex(StringAttr::get(&ctx, "storage"))}
+  );
+
+  EXPECT_FALSE(memberRef.isValidPrefix(podRef));
+  EXPECT_FALSE(podRef.isValidPrefix(memberRef));
+  EXPECT_FALSE(memberRef.overlaps(podRef));
+  EXPECT_FALSE(podRef.overlaps(memberRef));
+  EXPECT_TRUE(memberRef.isValidPrefix(root));
+
+  SourceRef arbitraryPodRef(
+      mlir::cast<OpResult>(newPod.getResult()), {SourceRefIndex(StringAttr::get(&ctx, "storage"))}
+  );
+  EXPECT_FALSE(memberRef.isValidPrefix(arbitraryPodRef));
+  EXPECT_FALSE(memberRef.overlaps(arbitraryPodRef));
+}
+
+TEST_F(SourceRefTests, ComputeSelfRebasesToConstrainSelfWithoutChangingPath) {
+  auto mod = parseSourceString<ModuleOp>(kModule, ParserConfig(&ctx));
+  ASSERT_TRUE(mod);
+  auto structDef = *mod->getOps<StructDefOp>().begin();
+  auto computeFn = structDef.getComputeFuncOp();
+  auto constrainFn = structDef.getConstrainFuncOp();
+  auto storage = *structDef.getOps<MemberDefOp>().begin();
+  auto valueName = StringAttr::get(&ctx, "value");
+
+  SourceRef computeSelf(mlir::cast<OpResult>(computeFn.getSelfValueFromCompute()));
+  auto constrainSelfArg = mlir::cast<BlockArgument>(constrainFn.getSelfValueFromConstrain());
+  SourceRef constrainSelf(constrainSelfArg);
+  SourceRef computeValue(
+      mlir::cast<OpResult>(computeFn.getSelfValueFromCompute()),
+      {SourceRefIndex(storage), SourceRefIndex(valueName)}
+  );
+  SourceRef expectedConstrainValue(
+      constrainSelfArg, {SourceRefIndex(storage), SourceRefIndex(valueName)}
+  );
+
+  auto translated = computeValue.translate(computeSelf, constrainSelf);
+  ASSERT_TRUE(succeeded(translated));
+  EXPECT_EQ(*translated, expectedConstrainValue);
+
+  SourceRef mismatchedComputeValue(
+      mlir::cast<OpResult>(computeFn.getSelfValueFromCompute()),
+      {SourceRefIndex(StringAttr::get(&ctx, "storage")), SourceRefIndex(valueName)}
+  );
+  auto mismatchedTranslation = mismatchedComputeValue.translate(computeSelf, constrainSelf);
+  ASSERT_TRUE(succeeded(mismatchedTranslation));
+  EXPECT_NE(*mismatchedTranslation, expectedConstrainValue);
+  EXPECT_TRUE(mismatchedTranslation->getPath().front().isPodRecord());
+}
+
+TEST_F(SourceRefTests, ConstrainSelfPrintsAsSelf) {
+  auto mod = parseSourceString<ModuleOp>(kModule, ParserConfig(&ctx));
+  ASSERT_TRUE(mod);
+  auto structDef = *mod->getOps<StructDefOp>().begin();
+  auto constrainFn = structDef.getConstrainFuncOp();
+  auto storage = *structDef.getOps<MemberDefOp>().begin();
+  auto constrainSelf = mlir::cast<BlockArgument>(constrainFn.getSelfValueFromConstrain());
+
+  EXPECT_EQ(buildStringViaPrint(SourceRef(constrainSelf)), "%self");
+  EXPECT_EQ(
+      buildStringViaPrint(SourceRef(constrainSelf, {SourceRefIndex(storage)})), "%self.storage"
+  );
+}
+
+TEST_F(SourceRefTests, ImmutableGlobalIsNotATemplateConstant) {
+  static constexpr auto source = R"mlir(
+module attributes {llzk.lang} {
+  global.def const @N : index = 3
+
+  function.def @read_global() -> index {
+    %value = global.read @N : index
+    function.return %value : index
+  }
+}
+)mlir";
+
+  auto mod = parseSourceString<ModuleOp>(source, ParserConfig(&ctx));
+  ASSERT_TRUE(mod);
+  auto func = *mod->getOps<function::FuncDefOp>().begin();
+  auto read = *func.getOps<global::GlobalReadOp>().begin();
+  auto ref = SourceRefLattice::getSourceRef(read.getResult());
+  ASSERT_TRUE(succeeded(ref));
+  EXPECT_TRUE(ref->isRooted());
+  EXPECT_FALSE(ref->isTemplateConstant());
+}
+
+TEST_F(SourceRefTests, ScfBlockArgumentsUseUnnamedFallback) {
+  static constexpr auto source = R"mlir(
+module attributes {llzk.lang} {
+  struct.def @ScfBlockArg {
+    function.def @compute() -> !struct.type<@ScfBlockArg> {
+      %self = struct.new : !struct.type<@ScfBlockArg>
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      %loop = scf.while (%i = %c0) : (index) -> index {
+        %cond = arith.cmpi slt, %i, %c1 : index
+        scf.condition(%cond) %i : index
+      } do {
+      ^bb0(%i: index):
+        %next = arith.addi %i, %c1 : index
+        scf.yield %next : index
+      }
+      function.return %self : !struct.type<@ScfBlockArg>
+    }
+
+    function.def @constrain(%self: !struct.type<@ScfBlockArg>) {
+      function.return
+    }
+  }
+}
+)mlir";
+
+  auto mod = parseSourceString<ModuleOp>(source, ParserConfig(&ctx));
+  ASSERT_TRUE(mod);
+  scf::WhileOp whileOp;
+  mod->walk([&](scf::WhileOp op) { whileOp = op; });
+  ASSERT_TRUE(whileOp);
+
+  SourceRef afterArg(whileOp.getAfter().front().getArgument(0));
+  EXPECT_EQ(buildStringViaPrint(afterArg), "%arg0");
+}

--- a/unittests/Analysis/SourceRefTests.cpp
+++ b/unittests/Analysis/SourceRefTests.cpp
@@ -308,7 +308,7 @@ TEST_F(SourceRefTests, ComputeSelfRebasesToConstrainSelfWithoutChangingPath) {
   EXPECT_TRUE(mismatchedTranslation->getPath().front().isPodRecord());
 }
 
-TEST_F(SourceRefTests, ConstrainSelfPrintsAsSelf) {
+TEST_F(SourceRefTests, OnlyConstrainEntryArgumentPrintsAsSelf) {
   auto mod = parseSourceString<ModuleOp>(kModule, ParserConfig(&ctx));
   ASSERT_TRUE(mod);
   auto structDef = *mod->getOps<StructDefOp>().begin();
@@ -316,9 +316,20 @@ TEST_F(SourceRefTests, ConstrainSelfPrintsAsSelf) {
   auto storage = *structDef.getOps<MemberDefOp>().begin();
   auto constrainSelf = mlir::cast<BlockArgument>(constrainFn.getSelfValueFromConstrain());
 
+  auto *successor = new Block();
+  constrainFn.getBody().push_back(successor);
+  auto successorArg = successor->addArgument(constrainSelf.getType(), loc);
+  OpBuilder builder(&ctx);
+  builder.setInsertionPointToEnd(successor);
+  builder.create<llzk::function::ReturnOp>(loc);
+
   EXPECT_EQ(buildStringViaPrint(SourceRef(constrainSelf)), "%self");
   EXPECT_EQ(
       buildStringViaPrint(SourceRef(constrainSelf, {SourceRefIndex(storage)})), "%self.storage"
+  );
+  EXPECT_EQ(buildStringViaPrint(SourceRef(successorArg)), "%arg0");
+  EXPECT_EQ(
+      buildStringViaPrint(SourceRef(successorArg, {SourceRefIndex(storage)})), "%arg0.storage"
   );
 }
 

--- a/unittests/Analysis/SourceRefTests.cpp
+++ b/unittests/Analysis/SourceRefTests.cpp
@@ -39,6 +39,7 @@ module attributes {llzk.lang} {
 
     function.def @compute() -> !struct.type<@SourceRefs> {
       %self = struct.new : !struct.type<@SourceRefs>
+      %temporary = struct.new : !struct.type<@SourceRefs>
       %pod = pod.new : !pod.type<[@storage: !felt.type]>
       function.return %self : !struct.type<@SourceRefs>
     }
@@ -169,6 +170,47 @@ TEST_F(SourceRefTests, LatticeWritesPointsSubarraysAndRanges) {
     ASSERT_TRUE(succeeded(ranged));
     EXPECT_TRUE(ranged->first.getScalarValue().contains(constrainRoot));
   }
+
+  SourceRefLatticeValue tensor(llvm::ArrayRef<int64_t>({2, 2, 3}));
+  SourceRefLatticeValue matrixSlice(llvm::ArrayRef<int64_t>({2, 3}));
+  EXPECT_EQ(
+      matrixSlice.getElemFlatIdx(0).setValue(SourceRefLatticeValue(computeRoot)),
+      ChangeResult::Change
+  );
+  EXPECT_EQ(tensor.write({SourceRefIndex(APInt(64, 1))}, matrixSlice), ChangeResult::Change);
+
+  SourceRefLatticeValue transposedSlice(llvm::ArrayRef<int64_t>({3, 2}));
+  EXPECT_DEATH(
+      (void)tensor.write({SourceRefIndex(APInt(64, 0))}, transposedSlice),
+      "SourceRef array write value shape does not match selected storage"
+  );
+}
+
+TEST_F(SourceRefTests, OnlyReturnedComputeStructOverlapsConstrainSelf) {
+  auto mod = parseSourceString<ModuleOp>(kModule, ParserConfig(&ctx));
+  ASSERT_TRUE(mod);
+  auto structDef = *mod->getOps<StructDefOp>().begin();
+  auto computeFn = structDef.getComputeFuncOp();
+  auto constrainFn = structDef.getConstrainFuncOp();
+  auto storage = *structDef.getOps<MemberDefOp>().begin();
+  auto allocations = llvm::to_vector(computeFn.getOps<CreateStructOp>());
+  ASSERT_EQ(allocations.size(), 2);
+
+  Value returnedSelf = computeFn.getSelfValueFromCompute();
+  CreateStructOp temporary =
+      allocations[0].getResult() == returnedSelf ? allocations[1] : allocations[0];
+  auto constrainSelf = mlir::cast<BlockArgument>(constrainFn.getSelfValueFromConstrain());
+
+  SourceRef computeMember(mlir::cast<OpResult>(returnedSelf), {SourceRefIndex(storage)});
+  SourceRef temporaryMember(mlir::cast<OpResult>(temporary.getResult()), {SourceRefIndex(storage)});
+  SourceRef constrainMember(constrainSelf, {SourceRefIndex(storage)});
+
+  EXPECT_TRUE(computeMember.overlaps(constrainMember));
+  EXPECT_TRUE(constrainMember.overlaps(computeMember));
+  EXPECT_FALSE(temporaryMember.overlaps(computeMember));
+  EXPECT_FALSE(computeMember.overlaps(temporaryMember));
+  EXPECT_FALSE(temporaryMember.overlaps(constrainMember));
+  EXPECT_FALSE(constrainMember.overlaps(temporaryMember));
 }
 
 TEST_F(SourceRefTests, PodRecordsAndMembersRemainDistinct) {


### PR DESCRIPTION
## Summary

Adds the SourceRef and lattice primitives required by the remaining aggregate analyses without introducing Circom-specific behavior. This is PR 1 of 6 in the stacked series.

## Related issues

No standalone issue; this is the first independently validated slice of the Circom analysis handoff.

## Changes

- Preserve array shape through bottom joins and publicly expose the inherited `getArrayShape()` accessor.
- Add element/subarray writes, prefix replacement, removal, and `SourceRef::narrowRanges()`; require an array write's RHS shape to match the selected destination's trailing dimensions exactly.
- Print only the exact entry self argument of a struct `@constrain` function as `%self`; non-entry, ordinary function, and nested SCF block arguments retain their existing names or `%arg…` fallback.
- Model global reads as ordinary rooted SourceRefs; immutable globals remain distinct from template constants.
- Treat only the struct instance returned by `@compute` as overlapping the entry `%self` returned by the corresponding `@constrain` function, preserving identity for other same-typed allocations and non-entry block arguments.
- Add deterministic symbol-name tie-breaking for equal or incomparable operation locations.
- Add focused API and output regressions in a dedicated `unittests/Analysis/SourceRefTests.cpp`, including multidimensional/ranged writes, mismatched multidimensional RHS rejection, returned-self and constrain-entry overlap, non-entry block-argument identity and printing, unmatched-prefix preservation, constrain-self spelling, nested SCF fallback, immutable-global classification, translation versus prefix-replacement behavior, and equal-location ordering.

## Testing

- `git diff --check`
- `SourceRefTests.*`: 11/11 passed
- `nix build -L` on commit `486edb92c`: 371 lit tests and 1,311 unit/CAPI tests passed

## Submission checklist

- [ ] ~If I am an external contributor, this PR has a linked issue marked `approved`; otherwise, this does not apply.~
- [x] I added or updated tests for all relevant behavior, or explained above why tests are not needed.
- [x] I updated the relevant TableGen or other documentation, or explained above why documentation is not needed.
- [x] I added a changelog entry describing user-visible changes. (`create-changelog` in the Nix development shell creates a template.)
- [ ] ~I enabled **Allow edits from maintainers** if this PR comes from a fork.~

## AI assistance

- [ ] No AI tools contributed to this PR.
- [x] AI tools contributed to this PR.

**Tools used:** OpenAI Codex.

**How the tools contributed:** Codex helped partition the original working-tree change, preserve dependency ordering, implement review feedback, add focused regressions, and prepare this draft PR.

**How I verified the contribution:** Reviewed the isolated diff, ran `git diff --check`, ran all 11 focused SourceRef tests in the release environment, and ran `nix build -L` on commit `486edb92c` (371 lit tests and 1,311 unit/CAPI tests passed).