### PR TITLE
Traverse overlapping constraint dependencies

### DIFF
--- a/changelogs/unreleased/codex__circom-analysis-4-overlap-cdg.yaml
+++ b/changelogs/unreleased/codex__circom-analysis-4-overlap-cdg.yaml
@@ -1,0 +1,2 @@
+fixed:
+  - Traverse overlapping aggregate constraint dependencies transitively and preserve concrete ranges

--- a/include/llzk/Analysis/ConstraintDependencyGraph.h
+++ b/include/llzk/Analysis/ConstraintDependencyGraph.h
@@ -185,13 +185,15 @@ public:
 
   ConstraintDependencyGraph(const ConstraintDependencyGraph &other)
       : mod(other.mod), structDef(other.structDef), ctx(other.ctx), signalSets(other.signalSets),
-        constantSets(other.constantSets), ref2Val(other.ref2Val), tables() {}
+        dependencyEdges(other.dependencyEdges), constantSets(other.constantSets),
+        ref2Val(other.ref2Val), tables() {}
 
   ConstraintDependencyGraph &operator=(const ConstraintDependencyGraph &other) {
     mod = other.mod;
     structDef = other.structDef;
     ctx = other.ctx;
     signalSets = other.signalSets;
+    dependencyEdges = other.dependencyEdges;
     constantSets = other.constantSets;
     ref2Val = other.ref2Val;
     return *this;
@@ -207,6 +209,9 @@ private:
 
   // Transitive closure only over signals.
   llvm::EquivalenceClasses<SourceRef> signalSets;
+  // Pairwise dependency edges retain the origin of relationships that an equivalence-class
+  // closure would otherwise erase, especially for control-flow-selected aggregate alternatives.
+  std::unordered_map<SourceRef, SourceRefSet, SourceRef::Hash> dependencyEdges;
   // A simple set mapping of constants, as we do not want to compute a transitive closure over
   // constants.
   std::unordered_map<SourceRef, SourceRefSet, SourceRef::Hash> constantSets;

--- a/lib/Analysis/ConstraintDependencyGraph.cpp
+++ b/lib/Analysis/ConstraintDependencyGraph.cpp
@@ -103,6 +103,86 @@ std::optional<std::pair<APInt, APInt>> getStaticLoopIndexRange(Value index) {
   return std::pair(lower.getValueAPInt(), upper.getValueAPInt());
 }
 
+llvm::SmallVector<std::pair<uint64_t, uint64_t>>
+getAggregateAlternativeOrdinals(const SourceRef &ref) {
+  llvm::SmallVector<std::pair<uint64_t, uint64_t>> result;
+  auto root = ref.getRoot();
+  if (failed(root)) {
+    return result;
+  }
+  Type currentType = root->getType();
+  for (const SourceRefIndex &index : ref.getPath()) {
+    if (index.isMember()) {
+      currentType = index.getMember().getType();
+      continue;
+    }
+    if (index.isPodRecord()) {
+      auto podType = llvm::dyn_cast<PodType>(currentType);
+      if (!podType) {
+        continue;
+      }
+      auto records = podType.getRecords();
+      for (auto [ordinal, record] : llvm::enumerate(records)) {
+        if (record.getName() == index.getPodRecordNameAttr()) {
+          result.emplace_back(ordinal, records.size());
+          currentType = record.getType();
+          break;
+        }
+      }
+      continue;
+    }
+    if (index.isIndex() || index.isIndexRange()) {
+      if (auto arrayType = llvm::dyn_cast<ArrayType>(currentType)) {
+        currentType = arrayType.getElementType();
+      }
+    }
+  }
+  return result;
+}
+
+bool isCompatibleIndexedAlternative(const SourceRef &candidate, const SourceRef &selection) {
+  llvm::SmallVector<std::pair<uint64_t, uint64_t>> selectedIndices;
+  auto root = selection.getRoot();
+  if (failed(root)) {
+    return true;
+  }
+  Type currentType = root->getType();
+  for (const SourceRefIndex &index : selection.getPath()) {
+    if (index.isMember()) {
+      currentType = index.getMember().getType();
+      continue;
+    }
+    if (index.isPodRecord()) {
+      if (auto podType = llvm::dyn_cast<PodType>(currentType)) {
+        for (auto record : podType.getRecords()) {
+          if (record.getName() == index.getPodRecordNameAttr()) {
+            currentType = record.getType();
+            break;
+          }
+        }
+      }
+      continue;
+    }
+    if (auto arrayType = llvm::dyn_cast<ArrayType>(currentType)) {
+      if (index.isIndex()) {
+        selectedIndices.emplace_back(
+            static_cast<uint64_t>(static_cast<int64_t>(index.getIndex())), arrayType.getDimSize(0)
+        );
+      }
+      currentType = arrayType.getElementType();
+    }
+  }
+
+  for (auto [ordinal, alternativeCount] : getAggregateAlternativeOrdinals(candidate)) {
+    for (auto [selected, dimensionSize] : selectedIndices) {
+      if (alternativeCount == dimensionSize && ordinal != selected) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
 SourceRefLatticeValue createShapedArrayValue(Value rootValue, ArrayType arrayTy) {
   SourceRefLatticeValue result(arrayTy.getShape());
   ArrayIndexGen indexGen = ArrayIndexGen::from(arrayTy);
@@ -1105,6 +1185,9 @@ mlir::LogicalResult ConstraintDependencyGraph::computeConstraints(
         signalSets.unionSets(leader, *mit);
       }
     }
+    for (const auto &[source, targets] : translatedCDG.dependencyEdges) {
+      dependencyEdges[source].insert(targets.begin(), targets.end());
+    }
     // And update the constant sets
     for (auto &[ref, constSet] : translatedCDG.constantSets) {
       constantSets[ref].insert(constSet.begin(), constSet.end());
@@ -1135,6 +1218,13 @@ void ConstraintDependencyGraph::walkConstrainOp(
 
   // Compute a transitive closure over the signals.
   if (!signalUsages.empty()) {
+    for (const SourceRef &lhs : signalUsages) {
+      for (const SourceRef &rhs : signalUsages) {
+        if (lhs != rhs) {
+          dependencyEdges[lhs].insert(rhs);
+        }
+      }
+    }
     auto it = signalUsages.begin();
     auto leader = signalSets.getOrInsertLeaderValue(*it);
     for (it++; it != signalUsages.end(); it++) {
@@ -1229,6 +1319,27 @@ ConstraintDependencyGraph::translate(SourceRefRemappings translation) const {
     }
   }
 
+  for (const auto &[source, targets] : dependencyEdges) {
+    auto translatedSources = translate(source);
+    if (failed(translatedSources)) {
+      continue;
+    }
+    for (const SourceRef &target : targets) {
+      auto translatedTargets = translate(target);
+      if (failed(translatedTargets)) {
+        continue;
+      }
+      for (const SourceRef &translatedSource : *translatedSources) {
+        for (const SourceRef &translatedTarget : *translatedTargets) {
+          if (!translatedSource.isConstant() && !translatedTarget.isConstant() &&
+              translatedSource != translatedTarget) {
+            res.dependencyEdges[translatedSource].insert(translatedTarget);
+          }
+        }
+      }
+    }
+  }
+
   // Translate ref2Val as well
   for (const auto &[ref, vals] : ref2Val) {
     auto translationRes = translate(ref);
@@ -1244,27 +1355,52 @@ ConstraintDependencyGraph::translate(SourceRefRemappings translation) const {
 
 SourceRefSet ConstraintDependencyGraph::getConstrainingValues(const SourceRef &ref) const {
   SourceRefSet res;
-  auto currRef = mlir::FailureOr<SourceRef>(ref);
-  while (mlir::succeeded(currRef)) {
-    // A dynamic access is represented by a half-open range. Match every concrete element and
-    // range that overlaps the queried path, as well as exact references.
-    for (auto candidate = signalSets.begin(); candidate != signalSets.end(); ++candidate) {
-      const SourceRef &candidateRef = candidate->getData();
-      if (!candidateRef.overlaps(*currRef)) {
-        continue;
+  SourceRefSet visited;
+  llvm::SmallVector<SourceRef> worklist = {ref};
+
+  // Overlapping aggregate ranges can bridge otherwise distinct equivalence sets. Follow those
+  // bridges transitively so that, for example, `out[2] == child.out[2]` and a child constraint on
+  // `child.out[0:N]` connect `out[2]` to the child's inputs.
+  while (!worklist.empty()) {
+    auto currRef = mlir::FailureOr<SourceRef>(worklist.pop_back_val());
+    while (mlir::succeeded(currRef)) {
+      if (!visited.insert(*currRef).second) {
+        break;
       }
-      for (auto it = signalSets.findLeader(candidate); it != signalSets.member_end(); ++it) {
-        if (!it->overlaps(ref)) {
-          res.insert(*it);
+
+      for (const auto &[source, targets] : dependencyEdges) {
+        if (!source.overlaps(*currRef) || !isCompatibleIndexedAlternative(source, ref)) {
+          continue;
+        }
+        if (auto constIt = constantSets.find(source); constIt != constantSets.end()) {
+          res.insert(constIt->second.begin(), constIt->second.end());
+        }
+        for (const SourceRef &target : targets) {
+          if (!isCompatibleIndexedAlternative(target, ref)) {
+            continue;
+          }
+          SourceRef narrowed = target.narrowRanges(*currRef);
+          if (!visited.contains(narrowed)) {
+            worklist.push_back(narrowed);
+          }
+          if (!narrowed.overlaps(ref)) {
+            res.insert(narrowed);
+          }
+          auto constIt = constantSets.find(target);
+          if (constIt != constantSets.end()) {
+            res.insert(constIt->second.begin(), constIt->second.end());
+          }
         }
       }
-      auto constIt = constantSets.find(candidateRef);
-      if (constIt != constantSets.end()) {
-        res.insert(constIt->second.begin(), constIt->second.end());
+      for (const auto &[constantSource, constants] : constantSets) {
+        if (constantSource.overlaps(*currRef) &&
+            isCompatibleIndexedAlternative(constantSource, ref)) {
+          res.insert(constants.begin(), constants.end());
+        }
       }
+      // Constraints on an aggregate also constrain its scalar descendants.
+      currRef = currRef->getParentPrefix();
     }
-    // Go to parent
-    currRef = currRef->getParentPrefix();
   }
   return res;
 }

--- a/unittests/Analysis/SourceRefTests.cpp
+++ b/unittests/Analysis/SourceRefTests.cpp
@@ -1088,3 +1088,63 @@ module attributes {llzk.lang} {
   SourceRef afterArg(whileOp.getAfter().front().getArgument(0));
   EXPECT_EQ(buildStringViaPrint(afterArg), "%arg0");
 }
+
+TEST_F(SourceRefTests, ConstraintQueriesNarrowStaticLoopRangesPerElement) {
+  static constexpr auto source = R"mlir(
+module attributes {llzk.lang} {
+  struct.def @LoopRanges {
+    struct.member @out : !array.type<3 x !felt.type> {llzk.pub, signal}
+
+    function.def @compute(%in: !array.type<3 x !felt.type>)
+        -> !struct.type<@LoopRanges> {
+      %self = struct.new : !struct.type<@LoopRanges>
+      %storage = array.new : !array.type<3 x !felt.type>
+      struct.writem %self[@out] = %storage
+          : !struct.type<@LoopRanges>, !array.type<3 x !felt.type>
+      function.return %self : !struct.type<@LoopRanges>
+    }
+
+    function.def @constrain(
+        %self: !struct.type<@LoopRanges>,
+        %in: !array.type<3 x !felt.type>) {
+      %out = struct.readm %self[@out]
+          : !struct.type<@LoopRanges>, !array.type<3 x !felt.type>
+      %c0 = arith.constant 0 : index
+      %c2 = arith.constant 2 : index
+      %c1 = arith.constant 1 : index
+      scf.for %i = %c0 to %c2 step %c1 {
+        %lhs = array.read %out[%i] : !array.type<3 x !felt.type>, !felt.type
+        %rhs = array.read %in[%i] : !array.type<3 x !felt.type>, !felt.type
+        constrain.eq %lhs, %rhs : !felt.type
+      }
+      function.return
+    }
+  }
+}
+)mlir";
+
+  auto mod = parseSourceString<ModuleOp>(source, ParserConfig(&ctx));
+  ASSERT_TRUE(mod);
+  auto structDef = *mod->getOps<StructDefOp>().begin();
+  auto constrainFn = structDef.getConstrainFuncOp();
+  auto outMember = *structDef.getOps<MemberDefOp>().begin();
+
+  ModuleAnalysisManager mam(*mod, nullptr);
+  AnalysisManager am = mam;
+  ConstraintDependencyGraphModuleAnalysis analysis(mod->getOperation());
+  analysis.ensureAnalysisRun(am);
+  const ConstraintDependencyGraph &graph = analysis.getResult(structDef);
+
+  for (uint64_t index = 0; index < 2; ++index) {
+    SourceRef output(
+        constrainFn.getArgument(0), {SourceRefIndex(outMember), SourceRefIndex(APInt(64, index))}
+    );
+    SourceRef input(constrainFn.getArgument(1), {SourceRefIndex(APInt(64, index))});
+    EXPECT_TRUE(graph.getConstrainingValues(output).contains(input));
+  }
+
+  SourceRef omitted(
+      constrainFn.getArgument(0), {SourceRefIndex(outMember), SourceRefIndex(APInt(64, 2))}
+  );
+  EXPECT_TRUE(graph.getConstrainingValues(omitted).empty());
+}


### PR DESCRIPTION
## Summary

Makes constraint-dependency traversal overlap-aware on top of #650 while consuming the explicit dependency-resolved SourceRef view. This is PR 4 of 6 in the stacked series.

## Related issues

No standalone issue; depends on #650.

## Changes

- Track pairwise dependency edges separately from broad equivalence classes.
- Traverse overlapping aggregate ranges transitively and narrow them to queried concrete elements.
- Include ancestor constraints while filtering structurally incompatible aggregate alternatives.
- Preserve dependency edges through graph copying, translation, and interprocedural merging.
- Add regressions proving a range constrains included elements while leaving omitted elements unconstrained.

## Testing

- `git diff --check`
- Focused overlap-aware CDG regressions
- `nix build -L` on this exact stacked commit: 371 lit tests and 1,313 unit/CAPI tests passed

## Submission checklist

- [ ] ~If I am an external contributor, this PR has a linked issue marked `approved`; otherwise, this does not apply.~
- [x] I added or updated tests for all relevant behavior, or explained above why tests are not needed.
- [x] I updated the relevant TableGen or other documentation, or explained above why documentation is not needed.
- [x] I added a changelog entry describing user-visible changes. (`create-changelog` in the Nix development shell creates a template.)
- [ ] ~I enabled **Allow edits from maintainers** if this PR comes from a fork.~

## AI assistance

- [ ] No AI tools contributed to this PR.
- [x] AI tools contributed to this PR.

**Tools used:** OpenAI Codex.

**How the tools contributed:** Codex helped partition the original working-tree change, implement the raw-versus-resolved SourceRef architecture, add focused regressions, and prepare this draft PR.

**How I verified the contribution:** Reviewed the isolated diff and ran `git diff --check`, the focused analysis regressions through the project test suite, and `nix build -L` on this exact commit.