### PR TITLE
Preserve aggregate state through SCF

### DIFF
--- a/changelogs/unreleased/codex__circom-analysis-2-aggregate-storage.yaml
+++ b/changelogs/unreleased/codex__circom-analysis-2-aggregate-storage.yaml
@@ -1,0 +1,2 @@
+fixed:
+  - Preserve SourceRef storage identities while exposing initialized, written, and rebased values through explicit dependency queries

--- a/changelogs/unreleased/codex__circom-analysis-3-scf-aggregates.yaml
+++ b/changelogs/unreleased/codex__circom-analysis-3-scf-aggregates.yaml
@@ -1,0 +1,2 @@
+fixed:
+  - Preserve array and POD SourceRef state through SCF loops and resultless aggregate writes

--- a/include/llzk/Analysis/ConstraintDependencyGraph.h
+++ b/include/llzk/Analysis/ConstraintDependencyGraph.h
@@ -76,8 +76,10 @@ protected:
   // Create the references for either an array.read op or an array.extract op, which
   // operate very similarly: index into the first operand using a variable number
   // of provided indices.
-  static SourceRefLatticeValue
-  arraySubdivisionOpUpdate(array::ArrayAccessOpInterface op, const OperandValues &operandVals);
+  static SourceRefLatticeValue arraySubdivisionOpUpdate(
+      array::ArrayAccessOpInterface op, const OperandValues &operandVals,
+      std::vector<SourceRefIndex> *resolvedIndices = nullptr
+  );
 
 private:
   class StorageState;

--- a/include/llzk/Analysis/ConstraintDependencyGraph.h
+++ b/include/llzk/Analysis/ConstraintDependencyGraph.h
@@ -41,7 +41,15 @@ public:
   using Base::SparseForwardDataFlowAnalysis;
 
   static const Lattice *getLattice(mlir::DataFlowSolver &solver, mlir::Value val);
+
+  /// Return the storage references represented by `val` without replacing them with values
+  /// written to those locations.
   static SourceRefLatticeValue getValueState(mlir::DataFlowSolver &solver, mlir::Value val);
+
+  /// Return the logical dependencies of `val` by following known storage writes transitively.
+  /// Unwritten storage remains represented by its address.
+  static SourceRefLatticeValue getDependencyState(mlir::DataFlowSolver &solver, mlir::Value val);
+
   static mlir::FailureOr<SourceRefLatticeValue>
   getWriteTargetState(mlir::DataFlowSolver &solver, mlir::Operation *op);
 
@@ -72,6 +80,9 @@ protected:
   arraySubdivisionOpUpdate(array::ArrayAccessOpInterface op, const OperandValues &operandVals);
 
 private:
+  class StorageState;
+  StorageState *getStorageState(mlir::Operation *op);
+
   mlir::SymbolTableCollection tables;
 };
 

--- a/include/llzk/Analysis/SourceRef.h
+++ b/include/llzk/Analysis/SourceRef.h
@@ -243,6 +243,8 @@ public:
   bool isTemplateConstant() const {
     return isConstant() && llvm::isa_and_present<polymorphic::ConstReadOp>(value.getDefiningOp());
   }
+  /// Return whether this reference originates from a read of an immutable global.
+  bool isImmutableGlobal() const;
 
   bool isConstant() const { return constant; }
   bool isConstantInt() const { return isConstantFelt() || isConstantIndex(); }

--- a/lib/Analysis/ConstraintDependencyGraph.cpp
+++ b/lib/Analysis/ConstraintDependencyGraph.cpp
@@ -90,7 +90,7 @@ public:
   /// Rebase an allocation/call result to the aggregate storage receiving it.
   void recordAggregateAlias(
       Operation *op, size_t aliasIndex, const SourceRefLatticeValue &source,
-      const SourceRefLatticeValue &target
+      const SourceRefLatticeValue &target, bool mayBeSkipped = false
   );
 
   void print(raw_ostream &os) const override { os << "SourceRefAnalysis::StorageState"; }
@@ -105,6 +105,7 @@ private:
   struct AggregateAlias {
     SourceRefLatticeValue source;
     SourceRefLatticeValue target;
+    bool mayBeSkipped;
   };
 
   /// Apply all known aggregate-storage aliases to a lattice value.
@@ -179,6 +180,33 @@ SourceRefLatticeValue SourceRefAnalysis::StorageState::resolveDependencies(
   const TranslationMap aliases = materializeAggregateAliases(before);
   const llvm::DenseMap<SourceRef, SourceRefLatticeValue> storedValues =
       materializeStoredValues(before, aliases);
+  std::function<
+      SourceRefLatticeValue(const SourceRefLatticeValue &, const SourceRef &, const SourceRef &)>
+      projectChild = [&](const SourceRefLatticeValue &value, const SourceRef &storedAddress,
+                         const SourceRef &readAddress) {
+    if (!readAddress.isValidPrefix(storedAddress)) {
+      return value;
+    }
+    if (value.isArray()) {
+      SourceRefLatticeValue result(value.getArrayShape());
+      for (size_t i = 0; i < value.getArraySize(); ++i) {
+        (void)result.getElemFlatIdx(i).setValue(
+            projectChild(value.getElemFlatIdx(i), storedAddress, readAddress)
+        );
+      }
+      return result;
+    }
+
+    SourceRefLatticeValue result;
+    for (const SourceRef &ref : value.getScalarValue()) {
+      if (auto translated = readAddress.translate(storedAddress, ref); succeeded(translated)) {
+        (void)result.insert(*translated);
+      } else {
+        (void)result.insert(ref);
+      }
+    }
+    return result;
+  };
   llvm::DenseSet<SourceRef> active;
   std::function<SourceRefLatticeValue(const SourceRefLatticeValue &)> resolve =
       [&](const SourceRefLatticeValue &input) {
@@ -194,7 +222,9 @@ SourceRefLatticeValue SourceRefAnalysis::StorageState::resolveDependencies(
     SourceRefLatticeValue result;
     for (const SourceRef &address : addressValue.getScalarValue()) {
       if (!active.insert(address).second) {
-        (void)result.insert(address);
+        if (addressValue.isSingleValue()) {
+          (void)result.insert(address);
+        }
         continue;
       }
 
@@ -204,11 +234,11 @@ SourceRefLatticeValue SourceRefAnalysis::StorageState::resolveDependencies(
         auto storedRoot = storedAddress.getRoot();
         auto addressRoot = address.getRoot();
         if (failed(storedRoot) || failed(addressRoot) || *storedRoot != *addressRoot ||
-            !storedAddress.overlaps(address)) {
+            (!storedAddress.overlaps(address) && !address.isValidPrefix(storedAddress))) {
           continue;
         }
         foundWrite = true;
-        (void)writtenValues.update(storedValue);
+        (void)writtenValues.update(projectChild(storedValue, storedAddress, address));
       }
       if (foundWrite) {
         SourceRefLatticeValue resolvedValues = resolve(writtenValues);
@@ -287,8 +317,16 @@ SourceRefAnalysis::StorageState::materializeStoredValues(
       }
       return;
     }
-    if (canonicalValue.isSingleValue() && canonicalValue.getSingleValue() == address) {
-      return;
+    if (canonicalValue.isScalar() && canonicalValue.getScalarValue().contains(address)) {
+      const bool hasPriorContents = llvm::any_of(storedValues, [&](const auto &entry) {
+        return entry.first == address || entry.first.isValidPrefix(address);
+      });
+      if (hasPriorContents || canonicalValue.isSingleValue()) {
+        (void)canonicalValue.getScalarValue().erase(address);
+        if (canonicalValue.getScalarValue().empty()) {
+          return;
+        }
+      }
     }
     applyWrite(address, canonicalValue, maySkip);
   };
@@ -313,10 +351,10 @@ SourceRefAnalysis::StorageState::materializeStoredValues(
 
 void SourceRefAnalysis::StorageState::recordAggregateAlias(
     Operation *op, size_t aliasIndex, const SourceRefLatticeValue &source,
-    const SourceRefLatticeValue &target
+    const SourceRefLatticeValue &target, bool mayBeSkipped
 ) {
   auto &aliases = aggregateAliases[op];
-  AggregateAlias alias {source, target};
+  AggregateAlias alias {source, target, mayBeSkipped};
   if (aliasIndex == aliases.size()) {
     aliases.push_back(std::move(alias));
     return;
@@ -346,8 +384,9 @@ SourceRefAnalysis::StorageState::materializeAggregateAliases(Operation *before) 
     return target;
   };
 
-  std::function<void(const SourceRefLatticeValue &, const SourceRefLatticeValue &)> addAlias =
-      [&](const SourceRefLatticeValue &source, const SourceRefLatticeValue &target) {
+  std::function<void(const SourceRefLatticeValue &, const SourceRefLatticeValue &, bool)> addAlias =
+      [&](const SourceRefLatticeValue &source, const SourceRefLatticeValue &target,
+          bool mayBeSkipped) {
     SourceRefLatticeValue canonicalSource = canonicalize(source, aliases);
     SourceRefLatticeValue canonicalTarget = canonicalize(target, aliases);
     if (canonicalSource.isArray() && canonicalTarget.isSingleValue()) {
@@ -360,7 +399,7 @@ SourceRefAnalysis::StorageState::materializeAggregateAliases(Operation *before) 
       for (size_t i = 0; i < canonicalSource.getArraySize(); ++i) {
         addAlias(
             canonicalSource.getElemFlatIdx(i),
-            SourceRefLatticeValue(getArrayElementTarget(targetRoot, i))
+            SourceRefLatticeValue(getArrayElementTarget(targetRoot, i)), mayBeSkipped
         );
       }
       return;
@@ -383,7 +422,11 @@ SourceRefAnalysis::StorageState::materializeAggregateAliases(Operation *before) 
       if (defOp == nullptr || !llvm::isa<CallOp, NewPodOp, CreateArrayOp, NonDetOp>(defOp)) {
         continue;
       }
-      aliases[sourceRef] = canonicalTarget;
+      SourceRefLatticeValue aliasTargets = canonicalTarget;
+      if (mayBeSkipped) {
+        (void)aliasTargets.insert(sourceRef);
+      }
+      aliases[sourceRef] = std::move(aliasTargets);
     }
   };
 
@@ -394,7 +437,7 @@ SourceRefAnalysis::StorageState::materializeAggregateAliases(Operation *before) 
     auto events = aggregateAliases.find(op);
     if (events != aggregateAliases.end()) {
       for (const AggregateAlias &event : events->second) {
-        addAlias(event.source, event.target);
+        addAlias(event.source, event.target, event.mayBeSkipped);
       }
     }
     return WalkResult::advance();
@@ -508,10 +551,13 @@ LogicalResult SourceRefAnalysis::visitOperation(
       auto writeOp = llvm::cast<MemberWriteOp>(op);
       SourceRefLatticeValue writeValue = operandVals.at(writeOp.getVal())->getValue();
       if (llvm::isa<ArrayType, StructType, PodType>(writeOp.getVal().getType())) {
+        const bool mayBeSkipped = isInMaybeSkippedScfRegion(op);
         getStorageState(op)->recordStorageWrite(
-            op, /*writeIndex=*/0, memberVals, writeValue, isInMaybeSkippedScfRegion(op)
+            op, /*writeIndex=*/0, memberVals, writeValue, mayBeSkipped
         );
-        getStorageState(op)->recordAggregateAlias(op, /*aliasIndex=*/0, writeValue, memberVals);
+        getStorageState(op)->recordAggregateAlias(
+            op, /*aliasIndex=*/0, writeValue, memberVals, mayBeSkipped
+        );
       }
     }
     return success();
@@ -529,17 +575,34 @@ LogicalResult SourceRefAnalysis::visitOperation(
       auto [podVals, _] = *podValsRes;
       auto writeOp = llvm::cast<WritePodOp>(op);
       SourceRefLatticeValue writeValue = operandVals.at(writeOp.getValue())->getValue();
+      const bool mayBeSkipped = isInMaybeSkippedScfRegion(op);
       getStorageState(op)->recordStorageWrite(
-          op, /*writeIndex=*/0, podVals, writeValue, isInMaybeSkippedScfRegion(op)
+          op, /*writeIndex=*/0, podVals, writeValue, mayBeSkipped
       );
       if (llvm::isa<ArrayType, StructType, PodType>(writeOp.getValue().getType())) {
-        getStorageState(op)->recordAggregateAlias(op, /*aliasIndex=*/0, writeValue, podVals);
+        getStorageState(op)->recordAggregateAlias(
+            op, /*aliasIndex=*/0, writeValue, podVals, mayBeSkipped
+        );
       }
     }
     return success();
   }
 
   if (auto arrayAccessOp = llvm::dyn_cast<ArrayAccessOpInterface>(op)) {
+    if (llvm::isa<WriteArrayOp, InsertArrayOp>(arrayAccessOp)) {
+      SourceRefLatticeValue writeTargets = arraySubdivisionOpUpdate(arrayAccessOp, operandVals);
+      Value rvalue = op->getOperands().back();
+      SourceRefLatticeValue writeValue = operandVals.at(rvalue)->getValue();
+      const bool mayBeSkipped = isInMaybeSkippedScfRegion(op);
+      getStorageState(op)->recordStorageWrite(
+          op, /*writeIndex=*/0, writeTargets, writeValue, mayBeSkipped
+      );
+      if (llvm::isa<ArrayType, StructType, PodType>(rvalue.getType())) {
+        getStorageState(op)->recordAggregateAlias(
+            op, /*aliasIndex=*/0, writeValue, writeTargets, mayBeSkipped
+        );
+      }
+    }
     if (!results.empty()) {
       auto newVals = arraySubdivisionOpUpdate(arrayAccessOp, operandVals);
       propagateIfChanged(results.front(), results.front()->setValue(newVals));
@@ -577,9 +640,10 @@ LogicalResult SourceRefAnalysis::visitOperation(
       SourceRefLatticeValue recordValue = operands[idx]->getValue();
       StorageState *state = getStorageState(op);
       SourceRefLatticeValue recordAddress(*recordRef);
-      state->recordStorageWrite(op, idx, recordAddress, recordValue, /*mayBeSkipped=*/false);
+      const bool mayBeSkipped = isInMaybeSkippedScfRegion(op);
+      state->recordStorageWrite(op, idx, recordAddress, recordValue, mayBeSkipped);
       if (llvm::isa<ArrayType, StructType, PodType>(record.value.getType())) {
-        state->recordAggregateAlias(op, idx, recordValue, recordAddress);
+        state->recordAggregateAlias(op, idx, recordValue, recordAddress, mayBeSkipped);
       }
     }
     return success();

--- a/lib/Analysis/ConstraintDependencyGraph.cpp
+++ b/lib/Analysis/ConstraintDependencyGraph.cpp
@@ -11,6 +11,7 @@
 
 #include "llzk/Analysis/SourceRefLattice.h"
 #include "llzk/Dialect/Array/IR/Ops.h"
+#include "llzk/Dialect/Array/Util/ArrayTypeHelper.h"
 #include "llzk/Dialect/Constrain/IR/Ops.h"
 #include "llzk/Dialect/Function/IR/Ops.h"
 #include "llzk/Dialect/POD/IR/Ops.h"
@@ -20,6 +21,7 @@
 
 #include <mlir/Analysis/DataFlow/DeadCodeAnalysis.h>
 #include <mlir/Analysis/DataFlow/DenseAnalysis.h>
+#include <mlir/Dialect/SCF/IR/SCF.h>
 #include <mlir/IR/Value.h>
 
 #include <llvm/Support/Debug.h>
@@ -39,7 +41,87 @@ using namespace constrain;
 using namespace function;
 using namespace pod;
 
+namespace {
+bool isInMaybeSkippedScfRegion(Operation *op) {
+  for (Operation *parent = op->getParentOp(); parent != nullptr; parent = parent->getParentOp()) {
+    if (llvm::isa<FuncDefOp>(parent)) {
+      return false;
+    }
+    if (llvm::isa<scf::ForOp, scf::IfOp, scf::WhileOp>(parent)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+} // namespace
+
 /* SourceRefAnalysis */
+
+/// Solver-owned state for aggregate storage dependencies discovered by `SourceRefAnalysis`.
+///
+/// The ordinary `SourceRefLattice` records the storage addresses represented by each SSA value.
+/// This state separately records values written to those addresses and aliases introduced when
+/// aggregates are assigned to other storage. It is anchored before the top-level operation so
+/// static dependency queries can retrieve it from the solver without retaining a pointer to the
+/// analysis instance. The state is created lazily when the analysis first records a storage write.
+class SourceRefAnalysis::StorageState : public AnalysisState {
+public:
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(StorageState)
+
+  using AnalysisState::AnalysisState;
+
+  /// Associate this state with the top-level operation whose writes it models.
+  void setTop(Operation *op) {
+    ensure(top == nullptr || top == op, "storage state cannot span top-level operations");
+    top = op;
+  }
+
+  /// Resolve known storage writes transitively, preserving unwritten and cyclic addresses.
+  SourceRefLatticeValue
+  resolveDependencies(const SourceRefLatticeValue &addresses, Operation *before) const;
+
+  /// Record a storage write for later dependency queries.
+  void recordStorageWrite(
+      Operation *op, size_t writeIndex, const SourceRefLatticeValue &addresses,
+      const SourceRefLatticeValue &value, bool mayBeSkipped = false
+  );
+
+  /// Rebase an allocation/call result to the aggregate storage receiving it.
+  void recordAggregateAlias(
+      Operation *op, size_t aliasIndex, const SourceRefLatticeValue &source,
+      const SourceRefLatticeValue &target
+  );
+
+  void print(raw_ostream &os) const override { os << "SourceRefAnalysis::StorageState"; }
+
+private:
+  struct StorageWrite {
+    SourceRefLatticeValue addresses;
+    SourceRefLatticeValue value;
+    bool mayBeSkipped;
+  };
+
+  struct AggregateAlias {
+    SourceRefLatticeValue source;
+    SourceRefLatticeValue target;
+  };
+
+  /// Apply all known aggregate-storage aliases to a lattice value.
+  static SourceRefLatticeValue
+  canonicalize(const SourceRefLatticeValue &value, const TranslationMap &aliases);
+
+  /// Materialize aliases established before `before` in program order.
+  TranslationMap materializeAggregateAliases(Operation *before) const;
+
+  /// Materialize storage contents at `before` by replaying earlier writes in IR order.
+  llvm::DenseMap<SourceRef, SourceRefLatticeValue>
+  materializeStoredValues(Operation *before, const TranslationMap &aliases) const;
+
+  Operation *top = nullptr;
+  llvm::DenseMap<Operation *, llvm::SmallVector<StorageWrite>> storageWrites;
+  llvm::DenseMap<Operation *, llvm::SmallVector<AggregateAlias>> aggregateAliases;
+};
 
 const SourceRefAnalysis::Lattice *SourceRefAnalysis::getLattice(DataFlowSolver &solver, Value val) {
   return solver.lookupState<Lattice>(val);
@@ -50,6 +132,274 @@ SourceRefLatticeValue SourceRefAnalysis::getValueState(DataFlowSolver &solver, V
     return state->getValue();
   }
   return SourceRefLattice::getDefaultValue(val);
+}
+
+SourceRefLatticeValue SourceRefAnalysis::getDependencyState(DataFlowSolver &solver, Value val) {
+  SourceRefLatticeValue value = getValueState(solver, val);
+  Operation *top = val.getParentRegion()->getParentOp();
+  while (top->getParentOp() != nullptr) {
+    top = top->getParentOp();
+  }
+  if (const auto *state = solver.lookupState<StorageState>(solver.getProgramPointBefore(top))) {
+    Operation *before = val.getDefiningOp();
+    if (before == nullptr) {
+      before = val.getParentBlock()->getParentOp();
+    }
+    return state->resolveDependencies(value, before);
+  }
+  return value;
+}
+
+SourceRefAnalysis::StorageState *SourceRefAnalysis::getStorageState(Operation *op) {
+  while (op->getParentOp() != nullptr) {
+    op = op->getParentOp();
+  }
+  auto *state = getOrCreate<StorageState>(getProgramPointBefore(op));
+  state->setTop(op);
+  return state;
+}
+
+SourceRefLatticeValue SourceRefAnalysis::StorageState::canonicalize(
+    const SourceRefLatticeValue &value, const TranslationMap &aliases
+) {
+  SourceRefLatticeValue canonical = value;
+  for (size_t i = 0; i < aliases.size(); ++i) {
+    auto [next, changed] = canonical.replacePrefixes(aliases);
+    canonical = std::move(next);
+    if (changed == ChangeResult::NoChange) {
+      break;
+    }
+  }
+  return canonical;
+}
+
+SourceRefLatticeValue SourceRefAnalysis::StorageState::resolveDependencies(
+    const SourceRefLatticeValue &addresses, Operation *before
+) const {
+  const TranslationMap aliases = materializeAggregateAliases(before);
+  const llvm::DenseMap<SourceRef, SourceRefLatticeValue> storedValues =
+      materializeStoredValues(before, aliases);
+  llvm::DenseSet<SourceRef> active;
+  std::function<SourceRefLatticeValue(const SourceRefLatticeValue &)> resolve =
+      [&](const SourceRefLatticeValue &input) {
+    SourceRefLatticeValue addressValue = canonicalize(input, aliases);
+    if (addressValue.isArray()) {
+      SourceRefLatticeValue result(addressValue.getArrayShape());
+      for (size_t i = 0; i < addressValue.getArraySize(); ++i) {
+        (void)result.getElemFlatIdx(i).setValue(resolve(addressValue.getElemFlatIdx(i)));
+      }
+      return result;
+    }
+
+    SourceRefLatticeValue result;
+    for (const SourceRef &address : addressValue.getScalarValue()) {
+      if (!active.insert(address).second) {
+        (void)result.insert(address);
+        continue;
+      }
+
+      bool foundWrite = false;
+      SourceRefLatticeValue writtenValues;
+      for (const auto &[storedAddress, storedValue] : storedValues) {
+        auto storedRoot = storedAddress.getRoot();
+        auto addressRoot = address.getRoot();
+        if (failed(storedRoot) || failed(addressRoot) || *storedRoot != *addressRoot ||
+            !storedAddress.overlaps(address)) {
+          continue;
+        }
+        foundWrite = true;
+        (void)writtenValues.update(storedValue);
+      }
+      if (foundWrite) {
+        SourceRefLatticeValue resolvedValues = resolve(writtenValues);
+        (void)result.update(resolvedValues);
+      }
+      if (!foundWrite) {
+        (void)result.insert(address);
+      }
+      active.erase(address);
+    }
+    return result;
+  };
+
+  return resolve(addresses);
+}
+
+void SourceRefAnalysis::StorageState::recordStorageWrite(
+    Operation *op, size_t writeIndex, const SourceRefLatticeValue &addresses,
+    const SourceRefLatticeValue &value, bool mayBeSkipped
+) {
+  auto &writes = storageWrites[op];
+  StorageWrite write {addresses, value, mayBeSkipped};
+  if (writeIndex == writes.size()) {
+    writes.push_back(std::move(write));
+    return;
+  }
+  ensure(writeIndex < writes.size(), "storage writes must be recorded in stable operation order");
+  writes[writeIndex] = std::move(write);
+}
+
+llvm::DenseMap<SourceRef, SourceRefLatticeValue>
+SourceRefAnalysis::StorageState::materializeStoredValues(
+    Operation *before, const TranslationMap &aliases
+) const {
+  llvm::DenseMap<SourceRef, SourceRefLatticeValue> storedValues;
+  ensure(top != nullptr, "storage state must be associated with a top-level operation");
+
+  auto getArrayElementAddress = [](const SourceRef &root, size_t flatIndex) {
+    auto arrayType = llvm::dyn_cast<ArrayType>(root.getType());
+    ensure(arrayType && arrayType.hasStaticShape(), "shaped storage write requires static array");
+    ArrayIndexGen indexGen = ArrayIndexGen::from(arrayType);
+    auto indices =
+        indexGen.delinearize(checkedCast<int64_t>(flatIndex), root.getType().getContext());
+    ensure(indices.has_value(), "could not delinearize shaped storage write");
+    SourceRef address = root;
+    for (Attribute attr : *indices) {
+      auto child = address.createChild(SourceRefIndex(llvm::cast<IntegerAttr>(attr).getValue()));
+      ensure(succeeded(child), "could not create shaped storage address");
+      address = *child;
+    }
+    return address;
+  };
+
+  auto applyWrite = [&](const SourceRef &address, const SourceRefLatticeValue &value,
+                        bool maySkip) {
+    auto [it, inserted] = storedValues.try_emplace(address, value);
+    if (!inserted) {
+      if (maySkip) {
+        (void)it->second.update(value);
+      } else {
+        (void)it->second.setValue(value);
+      }
+    }
+  };
+
+  std::function<void(const SourceRef &, const SourceRefLatticeValue &, bool)> materializeWrite =
+      [&](const SourceRef &address, const SourceRefLatticeValue &value, bool maySkip) {
+    SourceRefLatticeValue canonicalValue = canonicalize(value, aliases);
+    auto arrayType = llvm::dyn_cast<ArrayType>(address.getType());
+    if (canonicalValue.isArray() && arrayType && arrayType.hasStaticShape() &&
+        std::cmp_equal(canonicalValue.getArraySize(), arrayType.getNumElements())) {
+      for (size_t i = 0; i < canonicalValue.getArraySize(); ++i) {
+        materializeWrite(
+            getArrayElementAddress(address, i), canonicalValue.getElemFlatIdx(i), maySkip
+        );
+      }
+      return;
+    }
+    if (canonicalValue.isSingleValue() && canonicalValue.getSingleValue() == address) {
+      return;
+    }
+    applyWrite(address, canonicalValue, maySkip);
+  };
+
+  (void)top->walk([&](Operation *op) {
+    if (op == before) {
+      return WalkResult::interrupt();
+    }
+    auto writes = storageWrites.find(op);
+    if (writes == storageWrites.end()) {
+      return WalkResult::advance();
+    }
+    for (const StorageWrite &write : writes->second) {
+      for (const SourceRef &address : canonicalize(write.addresses, aliases).foldToScalar()) {
+        materializeWrite(address, write.value, write.mayBeSkipped);
+      }
+    }
+    return WalkResult::advance();
+  });
+  return storedValues;
+}
+
+void SourceRefAnalysis::StorageState::recordAggregateAlias(
+    Operation *op, size_t aliasIndex, const SourceRefLatticeValue &source,
+    const SourceRefLatticeValue &target
+) {
+  auto &aliases = aggregateAliases[op];
+  AggregateAlias alias {source, target};
+  if (aliasIndex == aliases.size()) {
+    aliases.push_back(std::move(alias));
+    return;
+  }
+  ensure(aliasIndex < aliases.size(), "aggregate aliases must use stable operation order");
+  aliases[aliasIndex] = std::move(alias);
+}
+
+TranslationMap
+SourceRefAnalysis::StorageState::materializeAggregateAliases(Operation *before) const {
+  TranslationMap aliases;
+  ensure(top != nullptr, "storage state must be associated with a top-level operation");
+
+  auto getArrayElementTarget = [](const SourceRef &root, size_t flatIndex) {
+    auto arrayType = llvm::dyn_cast<ArrayType>(root.getType());
+    ensure(arrayType && arrayType.hasStaticShape(), "array alias target requires static shape");
+    ArrayIndexGen indexGen = ArrayIndexGen::from(arrayType);
+    auto indices =
+        indexGen.delinearize(checkedCast<int64_t>(flatIndex), root.getType().getContext());
+    ensure(indices.has_value(), "could not delinearize aggregate alias target");
+    SourceRef target = root;
+    for (Attribute attr : *indices) {
+      auto child = target.createChild(SourceRefIndex(llvm::cast<IntegerAttr>(attr).getValue()));
+      ensure(succeeded(child), "could not create aggregate alias target child");
+      target = *child;
+    }
+    return target;
+  };
+
+  std::function<void(const SourceRefLatticeValue &, const SourceRefLatticeValue &)> addAlias =
+      [&](const SourceRefLatticeValue &source, const SourceRefLatticeValue &target) {
+    SourceRefLatticeValue canonicalSource = canonicalize(source, aliases);
+    SourceRefLatticeValue canonicalTarget = canonicalize(target, aliases);
+    if (canonicalSource.isArray() && canonicalTarget.isSingleValue()) {
+      const SourceRef &targetRoot = canonicalTarget.getSingleValue();
+      auto targetType = llvm::dyn_cast<ArrayType>(targetRoot.getType());
+      if (!targetType || !targetType.hasStaticShape() ||
+          !std::cmp_equal(canonicalSource.getArraySize(), targetType.getNumElements())) {
+        return;
+      }
+      for (size_t i = 0; i < canonicalSource.getArraySize(); ++i) {
+        addAlias(
+            canonicalSource.getElemFlatIdx(i),
+            SourceRefLatticeValue(getArrayElementTarget(targetRoot, i))
+        );
+      }
+      return;
+    }
+    if (!canonicalSource.isScalar() || !canonicalTarget.isSingleValue()) {
+      return;
+    }
+
+    const SourceRef &targetRef = canonicalTarget.getSingleValue();
+    for (const SourceRef &sourceRef : canonicalSource.getScalarValue()) {
+      if (sourceRef == targetRef || !sourceRef.isRooted() ||
+          !llvm::isa<ArrayType, StructType, PodType>(sourceRef.getType())) {
+        continue;
+      }
+      auto sourceRoot = sourceRef.getRoot();
+      if (failed(sourceRoot)) {
+        continue;
+      }
+      Operation *defOp = sourceRoot->getDefiningOp();
+      if (defOp == nullptr || !llvm::isa<CallOp, NewPodOp, CreateArrayOp, NonDetOp>(defOp)) {
+        continue;
+      }
+      aliases[sourceRef] = canonicalTarget;
+    }
+  };
+
+  (void)top->walk([&](Operation *op) {
+    if (op == before) {
+      return WalkResult::interrupt();
+    }
+    auto events = aggregateAliases.find(op);
+    if (events != aggregateAliases.end()) {
+      for (const AggregateAlias &event : events->second) {
+        addAlias(event.source, event.target);
+      }
+    }
+    return WalkResult::advance();
+  });
+  return aliases;
 }
 
 mlir::FailureOr<SourceRefLatticeValue>
@@ -140,12 +490,10 @@ LogicalResult SourceRefAnalysis::visitOperation(
     Operation *op, ArrayRef<const Lattice *> operands, ArrayRef<Lattice *> results
 ) {
   LLVM_DEBUG(llvm::dbgs() << "SourceRefAnalysis::visitOperation: " << *op << '\n');
-
   DenseMap<Value, const Lattice *> operandVals;
   for (auto [operand, lattice] : llvm::zip(op->getOperands(), operands)) {
     operandVals[operand] = lattice;
   }
-
   if (auto memberRefOp = llvm::dyn_cast<MemberRefOpInterface>(op)) {
     auto memberOpRes = memberRefOp.getMemberDefOp(tables);
     ensure(succeeded(memberOpRes), "could not find member read");
@@ -155,6 +503,16 @@ LogicalResult SourceRefAnalysis::visitOperation(
     if (memberRefOp.isRead()) {
       auto [memberVals, _] = *memberValsRes;
       propagateIfChanged(results.front(), results.front()->setValue(memberVals));
+    } else {
+      auto [memberVals, _] = *memberValsRes;
+      auto writeOp = llvm::cast<MemberWriteOp>(op);
+      SourceRefLatticeValue writeValue = operandVals.at(writeOp.getVal())->getValue();
+      if (llvm::isa<ArrayType, StructType, PodType>(writeOp.getVal().getType())) {
+        getStorageState(op)->recordStorageWrite(
+            op, /*writeIndex=*/0, memberVals, writeValue, isInMaybeSkippedScfRegion(op)
+        );
+        getStorageState(op)->recordAggregateAlias(op, /*aliasIndex=*/0, writeValue, memberVals);
+      }
     }
     return success();
   }
@@ -167,6 +525,16 @@ LogicalResult SourceRefAnalysis::visitOperation(
     if (podAccessOp.isRead()) {
       auto [podVals, _] = *podValsRes;
       propagateIfChanged(results.front(), results.front()->setValue(podVals));
+    } else {
+      auto [podVals, _] = *podValsRes;
+      auto writeOp = llvm::cast<WritePodOp>(op);
+      SourceRefLatticeValue writeValue = operandVals.at(writeOp.getValue())->getValue();
+      getStorageState(op)->recordStorageWrite(
+          op, /*writeIndex=*/0, podVals, writeValue, isInMaybeSkippedScfRegion(op)
+      );
+      if (llvm::isa<ArrayType, StructType, PodType>(writeOp.getValue().getType())) {
+        getStorageState(op)->recordAggregateAlias(op, /*aliasIndex=*/0, writeValue, podVals);
+      }
     }
     return success();
   }
@@ -201,6 +569,19 @@ LogicalResult SourceRefAnalysis::visitOperation(
   if (auto newPod = llvm::dyn_cast<NewPodOp>(op)) {
     auto newPodValue = SourceRefLattice::getDefaultValue(newPod.getResult());
     propagateIfChanged(results.front(), results.front()->setValue(newPodValue));
+    SourceRef podRoot(llvm::cast<OpResult>(newPod.getResult()));
+    for (auto [idx, record] : llvm::enumerate(newPod.getInitializedRecordValues())) {
+      auto recordRef =
+          podRoot.createChild(SourceRefIndex(StringAttr::get(op->getContext(), record.name)));
+      ensure(succeeded(recordRef), "could not create initialized POD record SourceRef");
+      SourceRefLatticeValue recordValue = operands[idx]->getValue();
+      StorageState *state = getStorageState(op);
+      SourceRefLatticeValue recordAddress(*recordRef);
+      state->recordStorageWrite(op, idx, recordAddress, recordValue, /*mayBeSkipped=*/false);
+      if (llvm::isa<ArrayType, StructType, PodType>(record.value.getType())) {
+        state->recordAggregateAlias(op, idx, recordValue, recordAddress);
+      }
+    }
     return success();
   }
 
@@ -227,7 +608,8 @@ void SourceRefAnalysis::visitExternalCall(
     for (auto [result, lattice] : llvm::zip(call->getResults(), resultLattices)) {
       auto resultRef = SourceRefLattice::getSourceRef(result);
       ensure(succeeded(resultRef), "could not create external call SourceRef");
-      propagateIfChanged(lattice, lattice->setValue(*resultRef));
+      SourceRefLatticeValue resultValue(*resultRef);
+      propagateIfChanged(lattice, lattice->setValue(resultValue));
     }
     return;
   }
@@ -256,8 +638,13 @@ void SourceRefAnalysis::visitExternalCall(
 
   std::unordered_map<SourceRef, SourceRefLatticeValue, SourceRef::Hash> translation;
   for (unsigned i = 0; i < funcOp.getNumArguments(); i++) {
-    translation[SourceRef(funcOp.getArgument(i))] =
+    SourceRefLatticeValue argumentValue =
         static_cast<const Lattice *>(operandLattices[i])->getValue();
+    if (!llvm::isa<ArrayType, StructType, PodType>(call->getOperand(i).getType())) {
+      argumentValue = getStorageState(call.getOperation())
+                          ->resolveDependencies(argumentValue, call.getOperation());
+    }
+    translation[SourceRef(funcOp.getArgument(i))] = argumentValue;
   }
 
   for (auto [result, resultLattice] : llvm::zip(call->getResults(), resultLattices)) {
@@ -270,7 +657,11 @@ void SourceRefAnalysis::visitExternalCall(
                                                      returnSite->getOperand(resultNum)
                                                  ))
                         ->getValue();
-      auto [translatedVal, _] = retVal.translate(translation);
+      SourceRefLatticeValue returnDependencies = retVal;
+      if (!llvm::isa<ArrayType, StructType, PodType>(returnSite->getOperand(resultNum).getType())) {
+        returnDependencies = getStorageState(returnSite)->resolveDependencies(retVal, returnSite);
+      }
+      auto [translatedVal, _] = returnDependencies.translate(translation);
       (void)combined.update(translatedVal);
     }
     propagateIfChanged(resultLattice, static_cast<Lattice *>(resultLattice)->setValue(combined));
@@ -420,15 +811,21 @@ mlir::LogicalResult ConstraintDependencyGraph::computeConstraints(
     }
 
     for (Value operand : op->getOperands()) {
-      auto operandRefs = SourceRefAnalysis::getValueState(solver, operand).foldToScalar();
-      for (const SourceRef &ref : operandRefs) {
-        ref2Val[ref].insert(operand);
+      for (const SourceRefLatticeValue &state :
+           {SourceRefAnalysis::getValueState(solver, operand),
+            SourceRefAnalysis::getDependencyState(solver, operand)}) {
+        for (const SourceRef &ref : state.foldToScalar()) {
+          ref2Val[ref].insert(operand);
+        }
       }
     }
     for (Value result : op->getResults()) {
-      auto resultRefs = SourceRefAnalysis::getValueState(solver, result).foldToScalar();
-      for (const SourceRef &ref : resultRefs) {
-        ref2Val[ref].insert(result);
+      for (const SourceRefLatticeValue &state :
+           {SourceRefAnalysis::getValueState(solver, result),
+            SourceRefAnalysis::getDependencyState(solver, result)}) {
+        for (const SourceRef &ref : state.foldToScalar()) {
+          ref2Val[ref].insert(result);
+        }
       }
     }
     auto writeTargetState = SourceRefAnalysis::getWriteTargetState(solver, op);
@@ -468,7 +865,9 @@ mlir::LogicalResult ConstraintDependencyGraph::computeConstraints(
     for (unsigned i = 0; i < fn.getNumArguments(); i++) {
       SourceRef prefix(fn.getArgument(i));
       Value operand = fnCall.getOperand(i);
-      SourceRefLatticeValue val = SourceRefAnalysis::getValueState(solver, operand);
+      SourceRefLatticeValue val = llvm::isa<ArrayType, StructType, PodType>(operand.getType())
+                                      ? SourceRefAnalysis::getValueState(solver, operand)
+                                      : SourceRefAnalysis::getDependencyState(solver, operand);
       translations.push_back({prefix, val});
     }
     auto &childAnalysis =
@@ -514,7 +913,7 @@ void ConstraintDependencyGraph::walkConstrainOp(
   std::vector<SourceRef> signalUsages, constUsages;
 
   for (auto operand : emitOp->getOperands()) {
-    auto latticeVal = SourceRefAnalysis::getValueState(solver, operand);
+    auto latticeVal = SourceRefAnalysis::getDependencyState(solver, operand);
     for (const auto &ref : latticeVal.foldToScalar()) {
       if (ref.isConstant()) {
         constUsages.push_back(ref);

--- a/lib/Analysis/ConstraintDependencyGraph.cpp
+++ b/lib/Analysis/ConstraintDependencyGraph.cpp
@@ -12,7 +12,10 @@
 #include "llzk/Analysis/SourceRefLattice.h"
 #include "llzk/Dialect/Array/IR/Ops.h"
 #include "llzk/Dialect/Array/Util/ArrayTypeHelper.h"
+#include "llzk/Dialect/Bool/IR/Ops.h"
+#include "llzk/Dialect/Cast/IR/Ops.h"
 #include "llzk/Dialect/Constrain/IR/Ops.h"
+#include "llzk/Dialect/Felt/IR/Ops.h"
 #include "llzk/Dialect/Function/IR/Ops.h"
 #include "llzk/Dialect/POD/IR/Ops.h"
 #include "llzk/Util/Hash.h"
@@ -36,6 +39,7 @@ using namespace mlir;
 namespace llzk {
 
 using namespace array;
+using namespace cast;
 using namespace component;
 using namespace constrain;
 using namespace function;
@@ -52,6 +56,69 @@ bool isInMaybeSkippedScfRegion(Operation *op) {
     }
   }
   return false;
+}
+
+std::optional<std::pair<APInt, APInt>> getStaticLoopIndexRange(Value index) {
+  if (auto toIndex = index.getDefiningOp<FeltToIndexOp>()) {
+    index = toIndex.getValue();
+  }
+  auto blockArg = llvm::dyn_cast<BlockArgument>(index);
+  if (!blockArg) {
+    return std::nullopt;
+  }
+
+  if (auto forOp = llvm::dyn_cast<scf::ForOp>(blockArg.getOwner()->getParentOp())) {
+    if (blockArg != forOp.getInductionVar()) {
+      return std::nullopt;
+    }
+    auto lower = forOp.getLowerBound().getDefiningOp<arith::ConstantIndexOp>();
+    auto upper = forOp.getUpperBound().getDefiningOp<arith::ConstantIndexOp>();
+    if (lower && upper) {
+      return std::pair(APInt(64, lower.value()), APInt(64, upper.value()));
+    }
+    return std::nullopt;
+  }
+
+  auto whileOp = llvm::dyn_cast<scf::WhileOp>(blockArg.getOwner()->getParentOp());
+  if (!whileOp || blockArg.getOwner() != &whileOp.getAfter().front()) {
+    return std::nullopt;
+  }
+  unsigned argumentNumber = blockArg.getArgNumber();
+  if (argumentNumber >= whileOp.getBeforeArguments().size() ||
+      argumentNumber >= whileOp.getInits().size()) {
+    return std::nullopt;
+  }
+
+  auto lower = whileOp.getInits()[argumentNumber].getDefiningOp<felt::FeltConstantOp>();
+  auto cmp = whileOp.getConditionOp().getCondition().getDefiningOp<boolean::CmpOp>();
+  Value beforeArgument = whileOp.getBeforeArguments()[argumentNumber];
+  if (!lower || !cmp || cmp.getPredicate() != boolean::FeltCmpPredicate::LT ||
+      cmp.getLhs() != beforeArgument) {
+    return std::nullopt;
+  }
+  auto upper = cmp.getRhs().getDefiningOp<felt::FeltConstantOp>();
+  if (!upper) {
+    return std::nullopt;
+  }
+  return std::pair(lower.getValueAPInt(), upper.getValueAPInt());
+}
+
+SourceRefLatticeValue createShapedArrayValue(Value rootValue, ArrayType arrayTy) {
+  SourceRefLatticeValue result(arrayTy.getShape());
+  ArrayIndexGen indexGen = ArrayIndexGen::from(arrayTy);
+  SourceRef root = *SourceRefLattice::getSourceRef(rootValue);
+  for (size_t i = 0; i < result.getArraySize(); ++i) {
+    auto indices = indexGen.delinearize(i, rootValue.getContext());
+    ensure(indices.has_value(), "could not delinearize aggregate array element index");
+    SourceRef element = root;
+    for (Attribute attr : *indices) {
+      auto child = element.createChild(SourceRefIndex(llvm::cast<IntegerAttr>(attr).getValue()));
+      ensure(succeeded(child), "could not create aggregate array element SourceRef");
+      element = *child;
+    }
+    (void)result.getElemFlatIdx(i).setValue(SourceRefLatticeValue(element));
+  }
+  return result;
 }
 
 } // namespace
@@ -80,6 +147,14 @@ public:
   /// Resolve known storage writes transitively, preserving unwritten and cyclic addresses.
   SourceRefLatticeValue
   resolveDependencies(const SourceRefLatticeValue &addresses, Operation *before) const;
+
+  /// Materialize compact nondeterministic aggregates from their storage dependencies.
+  SourceRefLatticeValue
+  resolveValueDependencies(mlir::Value value, const SourceRefLatticeValue &fallback) const;
+
+  /// Materialize compact nondeterministic aggregates from their final storage dependencies.
+  SourceRefLatticeValue
+  resolveValueDependencies(mlir::Value value, const SourceRefLatticeValue &fallback) const;
 
   /// Record a storage write for later dependency queries.
   void recordStorageWrite(
@@ -142,11 +217,7 @@ SourceRefLatticeValue SourceRefAnalysis::getDependencyState(DataFlowSolver &solv
     top = top->getParentOp();
   }
   if (const auto *state = solver.lookupState<StorageState>(solver.getProgramPointBefore(top))) {
-    Operation *before = val.getDefiningOp();
-    if (before == nullptr) {
-      before = val.getParentBlock()->getParentOp();
-    }
-    return state->resolveDependencies(value, before);
+    return state->resolveValueDependencies(val, value);
   }
   return value;
 }
@@ -158,6 +229,46 @@ SourceRefAnalysis::StorageState *SourceRefAnalysis::getStorageState(Operation *o
   auto *state = getOrCreate<StorageState>(getProgramPointBefore(op));
   state->setTop(op);
   return state;
+}
+
+SourceRefLatticeValue SourceRefAnalysis::StorageState::resolveValueDependencies(
+    Value value, const SourceRefLatticeValue &fallback
+) const {
+  auto result = llvm::dyn_cast<OpResult>(value);
+  auto nondet = result ? result.getDefiningOp<NonDetOp>() : NonDetOp();
+  auto arrayTy = nondet ? llvm::dyn_cast<ArrayType>(value.getType()) : ArrayType();
+  Operation *before = nullptr;
+  if (Operation *defOp = value.getDefiningOp()) {
+    auto memberAccess = llvm::dyn_cast<MemberRefOpInterface>(defOp);
+    auto podAccess = llvm::dyn_cast<PodAccessOpInterface>(defOp);
+    if ((memberAccess && memberAccess.isRead()) || (podAccess && podAccess.isRead()) ||
+        llvm::isa<ReadArrayOp, ExtractArrayOp>(defOp)) {
+      before = defOp;
+    }
+  }
+  constexpr size_t maxPreciselyResolvedElements = 64;
+  if (!arrayTy || !arrayTy.hasStaticShape() ||
+      std::cmp_greater(arrayTy.getNumElements(), maxPreciselyResolvedElements)) {
+    return resolveDependencies(fallback, before);
+  }
+  // Aggregate allocations model storage populated by following operations, so their dependencies
+  // intentionally use the complete write history. Storage reads use their defining operation as
+  // the cutoff above.
+  SourceRefLatticeValue resolved =
+      resolveDependencies(createShapedArrayValue(value, arrayTy), before);
+  for (size_t i = 0; i < resolved.getArraySize(); ++i) {
+    SourceRefLatticeValue &element = resolved.getElemFlatIdx(i);
+    SourceRefSet refs = element.foldToScalar();
+    if (llvm::any_of(refs, [](const SourceRef &ref) { return !ref.isConstant(); })) {
+      for (const SourceRef &ref : refs) {
+        auto constant = ref.getConstantValue();
+        if (succeeded(constant) && *constant == 0) {
+          (void)element.remove(ref);
+        }
+      }
+    }
+  }
+  return resolved;
 }
 
 SourceRefLatticeValue SourceRefAnalysis::StorageState::canonicalize(
@@ -491,6 +602,8 @@ SourceRefAnalysis::getWriteTargetState(DataFlowSolver &solver, Operation *op) {
 
         if (idxVals.isSingleValue() && idxVals.getSingleValue().isConstant()) {
           indices.emplace_back(*idxVals.getSingleValue().getConstantValue());
+        } else if (auto bounds = getStaticLoopIndexRange(idxOperand)) {
+          indices.emplace_back(bounds->first, bounds->second);
         } else {
           auto arrayType = llvm::dyn_cast<ArrayType>(array.getType());
           auto lower = APInt::getZero(64);
@@ -517,7 +630,8 @@ void SourceRefAnalysis::setToEntryState(Lattice *lattice) {
   if (auto value = llvm::dyn_cast_if_present<Value>(lattice->getAnchor())) {
     if (auto arg = llvm::dyn_cast<BlockArgument>(value)) {
       Operation *parent = arg.getOwner()->getParentOp();
-      if (llvm::isa_and_present<RegionBranchOpInterface>(parent) &&
+      if (parent && !llvm::isa<FunctionOpInterface>(parent) &&
+          llvm::isa<RegionBranchOpInterface>(parent) &&
           llvm::isa<ArrayType, StructType, PodType>(value.getType())) {
         // Region-branch arguments are aliases of their incoming aggregate storage. Giving them a
         // fresh root would make loop-carried writes unstable and would discard that identity.
@@ -589,11 +703,21 @@ LogicalResult SourceRefAnalysis::visitOperation(
   }
 
   if (auto arrayAccessOp = llvm::dyn_cast<ArrayAccessOpInterface>(op)) {
-    if (llvm::isa<WriteArrayOp, InsertArrayOp>(arrayAccessOp)) {
-      SourceRefLatticeValue writeTargets = arraySubdivisionOpUpdate(arrayAccessOp, operandVals);
+    if (llvm::isa<WriteArrayOp, InsertArrayOp>(op)) {
+      auto *arrayLattice = getLatticeElement(arrayAccessOp.getArrRef());
+      SourceRefLatticeValue updatedArray = arrayLattice->getValue();
       Value rvalue = op->getOperands().back();
       SourceRefLatticeValue writeValue = operandVals.at(rvalue)->getValue();
       const bool mayBeSkipped = isInMaybeSkippedScfRegion(op);
+      std::vector<SourceRefIndex> indices;
+      SourceRefLatticeValue writeTargets =
+          arraySubdivisionOpUpdate(arrayAccessOp, operandVals, &indices);
+      if (updatedArray.isArray()) {
+        ChangeResult changed = updatedArray.write(indices, writeValue, mayBeSkipped);
+        if (changed == ChangeResult::Change) {
+          propagateIfChanged(arrayLattice, arrayLattice->setValue(updatedArray));
+        }
+      }
       getStorageState(op)->recordStorageWrite(
           op, /*writeIndex=*/0, writeTargets, writeValue, mayBeSkipped
       );
@@ -602,8 +726,7 @@ LogicalResult SourceRefAnalysis::visitOperation(
             op, /*aliasIndex=*/0, writeValue, writeTargets, mayBeSkipped
         );
       }
-    }
-    if (!results.empty()) {
+    } else if (!results.empty()) {
       auto newVals = arraySubdivisionOpUpdate(arrayAccessOp, operandVals);
       propagateIfChanged(results.front(), results.front()->setValue(newVals));
     }
@@ -614,10 +737,18 @@ LogicalResult SourceRefAnalysis::visitOperation(
     auto createArrayRes = createArray.getResult();
     const auto &elements = createArray.getElements();
     if (elements.empty()) {
-      propagateIfChanged(
-          results.front(),
-          results.front()->setValue(SourceRef(llvm::cast<OpResult>(createArrayRes)))
-      );
+      ArrayType arrayTy = createArray.getType();
+      if (arrayTy.hasStaticShape()) {
+        propagateIfChanged(
+            results.front(),
+            results.front()->setValue(createShapedArrayValue(createArrayRes, arrayTy))
+        );
+      } else {
+        propagateIfChanged(
+            results.front(),
+            results.front()->setValue(SourceRef(llvm::cast<OpResult>(createArrayRes)))
+        );
+      }
       return success();
     }
 
@@ -747,7 +878,8 @@ ChangeResult SourceRefAnalysis::fallbackOpUpdate(
 }
 
 SourceRefLatticeValue SourceRefAnalysis::arraySubdivisionOpUpdate(
-    ArrayAccessOpInterface arrayAccessOp, const OperandValues &operandVals
+    ArrayAccessOpInterface arrayAccessOp, const OperandValues &operandVals,
+    std::vector<SourceRefIndex> *resolvedIndices
 ) {
   auto array = arrayAccessOp.getArrRef();
   auto it = operandVals.find(array);
@@ -763,6 +895,8 @@ SourceRefLatticeValue SourceRefAnalysis::arraySubdivisionOpUpdate(
 
     if (idxVals.isSingleValue() && idxVals.getSingleValue().isConstant()) {
       indices.emplace_back(*idxVals.getSingleValue().getConstantValue());
+    } else if (auto bounds = getStaticLoopIndexRange(idxOperand)) {
+      indices.emplace_back(bounds->first, bounds->second);
     } else {
       auto arrayType = llvm::dyn_cast<ArrayType>(array.getType());
       auto lower = APInt::getZero(64);
@@ -772,8 +906,20 @@ SourceRefLatticeValue SourceRefAnalysis::arraySubdivisionOpUpdate(
     }
   }
 
+  if (resolvedIndices != nullptr) {
+    *resolvedIndices = indices;
+    // Write-like operations only need the selected indices before updating the base lattice. Do
+    // not try to extract the old value: uninitialized or partially shaped aggregate storage may
+    // not yet support that read, while the subsequent write can still initialize it.
+    return SourceRefLatticeValue();
+  }
   auto newValsRes = currVals.extract(indices);
-  ensure(succeeded(newValsRes), "could not create SourceRef child for array access");
+  if (failed(newValsRes)) {
+    // Aggregate storage may conservatively fold to a scalar dependency set after control-flow or
+    // alias joins. In that case an element read depends on the whole folded value; retaining those
+    // dependencies is safer than manufacturing an ill-typed child path (and avoids a fatal error).
+    return currVals;
+  }
   auto [newVals, _] = *newValsRes;
   if (llvm::isa<ReadArrayOp, WriteArrayOp>(arrayAccessOp)) {
     ensure(newVals.isScalar(), "array read/write must produce a scalar value");

--- a/lib/Analysis/IntervalAnalysis.cpp
+++ b/lib/Analysis/IntervalAnalysis.cpp
@@ -1104,10 +1104,15 @@ mlir::LogicalResult IntervalDataFlowAnalysis::visitOperation(
     }
 
     SourceRefLatticeValue arrayVals = getSourceRefState(writeArr.getArrRef());
-    if (arrayVals.isScalar()) {
+    if (arrayVals.isSingleValue()) {
       std::vector<SourceRefIndex> indices = getArrayAccessIndices(op, writeArr);
       auto targetRefsRes = arrayVals.extract(indices);
-      ensure(succeeded(targetRefsRes), "could not create SourceRef child for array write");
+      // Aggregate escape snapshots may compact all element dependencies into a scalar set.
+      // The direct access reference above still records this write precisely; a compact set
+      // cannot be indexed further and is therefore only useful as a conservative dependency.
+      if (failed(targetRefsRes)) {
+        return success();
+      }
       auto [targetRefs, _] = *targetRefsRes;
       ensure(targetRefs.isScalar(), "array write must resolve to scalar references");
       for (const SourceRef &ref : targetRefs.getScalarValue()) {

--- a/lib/Analysis/SourceRef.cpp
+++ b/lib/Analysis/SourceRef.cpp
@@ -11,6 +11,7 @@
 
 #include "llzk/Dialect/Array/IR/Ops.h"
 #include "llzk/Dialect/Function/IR/Ops.h"
+#include "llzk/Dialect/Global/IR/Ops.h"
 #include "llzk/Dialect/String/IR/Types.h"
 #include "llzk/Transforms/LLZKLoweringUtils.h"
 #include "llzk/Util/Compare.h"
@@ -189,6 +190,16 @@ bool SourceRefIndex::overlaps(const SourceRefIndex &rhs) const {
 }
 
 /* SourceRef */
+
+bool SourceRef::isImmutableGlobal() const {
+  auto read = llvm::dyn_cast_if_present<global::GlobalReadOp>(value.getDefiningOp());
+  if (!read) {
+    return false;
+  }
+  SymbolTableCollection tables;
+  auto globalDef = read.getGlobalDefOp(tables);
+  return succeeded(globalDef) && globalDef->get().isConstant();
+}
 
 SourceRef::SortCategory SourceRef::getSortCategory() const {
   if (isBlockArgument()) {

--- a/test/Analysis/constraint_dependency_graph_pass.llzk
+++ b/test/Analysis/constraint_dependency_graph_pass.llzk
@@ -1322,8 +1322,8 @@ module attributes {llzk.lang} {
 }
 
 // CHECK-LABEL: @PodInitializedRoot ConstraintDependencyGraph {
-// CHECK-NEXT:     { %self.out, %pod.value }
+// CHECK-NEXT:     { %self.out, %arg1 }
 // CHECK-NEXT: }
 // INTRA-LABEL: @PodInitializedRoot ConstraintDependencyGraph {
-// INTRA-NEXT:     { %self.out, %pod.value }
+// INTRA-NEXT:     { %self.out, %arg1 }
 // INTRA-NEXT: }

--- a/unittests/Analysis/IntervalTests.cpp
+++ b/unittests/Analysis/IntervalTests.cpp
@@ -19,6 +19,7 @@
 #include "llzk/Util/StreamHelper.h"
 
 #include <mlir/Dialect/Arith/IR/Arith.h>
+#include <mlir/Dialect/SCF/IR/SCF.h>
 #include <mlir/Parser/Parser.h>
 
 #include <gtest/gtest.h>
@@ -601,6 +602,53 @@ module attributes {llzk.lang} {
 }
 )mlir";
 
+  static constexpr auto kScfCarriedPodArrayModule = R"mlir(
+module attributes {llzk.lang} {
+  struct.def @ScfCarriedPodArray {
+    struct.member @out : !felt.type {llzk.pub, signal}
+
+    function.def @compute() -> !struct.type<@ScfCarriedPodArray>
+        attributes {function.allow_non_native_field_ops, function.allow_witness} {
+      %self = struct.new : <@ScfCarriedPodArray>
+      %three = felt.const 3
+      %nine = felt.const 9
+      %left = pod.new { @value = %three } : !pod.type<[@value: !felt.type]>
+      %right = pod.new { @value = %nine } : !pod.type<[@value: !felt.type]>
+      %pods = array.new %left, %right : <2 x !pod.type<[@value: !felt.type]>>
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      %loop:2 = scf.while (%i = %c0, %state = %pods)
+          : (index, !array.type<2 x !pod.type<[@value: !felt.type]>>)
+          -> (index, !array.type<2 x !pod.type<[@value: !felt.type]>>) {
+        %lt = arith.cmpi slt, %i, %c1 : index
+        %eq = arith.cmpi eq, %i, %c0 : index
+        %cond = bool.and %lt, %eq
+        scf.condition(%cond) %i, %state
+            : index, !array.type<2 x !pod.type<[@value: !felt.type]>>
+      } do {
+      ^bb0(%i: index, %state: !array.type<2 x !pod.type<[@value: !felt.type]>>):
+        %pod = array.read %state[%c0]
+            : <2 x !pod.type<[@value: !felt.type]>>, !pod.type<[@value: !felt.type]>
+        %value = pod.read %pod[@value] : !pod.type<[@value: !felt.type]>, !felt.type
+        %next = arith.addi %i, %c1 : index
+        scf.yield %next, %state
+            : index, !array.type<2 x !pod.type<[@value: !felt.type]>>
+      }
+      %resultPod = array.read %loop#1[%c0]
+          : <2 x !pod.type<[@value: !felt.type]>>, !pod.type<[@value: !felt.type]>
+      %result = pod.read %resultPod[@value] : !pod.type<[@value: !felt.type]>, !felt.type
+      struct.writem %self[@out] = %result : <@ScfCarriedPodArray>, !felt.type
+      function.return %self : !struct.type<@ScfCarriedPodArray>
+    }
+
+    function.def @constrain(%self: !struct.type<@ScfCarriedPodArray>)
+        attributes {function.allow_constraint} {
+      function.return
+    }
+  }
+}
+)mlir";
+
   static constexpr auto kInitializedPodStorageModule = R"mlir(
 module attributes {llzk.lang} {
   struct.def @PodStorage {
@@ -731,6 +779,57 @@ TEST_F(IntervalAnalysisAPITests, ComputeIntervalsTrackArrayNewStoredIntoMember) 
   auto expected = Interval::TypeA(field, field.felt(5), field.felt(6));
   ASSERT_TRUE(checkCond(expected, out1It->second, expected == out1It->second))
       << buildStringViaPrint(*out1Ref) << " -> " << buildStringViaPrint(out1It->second);
+}
+
+TEST_F(IntervalAnalysisAPITests, ScfWhilePreservesCarriedPodArraySourceRefs) {
+  auto mod = parseModule(kScfCarriedPodArrayModule);
+  ASSERT_TRUE(mod);
+  auto structDef = *mod->getOps<StructDefOp>().begin();
+  auto computeFn = structDef.getComputeFuncOp();
+  ASSERT_TRUE(computeFn != nullptr);
+
+  scf::WhileOp whileOp;
+  array::ReadArrayOp resultRead;
+  pod::ReadPodOp resultPodRead;
+  computeFn.walk([&](scf::WhileOp candidate) { whileOp = candidate; });
+  ASSERT_TRUE(whileOp != nullptr);
+  computeFn.walk([&](array::ReadArrayOp candidateArrayRead) {
+    if (candidateArrayRead.getArrRef() == whileOp.getResult(1)) {
+      resultRead = candidateArrayRead;
+    }
+  });
+  ASSERT_TRUE(resultRead != nullptr);
+  computeFn.walk([&](pod::ReadPodOp candidatePodRead) {
+    if (candidatePodRead.getPodRef() == resultRead.getResult()) {
+      resultPodRead = candidatePodRead;
+    }
+  });
+  ASSERT_TRUE(resultPodRead != nullptr);
+
+  ModuleAnalysisManager mam(*mod, nullptr);
+  AnalysisManager am = mam;
+  ModuleIntervalAnalysis analysis(mod->getOperation());
+  const Field &field = Field::getField("babybear");
+  analysis.setField(field);
+  analysis.runAnalysis(am);
+
+  SourceRefLatticeValue carried =
+      SourceRefAnalysis::getValueState(analysis.getSolver(), whileOp.getResult(1));
+  ASSERT_TRUE(carried.isArray());
+  ASSERT_EQ(carried.getArraySize(), 2U);
+
+  SourceRefLatticeValue readState =
+      SourceRefAnalysis::getValueState(analysis.getSolver(), resultRead.getResult());
+  ASSERT_TRUE(readState.isSingleValue());
+  SourceRefLatticeValue scalarState =
+      SourceRefAnalysis::getValueState(analysis.getSolver(), resultPodRead.getResult());
+  ASSERT_TRUE(scalarState.isSingleValue());
+
+  const IntervalAnalysisLattice *resultLattice = lookupLattice(analysis, resultPodRead.getResult());
+  ASSERT_NE(resultLattice, nullptr);
+  const Interval &resultInterval = resultLattice->getValue().getScalarValue().getInterval();
+  // Loop-carried values are deliberately widened, but the post-loop query must remain usable.
+  EXPECT_TRUE(resultInterval.isEntire());
 }
 
 TEST_F(IntervalAnalysisAPITests, InitializedPodIntervalsSurviveAggregateMemberAssignment) {

--- a/unittests/Analysis/IntervalTests.cpp
+++ b/unittests/Analysis/IntervalTests.cpp
@@ -601,6 +601,32 @@ module attributes {llzk.lang} {
 }
 )mlir";
 
+  static constexpr auto kInitializedPodStorageModule = R"mlir(
+module attributes {llzk.lang} {
+  struct.def @PodStorage {
+    struct.member @storage : !pod.type<[@initialized: !felt.type, @written: !felt.type]>
+    function.def @compute() -> !struct.type<@PodStorage> {
+      %self = struct.new : !struct.type<@PodStorage>
+      %five = felt.const 5
+      %seven = felt.const 7
+      %storage = pod.new { @initialized = %five }
+          : !pod.type<[@initialized: !felt.type, @written: !felt.type]>
+      pod.write %storage[@written] = %seven
+          : !pod.type<[@initialized: !felt.type, @written: !felt.type]>, !felt.type
+      %read = pod.read %storage[@initialized]
+          : !pod.type<[@initialized: !felt.type, @written: !felt.type]>, !felt.type
+      struct.writem %self[@storage] = %storage
+          : !struct.type<@PodStorage>,
+            !pod.type<[@initialized: !felt.type, @written: !felt.type]>
+      function.return %self : !struct.type<@PodStorage>
+    }
+    function.def @constrain(%self: !struct.type<@PodStorage>) {
+      function.return
+    }
+  }
+}
+)mlir";
+
   OwningOpRef<ModuleOp> parseModule(llvm::StringRef source) {
     auto mod = parseSourceString<ModuleOp>(source, ParserConfig(&ctx));
     EXPECT_TRUE(mod);
@@ -705,6 +731,39 @@ TEST_F(IntervalAnalysisAPITests, ComputeIntervalsTrackArrayNewStoredIntoMember) 
   auto expected = Interval::TypeA(field, field.felt(5), field.felt(6));
   ASSERT_TRUE(checkCond(expected, out1It->second, expected == out1It->second))
       << buildStringViaPrint(*out1Ref) << " -> " << buildStringViaPrint(out1It->second);
+}
+
+TEST_F(IntervalAnalysisAPITests, InitializedPodIntervalsSurviveAggregateMemberAssignment) {
+  auto mod = parseModule(kInitializedPodStorageModule);
+  ASSERT_TRUE(mod);
+  auto structDef = *mod->getOps<StructDefOp>().begin();
+  auto computeFn = structDef.getComputeFuncOp();
+  ASSERT_TRUE(computeFn);
+
+  ModuleAnalysisManager mam(*mod, nullptr);
+  AnalysisManager am = mam;
+  ModuleIntervalAnalysis analysis(mod->getOperation());
+  const Field &field = Field::getField("babybear");
+  analysis.setField(field);
+  analysis.runAnalysis(am);
+
+  MemberDefOp storageMember = *structDef.getOps<MemberDefOp>().begin();
+  SourceRef storageRef(
+      mlir::cast<OpResult>(computeFn.getSelfValueFromCompute()),
+      {SourceRefIndex(storageMember), SourceRefIndex(StringAttr::get(&ctx, "initialized"))}
+  );
+  const auto &intervals = analysis.getResult(structDef).getComputeIntervals();
+  auto intervalIt = intervals.find(storageRef);
+  ASSERT_NE(intervalIt, intervals.end());
+  EXPECT_EQ(intervalIt->second, Interval::Degenerate(field, field.felt(5)));
+
+  SourceRef writtenRef(
+      mlir::cast<OpResult>(computeFn.getSelfValueFromCompute()),
+      {SourceRefIndex(storageMember), SourceRefIndex(StringAttr::get(&ctx, "written"))}
+  );
+  auto writtenIt = intervals.find(writtenRef);
+  ASSERT_NE(writtenIt, intervals.end());
+  EXPECT_EQ(writtenIt->second, Interval::Degenerate(field, field.felt(7)));
 }
 
 TEST_F(IntervalAnalysisAPITests, UnreducedIntervalsDisabledByDefault) {

--- a/unittests/Analysis/SourceRefTests.cpp
+++ b/unittests/Analysis/SourceRefTests.cpp
@@ -747,6 +747,220 @@ module attributes {llzk.lang} {
   );
 }
 
+TEST_F(SourceRefTests, ArrayMutationsUpdateStorageDependencies) {
+  static constexpr auto source = R"mlir(
+module attributes {llzk.lang} {
+  struct.def @ArrayMutations {
+    function.def @compute(%uninitializedValue: !felt.type, %initial: !felt.type,
+                          %replacement: !felt.type) -> !struct.type<@ArrayMutations> {
+      %self = struct.new : !struct.type<@ArrayMutations>
+      %c0 = arith.constant 0 : index
+      %uninitialized = array.new : !array.type<1 x !felt.type>
+      array.write %uninitialized[%c0] = %uninitializedValue
+          : !array.type<1 x !felt.type>, !felt.type
+      %readUninitialized = array.read %uninitialized[%c0]
+          : !array.type<1 x !felt.type>, !felt.type
+      %initialized = array.new %initial : !array.type<1 x !felt.type>
+      array.write %initialized[%c0] = %replacement
+          : !array.type<1 x !felt.type>, !felt.type
+      %readOverwritten = array.read %initialized[%c0]
+          : !array.type<1 x !felt.type>, !felt.type
+      function.return %self : !struct.type<@ArrayMutations>
+    }
+
+    function.def @constrain(
+        %self: !struct.type<@ArrayMutations>, %uninitializedValue: !felt.type,
+        %initial: !felt.type, %replacement: !felt.type
+    ) {
+      function.return
+    }
+  }
+}
+)mlir";
+
+  auto mod = parseSourceString<ModuleOp>(source, ParserConfig(&ctx));
+  ASSERT_TRUE(mod);
+  auto structDef = *mod->getOps<StructDefOp>().begin();
+  auto computeFn = structDef.getComputeFuncOp();
+  auto reads = llvm::to_vector(computeFn.getOps<array::ReadArrayOp>());
+  ASSERT_EQ(reads.size(), 2U);
+
+  ModuleAnalysisManager mam(*mod, nullptr);
+  AnalysisManager am = mam;
+  ConstraintDependencyGraphModuleAnalysis analysis(mod->getOperation());
+  analysis.ensureAnalysisRun(am);
+  DataFlowSolver &solver = analysis.getSolver();
+
+  EXPECT_EQ(
+      SourceRefAnalysis::getDependencyState(solver, reads[0].getResult()).foldToScalar(),
+      SourceRefSet({SourceRef(computeFn.getArgument(0))})
+  );
+  EXPECT_EQ(
+      SourceRefAnalysis::getDependencyState(solver, reads[1].getResult()).foldToScalar(),
+      SourceRefSet({SourceRef(computeFn.getArgument(2))})
+  );
+}
+
+TEST_F(SourceRefTests, ConditionalAggregateAliasPreservesBothAlternatives) {
+  static constexpr auto source = R"mlir(
+module attributes {llzk.lang} {
+  struct.def @ConditionalAggregateAlias {
+    function.def @compute(%initial: !felt.type, %replacement: !felt.type)
+        -> !struct.type<@ConditionalAggregateAlias> {
+      %self = struct.new : !struct.type<@ConditionalAggregateAlias>
+      %first = pod.new { @value = %initial } : !pod.type<[@value: !felt.type]>
+      %storage = pod.new { @nested = %first }
+          : !pod.type<[@nested: !pod.type<[@value: !felt.type]>]>
+      %condition = arith.constant true
+      scf.if %condition {
+        %second = pod.new { @value = %replacement } : !pod.type<[@value: !felt.type]>
+        pod.write %storage[@nested] = %second
+            : !pod.type<[@nested: !pod.type<[@value: !felt.type]>]>,
+              !pod.type<[@value: !felt.type]>
+      }
+      %nested = pod.read %storage[@nested]
+          : !pod.type<[@nested: !pod.type<[@value: !felt.type]>]>,
+            !pod.type<[@value: !felt.type]>
+      %read = pod.read %nested[@value]
+          : !pod.type<[@value: !felt.type]>, !felt.type
+      function.return %self : !struct.type<@ConditionalAggregateAlias>
+    }
+
+    function.def @constrain(
+        %self: !struct.type<@ConditionalAggregateAlias>, %initial: !felt.type,
+        %replacement: !felt.type
+    ) {
+      function.return
+    }
+  }
+}
+)mlir";
+
+  auto mod = parseSourceString<ModuleOp>(source, ParserConfig(&ctx));
+  ASSERT_TRUE(mod);
+  auto structDef = *mod->getOps<StructDefOp>().begin();
+  auto computeFn = structDef.getComputeFuncOp();
+  auto reads = llvm::to_vector(computeFn.getOps<pod::ReadPodOp>());
+  ASSERT_EQ(reads.size(), 2U);
+
+  ModuleAnalysisManager mam(*mod, nullptr);
+  AnalysisManager am = mam;
+  ConstraintDependencyGraphModuleAnalysis analysis(mod->getOperation());
+  analysis.ensureAnalysisRun(am);
+
+  EXPECT_EQ(
+      SourceRefAnalysis::getDependencyState(analysis.getSolver(), reads[1].getResult())
+          .foldToScalar(),
+      SourceRefSet({SourceRef(computeFn.getArgument(0)), SourceRef(computeFn.getArgument(1))})
+  );
+}
+
+TEST_F(SourceRefTests, AggregateArgumentInitializerPreservesChildPath) {
+  static constexpr auto source = R"mlir(
+module attributes {llzk.lang} {
+  struct.def @AggregateArgumentInitializer {
+    function.def @compute(%source: !pod.type<[@left: !felt.type, @right: !felt.type]>)
+        -> !struct.type<@AggregateArgumentInitializer> {
+      %self = struct.new : !struct.type<@AggregateArgumentInitializer>
+      %storage = pod.new { @nested = %source }
+          : !pod.type<[@nested: !pod.type<[@left: !felt.type, @right: !felt.type]>]>
+      %nested = pod.read %storage[@nested]
+          : !pod.type<[@nested: !pod.type<[@left: !felt.type, @right: !felt.type]>]>,
+            !pod.type<[@left: !felt.type, @right: !felt.type]>
+      %read = pod.read %nested[@left]
+          : !pod.type<[@left: !felt.type, @right: !felt.type]>, !felt.type
+      function.return %self : !struct.type<@AggregateArgumentInitializer>
+    }
+
+    function.def @constrain(
+        %self: !struct.type<@AggregateArgumentInitializer>,
+        %source: !pod.type<[@left: !felt.type, @right: !felt.type]>
+    ) {
+      function.return
+    }
+  }
+}
+)mlir";
+
+  auto mod = parseSourceString<ModuleOp>(source, ParserConfig(&ctx));
+  ASSERT_TRUE(mod);
+  auto structDef = *mod->getOps<StructDefOp>().begin();
+  auto computeFn = structDef.getComputeFuncOp();
+  auto reads = llvm::to_vector(computeFn.getOps<pod::ReadPodOp>());
+  ASSERT_EQ(reads.size(), 2U);
+
+  ModuleAnalysisManager mam(*mod, nullptr);
+  AnalysisManager am = mam;
+  ConstraintDependencyGraphModuleAnalysis analysis(mod->getOperation());
+  analysis.ensureAnalysisRun(am);
+
+  SourceRef expected(
+      mlir::cast<BlockArgument>(computeFn.getArgument(0)),
+      {SourceRefIndex(StringAttr::get(&ctx, "left"))}
+  );
+  EXPECT_EQ(
+      SourceRefAnalysis::getDependencyState(analysis.getSolver(), reads[1].getResult())
+          .foldToScalar(),
+      SourceRefSet({expected})
+  );
+}
+
+TEST_F(SourceRefTests, AggregateStructMemberInitializerPreservesChildPath) {
+  static constexpr auto source = R"mlir(
+module attributes {llzk.lang} {
+  struct.def @AggregateStructMemberInitializer {
+    struct.member @source : !pod.type<[@left: !felt.type, @right: !felt.type]>
+
+    function.def @compute(%left: !felt.type, %right: !felt.type)
+        -> !struct.type<@AggregateStructMemberInitializer> {
+      %self = struct.new : !struct.type<@AggregateStructMemberInitializer>
+      %source = pod.new { @left = %left, @right = %right }
+          : !pod.type<[@left: !felt.type, @right: !felt.type]>
+      struct.writem %self[@source] = %source
+          : !struct.type<@AggregateStructMemberInitializer>,
+            !pod.type<[@left: !felt.type, @right: !felt.type]>
+      %member = struct.readm %self[@source]
+          : !struct.type<@AggregateStructMemberInitializer>,
+            !pod.type<[@left: !felt.type, @right: !felt.type]>
+      %storage = pod.new { @nested = %member }
+          : !pod.type<[@nested: !pod.type<[@left: !felt.type, @right: !felt.type]>]>
+      %nested = pod.read %storage[@nested]
+          : !pod.type<[@nested: !pod.type<[@left: !felt.type, @right: !felt.type]>]>,
+            !pod.type<[@left: !felt.type, @right: !felt.type]>
+      %read = pod.read %nested[@left]
+          : !pod.type<[@left: !felt.type, @right: !felt.type]>, !felt.type
+      function.return %self : !struct.type<@AggregateStructMemberInitializer>
+    }
+
+    function.def @constrain(
+        %self: !struct.type<@AggregateStructMemberInitializer>, %left: !felt.type,
+        %right: !felt.type
+    ) {
+      function.return
+    }
+  }
+}
+)mlir";
+
+  auto mod = parseSourceString<ModuleOp>(source, ParserConfig(&ctx));
+  ASSERT_TRUE(mod);
+  auto structDef = *mod->getOps<StructDefOp>().begin();
+  auto computeFn = structDef.getComputeFuncOp();
+  auto reads = llvm::to_vector(computeFn.getOps<pod::ReadPodOp>());
+  ASSERT_EQ(reads.size(), 2U);
+
+  ModuleAnalysisManager mam(*mod, nullptr);
+  AnalysisManager am = mam;
+  ConstraintDependencyGraphModuleAnalysis analysis(mod->getOperation());
+  analysis.ensureAnalysisRun(am);
+
+  EXPECT_EQ(
+      SourceRefAnalysis::getDependencyState(analysis.getSolver(), reads[1].getResult())
+          .foldToScalar(),
+      SourceRefSet({SourceRef(computeFn.getArgument(0))})
+  );
+}
+
 TEST_F(SourceRefTests, ComputeSelfRebasesToConstrainSelfWithoutChangingPath) {
   auto mod = parseSourceString<ModuleOp>(kModule, ParserConfig(&ctx));
   ASSERT_TRUE(mod);

--- a/unittests/Analysis/SourceRefTests.cpp
+++ b/unittests/Analysis/SourceRefTests.cpp
@@ -10,8 +10,10 @@
 #include "../LLZKTestBase.h"
 #include "../LLZKTestUtils.h"
 
+#include "llzk/Analysis/ConstraintDependencyGraph.h"
 #include "llzk/Analysis/SourceRef.h"
 #include "llzk/Analysis/SourceRefLattice.h"
+#include "llzk/Dialect/Felt/IR/Ops.h"
 #include "llzk/Dialect/Function/IR/Ops.h"
 #include "llzk/Dialect/Global/IR/Ops.h"
 #include "llzk/Dialect/POD/IR/Ops.h"
@@ -274,6 +276,477 @@ TEST_F(SourceRefTests, PodRecordsAndMembersRemainDistinct) {
   EXPECT_FALSE(memberRef.overlaps(arbitraryPodRef));
 }
 
+TEST_F(SourceRefTests, StorageDependenciesAreSeparateFromAddressIdentity) {
+  static constexpr auto source = R"mlir(
+module attributes {llzk.lang} {
+  struct.def @StorageDependencies {
+    struct.member @storage : !pod.type<[@value: !felt.type, @missing: !felt.type]>
+
+    function.def @compute(%initial: !felt.type, %replacement: !felt.type)
+        -> !struct.type<@StorageDependencies> {
+      %self = struct.new : !struct.type<@StorageDependencies>
+      %storage = pod.new { @value = %initial }
+          : !pod.type<[@value: !felt.type, @missing: !felt.type]>
+      pod.write %storage[@value] = %replacement
+          : !pod.type<[@value: !felt.type, @missing: !felt.type]>, !felt.type
+      %written = pod.read %storage[@value]
+          : !pod.type<[@value: !felt.type, @missing: !felt.type]>, !felt.type
+
+      %other = pod.new { @value = %written }
+          : !pod.type<[@value: !felt.type, @missing: !felt.type]>
+      %transitive = pod.read %other[@value]
+          : !pod.type<[@value: !felt.type, @missing: !felt.type]>, !felt.type
+      %unwritten = pod.read %storage[@missing]
+          : !pod.type<[@value: !felt.type, @missing: !felt.type]>, !felt.type
+
+      %conditional = pod.new { @value = %initial }
+          : !pod.type<[@value: !felt.type, @missing: !felt.type]>
+      %true = arith.constant true
+      scf.if %true {
+        pod.write %conditional[@value] = %replacement
+            : !pod.type<[@value: !felt.type, @missing: !felt.type]>, !felt.type
+      }
+      %maybe = pod.read %conditional[@value]
+          : !pod.type<[@value: !felt.type, @missing: !felt.type]>, !felt.type
+
+      %cycleA = pod.new : !pod.type<[@value: !felt.type, @missing: !felt.type]>
+      %cycleB = pod.new : !pod.type<[@value: !felt.type, @missing: !felt.type]>
+      %cycleBValue = pod.read %cycleB[@value]
+          : !pod.type<[@value: !felt.type, @missing: !felt.type]>, !felt.type
+      pod.write %cycleA[@value] = %cycleBValue
+          : !pod.type<[@value: !felt.type, @missing: !felt.type]>, !felt.type
+      %cycleAValue = pod.read %cycleA[@value]
+          : !pod.type<[@value: !felt.type, @missing: !felt.type]>, !felt.type
+      pod.write %cycleB[@value] = %cycleAValue
+          : !pod.type<[@value: !felt.type, @missing: !felt.type]>, !felt.type
+      %cycle = pod.read %cycleA[@value]
+          : !pod.type<[@value: !felt.type, @missing: !felt.type]>, !felt.type
+
+      struct.writem %self[@storage] = %storage
+          : !struct.type<@StorageDependencies>,
+            !pod.type<[@value: !felt.type, @missing: !felt.type]>
+      function.return %self : !struct.type<@StorageDependencies>
+    }
+
+    function.def @constrain(
+        %self: !struct.type<@StorageDependencies>,
+        %initial: !felt.type,
+        %replacement: !felt.type
+    ) {
+      %storage = struct.readm %self[@storage]
+          : !struct.type<@StorageDependencies>,
+            !pod.type<[@value: !felt.type, @missing: !felt.type]>
+      %value = pod.read %storage[@value]
+          : !pod.type<[@value: !felt.type, @missing: !felt.type]>, !felt.type
+      function.return
+    }
+  }
+}
+)mlir";
+
+  auto mod = parseSourceString<ModuleOp>(source, ParserConfig(&ctx));
+  ASSERT_TRUE(mod);
+  auto structDef = *mod->getOps<StructDefOp>().begin();
+  auto computeFn = structDef.getComputeFuncOp();
+  auto constrainFn = structDef.getConstrainFuncOp();
+  auto storageMember = *structDef.getOps<MemberDefOp>().begin();
+
+  llvm::SmallVector<pod::NewPodOp> pods;
+  llvm::SmallVector<pod::ReadPodOp> reads;
+  computeFn.walk([&](pod::NewPodOp op) { pods.push_back(op); });
+  computeFn.walk([&](pod::ReadPodOp op) { reads.push_back(op); });
+  ASSERT_EQ(pods.size(), 5U);
+  ASSERT_EQ(reads.size(), 7U);
+  pod::ReadPodOp constrainRead;
+  constrainFn.walk([&](pod::ReadPodOp op) { constrainRead = op; });
+  ASSERT_TRUE(constrainRead);
+
+  ModuleAnalysisManager mam(*mod, nullptr);
+  AnalysisManager am = mam;
+  ConstraintDependencyGraphModuleAnalysis analysis(mod->getOperation());
+  analysis.ensureAnalysisRun(am);
+  DataFlowSolver &solver = analysis.getSolver();
+
+  SourceRef constrainStorageValue(
+      mlir::cast<BlockArgument>(constrainFn.getSelfValueFromConstrain()),
+      {SourceRefIndex(storageMember), SourceRefIndex(StringAttr::get(&ctx, "value"))}
+  );
+  EXPECT_EQ(
+      SourceRefAnalysis::getDependencyState(solver, constrainRead.getResult()).foldToScalar(),
+      SourceRefSet({constrainStorageValue})
+  );
+
+  auto valueName = StringAttr::get(&ctx, "value");
+  auto missingName = StringAttr::get(&ctx, "missing");
+  SourceRef storageValue(mlir::cast<OpResult>(pods[0].getResult()), {SourceRefIndex(valueName)});
+  SourceRef storageMissing(
+      mlir::cast<OpResult>(pods[0].getResult()), {SourceRefIndex(missingName)}
+  );
+  SourceRef otherValue(mlir::cast<OpResult>(pods[1].getResult()), {SourceRefIndex(valueName)});
+
+  auto rawWritten = SourceRefAnalysis::getValueState(solver, reads[0].getResult());
+  ASSERT_TRUE(rawWritten.isSingleValue());
+  EXPECT_EQ(rawWritten.getSingleValue(), storageValue);
+  auto writtenDependencies =
+      SourceRefAnalysis::getDependencyState(solver, reads[0].getResult()).foldToScalar();
+  EXPECT_EQ(writtenDependencies, SourceRefSet({SourceRef(computeFn.getArgument(1))}));
+
+  auto rawTransitive = SourceRefAnalysis::getValueState(solver, reads[1].getResult());
+  ASSERT_TRUE(rawTransitive.isSingleValue());
+  EXPECT_EQ(rawTransitive.getSingleValue(), otherValue);
+  auto transitiveDependencies =
+      SourceRefAnalysis::getDependencyState(solver, reads[1].getResult()).foldToScalar();
+  EXPECT_EQ(transitiveDependencies, SourceRefSet({SourceRef(computeFn.getArgument(1))}));
+
+  auto rawUnwritten = SourceRefAnalysis::getValueState(solver, reads[2].getResult());
+  ASSERT_TRUE(rawUnwritten.isSingleValue());
+  EXPECT_EQ(rawUnwritten.getSingleValue(), storageMissing);
+  auto unwrittenDependencies =
+      SourceRefAnalysis::getDependencyState(solver, reads[2].getResult()).foldToScalar();
+  EXPECT_EQ(unwrittenDependencies, SourceRefSet({storageMissing}));
+
+  auto maybeDependencies =
+      SourceRefAnalysis::getDependencyState(solver, reads[3].getResult()).foldToScalar();
+  EXPECT_TRUE(maybeDependencies.contains(SourceRef(computeFn.getArgument(0))));
+  EXPECT_TRUE(maybeDependencies.contains(SourceRef(computeFn.getArgument(1))));
+
+  auto cycleDependencies =
+      SourceRefAnalysis::getDependencyState(solver, reads[6].getResult()).foldToScalar();
+  EXPECT_FALSE(cycleDependencies.empty());
+}
+
+TEST_F(SourceRefTests, ConditionalStorageWritePreservesNondeterministicAlternative) {
+  static constexpr auto source = R"mlir(
+module attributes {llzk.lang} {
+  struct.def @NondeterministicStorage {
+    function.def @compute(%replacement: !felt.type) -> !struct.type<@NondeterministicStorage> {
+      %self = struct.new : !struct.type<@NondeterministicStorage>
+      %unknown = llzk.nondet : !felt.type
+      %storage = pod.new { @value = %unknown } : !pod.type<[@value: !felt.type]>
+      %true = arith.constant true
+      scf.if %true {
+        pod.write %storage[@value] = %replacement
+            : !pod.type<[@value: !felt.type]>, !felt.type
+      }
+      %read = pod.read %storage[@value]
+          : !pod.type<[@value: !felt.type]>, !felt.type
+      function.return %self : !struct.type<@NondeterministicStorage>
+    }
+
+    function.def @constrain(
+        %self: !struct.type<@NondeterministicStorage>, %replacement: !felt.type
+    ) {
+      function.return
+    }
+  }
+}
+)mlir";
+
+  auto mod = parseSourceString<ModuleOp>(source, ParserConfig(&ctx));
+  ASSERT_TRUE(mod);
+  auto structDef = *mod->getOps<StructDefOp>().begin();
+  auto computeFn = structDef.getComputeFuncOp();
+  auto nondet = *computeFn.getOps<NonDetOp>().begin();
+  auto read = *computeFn.getOps<pod::ReadPodOp>().begin();
+
+  ModuleAnalysisManager mam(*mod, nullptr);
+  AnalysisManager am = mam;
+  ConstraintDependencyGraphModuleAnalysis analysis(mod->getOperation());
+  analysis.ensureAnalysisRun(am);
+  DataFlowSolver &solver = analysis.getSolver();
+
+  SourceRefSet dependencies =
+      SourceRefAnalysis::getDependencyState(solver, read.getResult()).foldToScalar();
+  EXPECT_TRUE(dependencies.contains(SourceRef(mlir::cast<OpResult>(nondet.getResult()))));
+  EXPECT_TRUE(dependencies.contains(SourceRef(computeFn.getArgument(0))));
+}
+
+TEST_F(SourceRefTests, DefiniteStorageWritesFollowProgramOrderAfterSolverRevisit) {
+  static constexpr auto source = R"mlir(
+module attributes {llzk.lang} {
+  struct.def @OrderedStorage {
+    function.def @compute(
+        %earlier: !felt.type, %alternative: !felt.type, %final: !felt.type
+    ) -> !struct.type<@OrderedStorage> {
+      %self = struct.new : !struct.type<@OrderedStorage>
+      %storage = pod.new : !pod.type<[@value: !felt.type]>
+      %true = arith.constant true
+      %selected = scf.if %true -> (!felt.type) {
+        scf.yield %earlier : !felt.type
+      } else {
+        scf.yield %alternative : !felt.type
+      }
+      pod.write %storage[@value] = %selected
+          : !pod.type<[@value: !felt.type]>, !felt.type
+      pod.write %storage[@value] = %final
+          : !pod.type<[@value: !felt.type]>, !felt.type
+      %read = pod.read %storage[@value]
+          : !pod.type<[@value: !felt.type]>, !felt.type
+      function.return %self : !struct.type<@OrderedStorage>
+    }
+
+    function.def @constrain(
+        %self: !struct.type<@OrderedStorage>, %earlier: !felt.type,
+        %alternative: !felt.type, %final: !felt.type
+    ) {
+      function.return
+    }
+  }
+}
+)mlir";
+
+  auto mod = parseSourceString<ModuleOp>(source, ParserConfig(&ctx));
+  ASSERT_TRUE(mod);
+  auto structDef = *mod->getOps<StructDefOp>().begin();
+  auto computeFn = structDef.getComputeFuncOp();
+  auto read = *computeFn.getOps<pod::ReadPodOp>().begin();
+
+  ModuleAnalysisManager mam(*mod, nullptr);
+  AnalysisManager am = mam;
+  ConstraintDependencyGraphModuleAnalysis analysis(mod->getOperation());
+  analysis.ensureAnalysisRun(am);
+  DataFlowSolver &solver = analysis.getSolver();
+
+  EXPECT_EQ(
+      SourceRefAnalysis::getDependencyState(solver, read.getResult()).foldToScalar(),
+      SourceRefSet({SourceRef(computeFn.getArgument(2))})
+  );
+}
+
+TEST_F(SourceRefTests, AggregatePodInitializerRebasesNestedRecordDependencies) {
+  static constexpr auto source = R"mlir(
+module attributes {llzk.lang} {
+  struct.def @NestedPodStorage {
+    function.def @compute(%left: !felt.type, %right: !felt.type)
+        -> !struct.type<@NestedPodStorage> {
+      %self = struct.new : !struct.type<@NestedPodStorage>
+      %inner = pod.new { @left = %left, @right = %right }
+          : !pod.type<[@left: !felt.type, @right: !felt.type]>
+      %outer = pod.new { @nested = %inner }
+          : !pod.type<[@nested: !pod.type<[@left: !felt.type, @right: !felt.type]>]>
+      %nested = pod.read %outer[@nested]
+          : !pod.type<[@nested: !pod.type<[@left: !felt.type, @right: !felt.type]>]>,
+            !pod.type<[@left: !felt.type, @right: !felt.type]>
+      %read = pod.read %nested[@left]
+          : !pod.type<[@left: !felt.type, @right: !felt.type]>, !felt.type
+      function.return %self : !struct.type<@NestedPodStorage>
+    }
+
+    function.def @constrain(
+        %self: !struct.type<@NestedPodStorage>, %left: !felt.type, %right: !felt.type
+    ) {
+      function.return
+    }
+  }
+}
+)mlir";
+
+  auto mod = parseSourceString<ModuleOp>(source, ParserConfig(&ctx));
+  ASSERT_TRUE(mod);
+  auto structDef = *mod->getOps<StructDefOp>().begin();
+  auto computeFn = structDef.getComputeFuncOp();
+  auto reads = llvm::to_vector(computeFn.getOps<pod::ReadPodOp>());
+  ASSERT_EQ(reads.size(), 2U);
+
+  ModuleAnalysisManager mam(*mod, nullptr);
+  AnalysisManager am = mam;
+  ConstraintDependencyGraphModuleAnalysis analysis(mod->getOperation());
+  analysis.ensureAnalysisRun(am);
+  DataFlowSolver &solver = analysis.getSolver();
+
+  EXPECT_EQ(
+      SourceRefAnalysis::getDependencyState(solver, reads[1].getResult()).foldToScalar(),
+      SourceRefSet({SourceRef(computeFn.getArgument(0))})
+  );
+}
+
+TEST_F(SourceRefTests, StorageReadsResolveAtTheirProgramPoint) {
+  static constexpr auto source = R"mlir(
+module attributes {llzk.lang} {
+  struct.def @ReadBeforeWrite {
+    function.def @compute(%initial: !felt.type, %replacement: !felt.type)
+        -> !struct.type<@ReadBeforeWrite> {
+      %self = struct.new : !struct.type<@ReadBeforeWrite>
+      %storage = pod.new { @value = %initial } : !pod.type<[@value: !felt.type]>
+      %before = pod.read %storage[@value]
+          : !pod.type<[@value: !felt.type]>, !felt.type
+      pod.write %storage[@value] = %replacement
+          : !pod.type<[@value: !felt.type]>, !felt.type
+      function.return %self : !struct.type<@ReadBeforeWrite>
+    }
+
+    function.def @constrain(
+        %self: !struct.type<@ReadBeforeWrite>, %initial: !felt.type,
+        %replacement: !felt.type
+    ) {
+      function.return
+    }
+  }
+}
+)mlir";
+
+  auto mod = parseSourceString<ModuleOp>(source, ParserConfig(&ctx));
+  ASSERT_TRUE(mod);
+  auto structDef = *mod->getOps<StructDefOp>().begin();
+  auto computeFn = structDef.getComputeFuncOp();
+  auto read = *computeFn.getOps<pod::ReadPodOp>().begin();
+
+  ModuleAnalysisManager mam(*mod, nullptr);
+  AnalysisManager am = mam;
+  ConstraintDependencyGraphModuleAnalysis analysis(mod->getOperation());
+  analysis.ensureAnalysisRun(am);
+
+  EXPECT_EQ(
+      SourceRefAnalysis::getDependencyState(analysis.getSolver(), read.getResult()).foldToScalar(),
+      SourceRefSet({SourceRef(computeFn.getArgument(0))})
+  );
+}
+
+TEST_F(SourceRefTests, StorageDependenciesTranslateAcrossFunctionReturns) {
+  static constexpr auto source = R"mlir(
+module attributes {llzk.lang} {
+  function.def @load(%input: !felt.type) -> !felt.type {
+    %storage = pod.new { @value = %input } : !pod.type<[@value: !felt.type]>
+    %read = pod.read %storage[@value]
+        : !pod.type<[@value: !felt.type]>, !felt.type
+    function.return %read : !felt.type
+  }
+
+  struct.def @CallStorage {
+    function.def @compute(%input: !felt.type) -> !struct.type<@CallStorage> {
+      %self = struct.new : !struct.type<@CallStorage>
+      %loaded = function.call @load(%input) : (!felt.type) -> !felt.type
+      function.return %self : !struct.type<@CallStorage>
+    }
+
+    function.def @constrain(%self: !struct.type<@CallStorage>, %input: !felt.type) {
+      function.return
+    }
+  }
+}
+)mlir";
+
+  auto mod = parseSourceString<ModuleOp>(source, ParserConfig(&ctx));
+  ASSERT_TRUE(mod);
+  auto structDef = *mod->getOps<StructDefOp>().begin();
+  auto computeFn = structDef.getComputeFuncOp();
+  auto call = *computeFn.getOps<function::CallOp>().begin();
+
+  ModuleAnalysisManager mam(*mod, nullptr);
+  AnalysisManager am = mam;
+  ConstraintDependencyGraphModuleAnalysis analysis(mod->getOperation());
+  analysis.ensureAnalysisRun(am);
+
+  EXPECT_EQ(
+      SourceRefAnalysis::getDependencyState(analysis.getSolver(), call.getResult(0)).foldToScalar(),
+      SourceRefSet({SourceRef(computeFn.getArgument(0))})
+  );
+}
+
+TEST_F(SourceRefTests, StorageDependenciesTranslateIntoNestedConstrainCalls) {
+  static constexpr auto source = R"mlir(
+module attributes {llzk.lang} {
+  struct.def @Child {
+    function.def @compute(%input: !felt.type) -> !struct.type<@Child> {
+      %self = struct.new : !struct.type<@Child>
+      function.return %self : !struct.type<@Child>
+    }
+
+    function.def @constrain(%self: !struct.type<@Child>, %input: !felt.type) {
+      %zero = felt.const 0
+      constrain.eq %input, %zero : !felt.type, !felt.type
+      function.return
+    }
+  }
+
+  struct.def @Parent {
+    struct.member @child : !struct.type<@Child>
+
+    function.def @compute(%input: !felt.type) -> !struct.type<@Parent> {
+      %self = struct.new : !struct.type<@Parent>
+      %child = function.call @Child::@compute(%input)
+          : (!felt.type) -> !struct.type<@Child>
+      struct.writem %self[@child] = %child
+          : !struct.type<@Parent>, !struct.type<@Child>
+      function.return %self : !struct.type<@Parent>
+    }
+
+    function.def @constrain(%self: !struct.type<@Parent>, %input: !felt.type) {
+      %child = struct.readm %self[@child]
+          : !struct.type<@Parent>, !struct.type<@Child>
+      %storage = pod.new { @value = %input } : !pod.type<[@value: !felt.type]>
+      %read = pod.read %storage[@value]
+          : !pod.type<[@value: !felt.type]>, !felt.type
+      function.call @Child::@constrain(%child, %read)
+          : (!struct.type<@Child>, !felt.type) -> ()
+      function.return
+    }
+  }
+}
+)mlir";
+
+  auto mod = parseSourceString<ModuleOp>(source, ParserConfig(&ctx));
+  ASSERT_TRUE(mod);
+  auto structs = llvm::to_vector(mod->getOps<StructDefOp>());
+  ASSERT_EQ(structs.size(), 2U);
+  auto childConstrain = structs[0].getConstrainFuncOp();
+  auto parentConstrain = structs[1].getConstrainFuncOp();
+  auto zero = *childConstrain.getOps<felt::FeltConstantOp>().begin();
+
+  ModuleAnalysisManager mam(*mod, nullptr);
+  AnalysisManager am = mam;
+  ConstraintDependencyGraphModuleAnalysis analysis(mod->getOperation());
+  analysis.ensureAnalysisRun(am);
+
+  SourceRef parentInput(parentConstrain.getArgument(1));
+  SourceRef zeroRef(zero);
+  EXPECT_TRUE(analysis.getResult(structs[1]).getConstrainingValues(parentInput).contains(zeroRef));
+}
+
+TEST_F(SourceRefTests, ArrayPodInitializerRebasesElementDependencies) {
+  static constexpr auto source = R"mlir(
+module attributes {llzk.lang} {
+  struct.def @ArrayPodStorage {
+    function.def @compute(%left: !felt.type, %right: !felt.type)
+        -> !struct.type<@ArrayPodStorage> {
+      %self = struct.new : !struct.type<@ArrayPodStorage>
+      %values = array.new %left, %right : !array.type<2 x !felt.type>
+      %storage = pod.new { @values = %values }
+          : !pod.type<[@values: !array.type<2 x !felt.type>]>
+      %stored = pod.read %storage[@values]
+          : !pod.type<[@values: !array.type<2 x !felt.type>]>,
+            !array.type<2 x !felt.type>
+      %c0 = arith.constant 0 : index
+      %read = array.read %stored[%c0] : !array.type<2 x !felt.type>, !felt.type
+      function.return %self : !struct.type<@ArrayPodStorage>
+    }
+
+    function.def @constrain(
+        %self: !struct.type<@ArrayPodStorage>, %left: !felt.type, %right: !felt.type
+    ) {
+      function.return
+    }
+  }
+}
+)mlir";
+
+  auto mod = parseSourceString<ModuleOp>(source, ParserConfig(&ctx));
+  ASSERT_TRUE(mod);
+  auto structDef = *mod->getOps<StructDefOp>().begin();
+  auto computeFn = structDef.getComputeFuncOp();
+  auto read = *computeFn.getOps<array::ReadArrayOp>().begin();
+
+  ModuleAnalysisManager mam(*mod, nullptr);
+  AnalysisManager am = mam;
+  ConstraintDependencyGraphModuleAnalysis analysis(mod->getOperation());
+  analysis.ensureAnalysisRun(am);
+
+  EXPECT_EQ(
+      SourceRefAnalysis::getDependencyState(analysis.getSolver(), read.getResult()).foldToScalar(),
+      SourceRefSet({SourceRef(computeFn.getArgument(0))})
+  );
+}
+
 TEST_F(SourceRefTests, ComputeSelfRebasesToConstrainSelfWithoutChangingPath) {
   auto mod = parseSourceString<ModuleOp>(kModule, ParserConfig(&ctx));
   ASSERT_TRUE(mod);
@@ -353,6 +826,7 @@ module attributes {llzk.lang} {
   ASSERT_TRUE(succeeded(ref));
   EXPECT_TRUE(ref->isRooted());
   EXPECT_FALSE(ref->isTemplateConstant());
+  EXPECT_TRUE(ref->isImmutableGlobal());
 }
 
 TEST_F(SourceRefTests, ScfBlockArgumentsUseUnnamedFallback) {

--- a/unittests/Analysis/SourceRefTests.cpp
+++ b/unittests/Analysis/SourceRefTests.cpp
@@ -353,10 +353,13 @@ module attributes {llzk.lang} {
 
   llvm::SmallVector<pod::NewPodOp> pods;
   llvm::SmallVector<pod::ReadPodOp> reads;
+  component::MemberWriteOp storageWrite;
   computeFn.walk([&](pod::NewPodOp op) { pods.push_back(op); });
   computeFn.walk([&](pod::ReadPodOp op) { reads.push_back(op); });
+  computeFn.walk([&](component::MemberWriteOp op) { storageWrite = op; });
   ASSERT_EQ(pods.size(), 5U);
   ASSERT_EQ(reads.size(), 7U);
+  ASSERT_TRUE(storageWrite);
   pod::ReadPodOp constrainRead;
   constrainFn.walk([&](pod::ReadPodOp op) { constrainRead = op; });
   ASSERT_TRUE(constrainRead);
@@ -366,6 +369,13 @@ module attributes {llzk.lang} {
   ConstraintDependencyGraphModuleAnalysis analysis(mod->getOperation());
   analysis.ensureAnalysisRun(am);
   DataFlowSolver &solver = analysis.getSolver();
+
+  auto writeTarget = SourceRefAnalysis::getWriteTargetState(solver, storageWrite);
+  ASSERT_TRUE(succeeded(writeTarget));
+  SourceRef expectedWriteTarget(
+      mlir::cast<OpResult>(computeFn.getSelfValueFromCompute()), {SourceRefIndex(storageMember)}
+  );
+  EXPECT_EQ(writeTarget->foldToScalar(), SourceRefSet({expectedWriteTarget}));
 
   SourceRef constrainStorageValue(
       mlir::cast<BlockArgument>(constrainFn.getSelfValueFromConstrain()),


### PR DESCRIPTION
## Summary

Preserves aggregate analysis state across SCF loops using the raw storage and explicit dependency views from #649. This is PR 3 of 6 in the stacked series.

## Related issues

No standalone issue; depends on #649.

## Changes

- Carry aggregate state through `scf.while` operands, block arguments, conditions, yields, and results.
- Support resultless array writes/inserts, nested and dynamic writes, and static loop-index ranges.
- Conservatively fold reads and extend dependency resolution to materialize small static nondeterministic arrays from final storage without exposing unwritten allocation roots.
- Add focused regressions for array-of-POD loop state, nested writes, post-loop reads, and conservative intervals.

## Testing

- `git diff --check`
- Focused SCF aggregate-state and dependency-resolution regressions
- `nix build -L` on this exact stacked commit: 371 lit tests and 1,312 unit/CAPI tests passed

## Submission checklist

- [ ] ~If I am an external contributor, this PR has a linked issue marked `approved`; otherwise, this does not apply.~
- [x] I added or updated tests for all relevant behavior, or explained above why tests are not needed.
- [x] I updated the relevant TableGen or other documentation, or explained above why documentation is not needed.
- [x] I added a changelog entry describing user-visible changes. (`create-changelog` in the Nix development shell creates a template.)
- [ ] ~I enabled **Allow edits from maintainers** if this PR comes from a fork.~

## AI assistance

- [ ] No AI tools contributed to this PR.
- [x] AI tools contributed to this PR.

**Tools used:** OpenAI Codex.

**How the tools contributed:** Codex helped partition the original working-tree change, implement the raw-versus-resolved SourceRef architecture, add focused regressions, and prepare this draft PR.

**How I verified the contribution:** Reviewed the isolated diff and ran `git diff --check`, the focused analysis regressions through the project test suite, and `nix build -L` on this exact commit.