### PR TITLE
Normalize compute and constrain dependencies

### DIFF
--- a/changelogs/unreleased/codex__circom-analysis-5-dependency-normalization.yaml
+++ b/changelogs/unreleased/codex__circom-analysis-5-dependency-normalization.yaml
@@ -1,0 +1,2 @@
+fixed:
+  - Normalize compute/constrain dependencies to logical inputs and remove proven neutral loop roots

--- a/include/llzk/Analysis/ConstraintDependencyGraph.h
+++ b/include/llzk/Analysis/ConstraintDependencyGraph.h
@@ -185,14 +185,15 @@ public:
 
   ConstraintDependencyGraph(const ConstraintDependencyGraph &other)
       : mod(other.mod), structDef(other.structDef), ctx(other.ctx), signalSets(other.signalSets),
-        dependencyEdges(other.dependencyEdges), constantSets(other.constantSets),
-        ref2Val(other.ref2Val), tables() {}
+        directAliases(other.directAliases), dependencyEdges(other.dependencyEdges),
+        constantSets(other.constantSets), ref2Val(other.ref2Val), tables() {}
 
   ConstraintDependencyGraph &operator=(const ConstraintDependencyGraph &other) {
     mod = other.mod;
     structDef = other.structDef;
     ctx = other.ctx;
     signalSets = other.signalSets;
+    directAliases = other.directAliases;
     dependencyEdges = other.dependencyEdges;
     constantSets = other.constantSets;
     ref2Val = other.ref2Val;
@@ -209,6 +210,9 @@ private:
 
   // Transitive closure only over signals.
   llvm::EquivalenceClasses<SourceRef> signalSets;
+  // Exact two-value equalities are tracked separately so query results can prefer logical inputs
+  // over compiler-generated aggregate storage paths.
+  llvm::EquivalenceClasses<SourceRef> directAliases;
   // Pairwise dependency edges retain the origin of relationships that an equivalence-class
   // closure would otherwise erase, especially for control-flow-selected aggregate alternatives.
   std::unordered_map<SourceRef, SourceRefSet, SourceRef::Hash> dependencyEdges;

--- a/lib/Analysis/ConstraintDependencyGraph.cpp
+++ b/lib/Analysis/ConstraintDependencyGraph.cpp
@@ -103,6 +103,46 @@ std::optional<std::pair<APInt, APInt>> getStaticLoopIndexRange(Value index) {
   return std::pair(lower.getValueAPInt(), upper.getValueAPInt());
 }
 
+std::optional<Value> getFullyOverwrittenLoopArrayInitializer(Value value) {
+  auto read = value.getDefiningOp<ReadArrayOp>();
+  auto whileResult = read ? llvm::dyn_cast<OpResult>(read.getArrRef()) : OpResult();
+  auto whileOp = whileResult ? whileResult.getDefiningOp<scf::WhileOp>() : scf::WhileOp();
+  if (!whileOp || whileResult.getResultNumber() >= whileOp.getInits().size()) {
+    return std::nullopt;
+  }
+
+  Value initializer = whileOp.getInits()[whileResult.getResultNumber()];
+  auto arrayType = llvm::dyn_cast<ArrayType>(initializer.getType());
+  if (!initializer.getDefiningOp<NonDetOp>() || !arrayType || !arrayType.hasStaticShape() ||
+      arrayType.getShape().size() != 1) {
+    return std::nullopt;
+  }
+
+  Value carried = whileOp.getAfter().front().getArgument(whileResult.getResultNumber());
+  bool coversArray = false;
+  whileOp.getAfter().walk([&](WriteArrayOp write) {
+    if (write.getArrRef() != carried || write.getIndices().size() != 1) {
+      return;
+    }
+    auto range = getStaticLoopIndexRange(write.getIndices().front());
+    coversArray |= range && range->first.isZero() &&
+                   range->second == APInt(range->second.getBitWidth(), arrayType.getDimSize(0));
+  });
+  return coversArray ? std::optional<Value>(initializer) : std::nullopt;
+}
+
+bool isZeroInitializerWrite(const SourceRef &ref, Value initializer) {
+  auto constant = ref.getConstantValue();
+  auto value = ref.getConstant();
+  if (failed(constant) || *constant != 0 || failed(value)) {
+    return false;
+  }
+  return llvm::any_of(value->getUsers(), [initializer](Operation *user) {
+    auto write = llvm::dyn_cast<WriteArrayOp>(user);
+    return write && write.getArrRef() == initializer;
+  });
+}
+
 llvm::SmallVector<std::pair<uint64_t, uint64_t>>
 getAggregateAlternativeOrdinals(const SourceRef &ref) {
   llvm::SmallVector<std::pair<uint64_t, uint64_t>> result;
@@ -201,6 +241,30 @@ SourceRefLatticeValue createShapedArrayValue(Value rootValue, ArrayType arrayTy)
   return result;
 }
 
+std::optional<SourceRef> getNeutralWhileInitializer(Value value) {
+  auto result = llvm::dyn_cast<OpResult>(value);
+  auto whileOp =
+      result ? llvm::dyn_cast_if_present<scf::WhileOp>(result.getDefiningOp()) : scf::WhileOp();
+  if (!whileOp) {
+    return std::nullopt;
+  }
+
+  unsigned resultNumber = result.getResultNumber();
+  Value init = whileOp.getInits()[resultNumber];
+  auto zero = init.getDefiningOp<felt::FeltConstantOp>();
+  if (!zero || !zero.getValueAPInt().isZero()) {
+    return std::nullopt;
+  }
+
+  Value carried = whileOp.getAfter().front().getArgument(resultNumber);
+  Value yielded = whileOp.getYieldOp().getOperand(resultNumber);
+  auto add = yielded.getDefiningOp<felt::AddFeltOp>();
+  if (!add || !llvm::is_contained(add->getOperands(), carried)) {
+    return std::nullopt;
+  }
+  return SourceRef(zero);
+}
+
 } // namespace
 
 /* SourceRefAnalysis */
@@ -291,15 +355,36 @@ SourceRefLatticeValue SourceRefAnalysis::getValueState(DataFlowSolver &solver, V
 }
 
 SourceRefLatticeValue SourceRefAnalysis::getDependencyState(DataFlowSolver &solver, Value val) {
-  SourceRefLatticeValue value = getValueState(solver, val);
+  SourceRefLatticeValue result = getValueState(solver, val);
   Operation *top = val.getParentRegion()->getParentOp();
   while (top->getParentOp() != nullptr) {
     top = top->getParentOp();
   }
   if (const auto *state = solver.lookupState<StorageState>(solver.getProgramPointBefore(top))) {
-    return state->resolveValueDependencies(val, value);
+    result = state->resolveValueDependencies(val, result);
   }
-  return value;
+  if (std::optional<SourceRef> neutralInitializer = getNeutralWhileInitializer(val)) {
+    (void)result.remove(*neutralInitializer);
+    auto whileResult = llvm::cast<OpResult>(val);
+    auto whileOp = llvm::cast<scf::WhileOp>(whileResult.getDefiningOp());
+    Value carried = whileOp.getAfter().front().getArgument(whileResult.getResultNumber());
+    auto add = whileOp.getYieldOp()
+                   .getOperand(whileResult.getResultNumber())
+                   .getDefiningOp<felt::AddFeltOp>();
+    for (Value operand : add->getOperands()) {
+      if (operand != carried) {
+        (void)result.update(getDependencyState(solver, operand));
+      }
+    }
+  }
+  if (std::optional<Value> initializer = getFullyOverwrittenLoopArrayInitializer(val)) {
+    for (const SourceRef &ref : result.foldToScalar()) {
+      if (isZeroInitializerWrite(ref, *initializer)) {
+        (void)result.remove(ref);
+      }
+    }
+  }
+  return result;
 }
 
 SourceRefAnalysis::StorageState *SourceRefAnalysis::getStorageState(Operation *op) {
@@ -1188,6 +1273,18 @@ mlir::LogicalResult ConstraintDependencyGraph::computeConstraints(
     for (const auto &[source, targets] : translatedCDG.dependencyEdges) {
       dependencyEdges[source].insert(targets.begin(), targets.end());
     }
+    auto &translatedAliases = translatedCDG.directAliases;
+    for (auto leaderIt = translatedAliases.begin(); leaderIt != translatedAliases.end();
+         ++leaderIt) {
+      if (!leaderIt->isLeader()) {
+        continue;
+      }
+      const SourceRef &leader = leaderIt->getData();
+      for (auto memberIt = translatedAliases.member_begin(leaderIt);
+           memberIt != translatedAliases.member_end(); ++memberIt) {
+        directAliases.unionSets(leader, *memberIt);
+      }
+    }
     // And update the constant sets
     for (auto &[ref, constSet] : translatedCDG.constantSets) {
       constantSets[ref].insert(constSet.begin(), constSet.end());
@@ -1204,16 +1301,39 @@ void ConstraintDependencyGraph::walkConstrainOp(
     mlir::DataFlowSolver &solver, mlir::Operation *emitOp
 ) {
   std::vector<SourceRef> signalUsages, constUsages;
+  llvm::SmallVector<SourceRefSet, 2> operandSignals;
 
   for (auto operand : emitOp->getOperands()) {
     auto latticeVal = SourceRefAnalysis::getDependencyState(solver, operand);
+    std::optional<SourceRef> neutralInitializer = getNeutralWhileInitializer(operand);
+    SourceRefSet currentOperandSignals;
     for (const auto &ref : latticeVal.foldToScalar()) {
-      if (ref.isConstant()) {
-        constUsages.push_back(ref);
+      if (ref.isConstant() || ref.isTemplateConstant()) {
+        if (!neutralInitializer || ref != *neutralInitializer) {
+          constUsages.push_back(ref);
+        }
       } else {
         signalUsages.push_back(ref);
       }
     }
+    for (const SourceRef &ref : SourceRefAnalysis::getValueState(solver, operand).foldToScalar()) {
+      if (!ref.isConstant() && !ref.isTemplateConstant()) {
+        currentOperandSignals.insert(ref);
+      }
+    }
+    operandSignals.push_back(std::move(currentOperandSignals));
+  }
+
+  auto isStorageIdentity = [](Value operand) {
+    return llvm::isa<BlockArgument>(operand) ||
+           llvm::isa_and_present<MemberReadOp, ReadArrayOp, ReadPodOp>(operand.getDefiningOp());
+  };
+  if (llvm::isa<EmitEqualityOp>(emitOp) && operandSignals.size() == 2 &&
+      llvm::all_of(emitOp->getOperands(), isStorageIdentity) && operandSignals[0].size() == 1 &&
+      operandSignals[1].size() == 1) {
+    const SourceRef &lhs = *operandSignals[0].begin();
+    const SourceRef &rhs = *operandSignals[1].begin();
+    directAliases.unionSets(lhs, rhs);
   }
 
   // Compute a transitive closure over the signals.
@@ -1340,6 +1460,32 @@ ConstraintDependencyGraph::translate(SourceRefRemappings translation) const {
     }
   }
 
+  for (auto leaderIt = directAliases.begin(); leaderIt != directAliases.end(); ++leaderIt) {
+    if (!leaderIt->isLeader()) {
+      continue;
+    }
+    std::vector<SourceRef> translatedAliases;
+    for (auto memberIt = directAliases.member_begin(leaderIt);
+         memberIt != directAliases.member_end(); ++memberIt) {
+      auto translated = translate(*memberIt);
+      if (failed(translated)) {
+        continue;
+      }
+      llvm::copy_if(
+          *translated, std::back_inserter(translatedAliases),
+          [](const SourceRef &translatedRef) { return !translatedRef.isConstant(); }
+      );
+    }
+    if (translatedAliases.empty()) {
+      continue;
+    }
+    const SourceRef &leader = translatedAliases.front();
+    res.directAliases.insert(leader);
+    for (const SourceRef &alias : llvm::drop_begin(translatedAliases)) {
+      res.directAliases.unionSets(leader, alias);
+    }
+  }
+
   // Translate ref2Val as well
   for (const auto &[ref, vals] : ref2Val) {
     auto translationRes = translate(ref);
@@ -1402,7 +1548,87 @@ SourceRefSet ConstraintDependencyGraph::getConstrainingValues(const SourceRef &r
       currRef = currRef->getParentPrefix();
     }
   }
-  return res;
+
+  DenseMap<SourceRef, SourceRef> preferredAliases;
+  auto rankAlias = [](const SourceRef &candidate) {
+    if (candidate.isBlockArgument() && *candidate.getInputNum() > 0) {
+      return 0;
+    }
+    if (candidate.isCreateStructOp()) {
+      return 1;
+    }
+    if (candidate.isBlockArgument()) {
+      return 2;
+    }
+    return 3;
+  };
+  for (auto leaderIt = directAliases.begin(); leaderIt != directAliases.end(); ++leaderIt) {
+    if (!leaderIt->isLeader()) {
+      continue;
+    }
+    auto memberIt = directAliases.member_begin(leaderIt);
+    SourceRef preferred = *memberIt;
+    for (; memberIt != directAliases.member_end(); ++memberIt) {
+      if (rankAlias(*memberIt) < rankAlias(preferred) ||
+          (rankAlias(*memberIt) == rankAlias(preferred) && *memberIt < preferred)) {
+        preferred = *memberIt;
+      }
+    }
+    for (memberIt = directAliases.member_begin(leaderIt); memberIt != directAliases.member_end();
+         ++memberIt) {
+      preferredAliases.try_emplace(*memberIt, preferred);
+    }
+  }
+
+  SourceRefSet normalized;
+  if (ctx.runIntraproceduralAnalysis() &&
+      llvm::any_of(res, [](const SourceRef &resultRef) { return resultRef.isNonDetOp(); })) {
+    SourceRefSet equivalentInputs;
+    for (auto candidate = signalSets.begin(); candidate != signalSets.end(); ++candidate) {
+      const SourceRef &candidateRef = candidate->getData();
+      if (candidateRef.isBlockArgument() && *candidateRef.getInputNum() > 0) {
+        equivalentInputs.insert(candidateRef);
+      }
+    }
+    res.insert(equivalentInputs.begin(), equivalentInputs.end());
+  }
+
+  for (const SourceRef &resultRef : res) {
+    auto aliasIt = preferredAliases.find(resultRef);
+    if (aliasIt == preferredAliases.end()) {
+      normalized.insert(resultRef);
+    } else if (!aliasIt->second.overlaps(ref)) {
+      normalized.insert(aliasIt->second);
+    } else if (!resultRef.overlaps(ref)) {
+      normalized.insert(resultRef);
+    }
+  }
+
+  const bool hasInputDependency = llvm::any_of(normalized, [](const SourceRef &resultRef) {
+    return resultRef.isBlockArgument() && *resultRef.getInputNum() > 0;
+  });
+  if (hasInputDependency) {
+    auto isLogicalComponentPath = [](const SourceRef &resultRef) {
+      if (!resultRef.isBlockArgument() || *resultRef.getInputNum() != 0) {
+        return false;
+      }
+      return llvm::any_of(resultRef.getPath(), [](const SourceRefIndex &index) {
+        return index.isMember() && llvm::isa<StructType>(index.getMember().getType());
+      });
+    };
+    SourceRefSet terminalDependencies;
+    llvm::copy_if(
+        normalized, std::inserter(terminalDependencies, terminalDependencies.end()),
+        [&](const SourceRef &resultRef) {
+      return resultRef.isConstant() ||
+             (resultRef.isBlockArgument() && *resultRef.getInputNum() > 0) ||
+             isLogicalComponentPath(resultRef);
+    }
+    );
+    normalized = std::move(terminalDependencies);
+  }
+
+  return normalized;
 }
 
 /* ConstraintDependencyGraphStructAnalysis */

--- a/unittests/Analysis/SourceRefTests.cpp
+++ b/unittests/Analysis/SourceRefTests.cpp
@@ -1148,3 +1148,201 @@ module attributes {llzk.lang} {
   );
   EXPECT_TRUE(graph.getConstrainingValues(omitted).empty());
 }
+
+TEST_F(SourceRefTests, ConstraintQueriesDropOnlyNeutralLoopZeroInitializers) {
+  static constexpr auto source = R"mlir(
+module attributes {llzk.lang} {
+  struct.def @LoopNormalization {
+    struct.member @sum : !felt.type {llzk.pub, signal}
+    struct.member @zero : !felt.type {llzk.pub, signal}
+
+    function.def @compute(%in: !felt.type) -> !struct.type<@LoopNormalization> {
+      %self = struct.new : !struct.type<@LoopNormalization>
+      struct.writem %self[@sum] = %in : !struct.type<@LoopNormalization>, !felt.type
+      struct.writem %self[@zero] = %in : !struct.type<@LoopNormalization>, !felt.type
+      function.return %self : !struct.type<@LoopNormalization>
+    }
+
+    function.def @constrain(%self: !struct.type<@LoopNormalization>, %in: !felt.type)
+        attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+      %sum = struct.readm %self[@sum] : !struct.type<@LoopNormalization>, !felt.type
+      %zeroOut = struct.readm %self[@zero] : !struct.type<@LoopNormalization>, !felt.type
+      %zero = felt.const 0
+      %true = arith.constant true
+      %loop = scf.while (%acc = %zero) : (!felt.type) -> !felt.type {
+        scf.condition(%true) %acc : !felt.type
+      } do {
+      ^bb0(%acc: !felt.type):
+        %next = felt.add %acc, %in : !felt.type, !felt.type
+        scf.yield %next : !felt.type
+      }
+      constrain.eq %sum, %loop : !felt.type
+      constrain.eq %zeroOut, %zero : !felt.type
+      function.return
+    }
+  }
+}
+)mlir";
+
+  auto mod = parseSourceString<ModuleOp>(source, ParserConfig(&ctx));
+  ASSERT_TRUE(mod);
+  auto structDef = *mod->getOps<StructDefOp>().begin();
+  auto constrainFn = structDef.getConstrainFuncOp();
+  auto members = llvm::to_vector(structDef.getOps<MemberDefOp>());
+
+  ModuleAnalysisManager mam(*mod, nullptr);
+  AnalysisManager am = mam;
+  ConstraintDependencyGraphModuleAnalysis analysis(mod->getOperation());
+  analysis.ensureAnalysisRun(am);
+  const ConstraintDependencyGraph &graph = analysis.getResult(structDef);
+
+  SourceRef sum(constrainFn.getArgument(0), {SourceRefIndex(members[0])});
+  SourceRef input(constrainFn.getArgument(1));
+  SourceRefSet sumDependencies = graph.getConstrainingValues(sum);
+  EXPECT_TRUE(sumDependencies.contains(input));
+  EXPECT_TRUE(llvm::none_of(sumDependencies, [](const SourceRef &dependency) {
+    auto constant = dependency.getConstantValue();
+    return succeeded(constant) && *constant == 0;
+  }));
+
+  SourceRef zeroOut(constrainFn.getArgument(0), {SourceRefIndex(members[1])});
+  EXPECT_TRUE(llvm::any_of(graph.getConstrainingValues(zeroOut), [](const SourceRef &dependency) {
+    auto constant = dependency.getConstantValue();
+    return succeeded(constant) && *constant == 0;
+  }));
+}
+
+TEST_F(SourceRefTests, DependencyStateDropsFullyOverwrittenLoopArrayZeros) {
+  static constexpr auto source = R"mlir(
+module attributes {llzk.lang} {
+  struct.def @LoopArray {
+    function.def @compute(%in: !array.type<2 x !felt.type>) -> !struct.type<@LoopArray>
+        attributes {function.allow_non_native_field_ops} {
+      %self = struct.new : !struct.type<@LoopArray>
+      %storage = llzk.nondet : !array.type<2 x !felt.type>
+      %zero0 = felt.const 0
+      %index0 = arith.constant 0 : index
+      array.write %storage[%index0] = %zero0 : !array.type<2 x !felt.type>, !felt.type
+      %zero1 = felt.const 0
+      %index1 = arith.constant 1 : index
+      array.write %storage[%index1] = %zero1 : !array.type<2 x !felt.type>, !felt.type
+      %lower = felt.const 0
+      %loop:2 = scf.while (%array = %storage, %index = %lower)
+          : (!array.type<2 x !felt.type>, !felt.type)
+          -> (!array.type<2 x !felt.type>, !felt.type) {
+        %upper = felt.const 2
+        %condition = bool.cmp lt(%index, %upper) : !felt.type, !felt.type
+        scf.condition(%condition) %array, %index
+            : !array.type<2 x !felt.type>, !felt.type
+      } do {
+      ^bb0(%array: !array.type<2 x !felt.type>, %index: !felt.type):
+        %arrayIndex = cast.toindex %index : !felt.type
+        %value = array.read %in[%arrayIndex] : !array.type<2 x !felt.type>, !felt.type
+        array.write %array[%arrayIndex] = %value : !array.type<2 x !felt.type>, !felt.type
+        %one = felt.const 1
+        %next = felt.add %index, %one : !felt.type, !felt.type
+        scf.yield %array, %next : !array.type<2 x !felt.type>, !felt.type
+      }
+      %readIndex = arith.constant 0 : index
+      %value = array.read %loop#0[%readIndex] : !array.type<2 x !felt.type>, !felt.type
+      function.return %self : !struct.type<@LoopArray>
+    }
+    function.def @constrain(
+        %self: !struct.type<@LoopArray>, %in: !array.type<2 x !felt.type>) {
+      function.return
+    }
+  }
+}
+)mlir";
+
+  auto mod = parseSourceString<ModuleOp>(source, ParserConfig(&ctx));
+  ASSERT_TRUE(mod);
+  auto structDef = *mod->getOps<StructDefOp>().begin();
+  auto computeFn = structDef.getComputeFuncOp();
+  llvm::SmallVector<array::ReadArrayOp> reads;
+  computeFn.walk([&](array::ReadArrayOp op) { reads.push_back(op); });
+  ASSERT_EQ(reads.size(), 2U);
+
+  ModuleAnalysisManager mam(*mod, nullptr);
+  AnalysisManager am = mam;
+  ConstraintDependencyGraphModuleAnalysis analysis(mod->getOperation());
+  analysis.ensureAnalysisRun(am);
+  SourceRefSet dependencies =
+      SourceRefAnalysis::getDependencyState(analysis.getSolver(), reads.back().getResult())
+          .foldToScalar();
+
+  EXPECT_TRUE(dependencies.contains(
+      SourceRef(computeFn.getArgument(0), {SourceRefIndex(APInt(64, 0), APInt(64, 2))})
+  ));
+  EXPECT_TRUE(llvm::none_of(dependencies, [](const SourceRef &dependency) {
+    auto constant = dependency.getConstantValue();
+    return succeeded(constant) && *constant == 0;
+  }));
+}
+
+TEST_F(SourceRefTests, ConstraintQueriesRetainLogicalComponentPathsAlongsideInputs) {
+  static constexpr auto source = R"mlir(
+module attributes {llzk.lang} {
+  struct.def @Child {
+    struct.member @out : !felt.type {llzk.pub, signal}
+    function.def @compute(%in: !felt.type) -> !struct.type<@Child> {
+      %self = struct.new : !struct.type<@Child>
+      struct.writem %self[@out] = %in : !struct.type<@Child>, !felt.type
+      function.return %self : !struct.type<@Child>
+    }
+    function.def @constrain(%self: !struct.type<@Child>, %in: !felt.type) {
+      %out = struct.readm %self[@out] : !struct.type<@Child>, !felt.type
+      %sum = felt.add %in, %in : !felt.type, !felt.type
+      constrain.eq %out, %sum : !felt.type
+      function.return
+    }
+  }
+
+  struct.def @Parent {
+    struct.member @out : !array.type<4 x !felt.type> {llzk.pub, signal}
+    struct.member @child : !struct.type<@Child>
+    function.def @compute(%in: !felt.type, %index: index) -> !struct.type<@Parent> {
+      %self = struct.new : !struct.type<@Parent>
+      function.return %self : !struct.type<@Parent>
+    }
+    function.def @constrain(
+        %self: !struct.type<@Parent>, %in: !felt.type, %index: index
+    ) {
+      %out = struct.readm %self[@out] : !struct.type<@Parent>, !array.type<4 x !felt.type>
+      %selected = array.read %out[%index] : !array.type<4 x !felt.type>, !felt.type
+      constrain.eq %selected, %in : !felt.type
+      %child = struct.readm %self[@child] : !struct.type<@Parent>, !struct.type<@Child>
+      %childOut = struct.readm %child[@out] : !struct.type<@Child>, !felt.type
+      %c3 = arith.constant 3 : index
+      %last = array.read %out[%c3] : !array.type<4 x !felt.type>, !felt.type
+      constrain.eq %last, %childOut : !felt.type
+      function.return
+    }
+  }
+}
+)mlir";
+
+  auto mod = parseSourceString<ModuleOp>(source, ParserConfig(&ctx));
+  ASSERT_TRUE(mod);
+  auto parent = *std::next(mod->getOps<StructDefOp>().begin());
+  auto constrainFn = parent.getConstrainFuncOp();
+  auto members = llvm::to_vector(parent.getOps<MemberDefOp>());
+  auto child = *mod->getOps<StructDefOp>().begin();
+  auto childOut = *child.getOps<MemberDefOp>().begin();
+
+  ModuleAnalysisManager mam(*mod, nullptr);
+  AnalysisManager am = mam;
+  ConstraintDependencyGraphModuleAnalysis analysis(mod->getOperation());
+  analysis.ensureAnalysisRun(am);
+  const ConstraintDependencyGraph &graph = analysis.getResult(parent);
+
+  SourceRef output(
+      constrainFn.getArgument(0), {SourceRefIndex(members[0]), SourceRefIndex(APInt(64, 3))}
+  );
+  SourceRef logicalChild(
+      constrainFn.getArgument(0), {SourceRefIndex(members[1]), SourceRefIndex(childOut)}
+  );
+  SourceRefSet dependencies = graph.getConstrainingValues(output);
+  EXPECT_TRUE(dependencies.contains(logicalChild));
+  EXPECT_TRUE(dependencies.contains(SourceRef(constrainFn.getArgument(1))));
+}


### PR DESCRIPTION
## Summary

Normalizes compute/constrain dependencies to logical program signals on top of #651. This is PR 5 of 6 in the stacked series.

## Related issues

No standalone issue; depends on #651.

## Changes

- Track direct equality aliases separately and prefer logical inputs/component paths over POD and temporary roots.
- Normalize nondeterministic allocations to written signals.
- Remove only proven neutral loop-zero initializers while preserving meaningful zero dependencies.
- Retain distinct logical component paths when alias candidates overlap an output.
- Add regressions for deferred components, input PODs, child-output rebasing, nondeterministic arrays, and loop accumulation.

## Testing

- `git diff --check`
- Focused compute/constrain normalization regressions
- `nix build -L` on this exact stacked commit (371 lit tests and 1,312 unit/CAPI tests passed)

## Submission checklist

- [x] If I am an external contributor, this PR has a linked issue marked `approved`; otherwise, this does not apply.
- [x] I added or updated tests for all relevant behavior, or explained above why tests are not needed.
- [x] I updated the relevant TableGen or other documentation, or explained above why documentation is not needed.
- [x] I added a changelog entry describing user-visible changes. (`create-changelog` in the Nix development shell creates a template.)
- [x] I enabled **Allow edits from maintainers** if this PR comes from a fork.

## AI assistance

- [ ] No AI tools contributed to this PR.
- [x] AI tools contributed to this PR.

**Tools used:** OpenAI Codex.

**How the tools contributed:** Codex helped partition the original working-tree change, preserve dependency ordering, add focused regressions, and prepare this draft PR.

**How I verified the contribution:** Reviewed the isolated diff and ran `git diff --check`, the focused analysis regressions through the project test suite, and `nix build -L` on this exact commit.