### PR TITLE
Add workflow that posts a comment if PRs do not have a linked issue

### DIFF
--- a/.github/workflows/pr-require-linked-issue.yml
+++ b/.github/workflows/pr-require-linked-issue.yml
@@ -59,14 +59,6 @@ jobs:
           permission-pull-requests: write
           permission-members: read
 
-      - name: Show issue triage token permissions
-        if: steps.linked-issue.outputs.has-linked-issue != 'true'
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          gh api /installation/repositories \
-            --jq '.repositories[] | select(.full_name == "${{ github.repository }}") | .permissions'
-
       - name: Comment when no issue is linked
         if: steps.linked-issue.outputs.has-linked-issue != 'true'
         uses: actions/github-script@v9

--- a/.github/workflows/pr-require-linked-issue.yml
+++ b/.github/workflows/pr-require-linked-issue.yml
@@ -86,9 +86,9 @@ jobs:
                 return;
               }
             } catch (error) {
-              if (error.status !== 404) {
-                throw error;
-              }
+              core.warning(
+                `Unable to check ${coreTeam} membership for ${pr.user.login} (status: ${error.status ?? "unknown"}). Proceeding as non-member.`
+              );
             }
 
             // Avoid posting the same warning more than once.

--- a/.github/workflows/pr-require-linked-issue.yml
+++ b/.github/workflows/pr-require-linked-issue.yml
@@ -77,14 +77,12 @@ jobs:
                 username: pr.user.login,
               });
 
-              /*
               if (membership.data.state === "active") {
                 core.info(
                   `${pr.user.login} is a member of ${coreTeam}; skipping linked issue reminder.`
                 );
                 return;
               }
-              */
             } catch (error) {
               if (error.status !== 404) {
                 throw error;

--- a/.github/workflows/pr-require-linked-issue.yml
+++ b/.github/workflows/pr-require-linked-issue.yml
@@ -1,0 +1,128 @@
+name: Check for linked issue
+
+on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review]
+
+permissions:
+  pull-requests: read
+  issues: read
+
+jobs:
+  check-linked-issue:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check for linked issue
+        id: linked-issue
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const pr = context.payload.pull_request;
+
+            const result = await github.graphql(
+              `
+                query ($prId: ID!) {
+                  node(id: $prId) {
+                    ... on PullRequest {
+                      closingIssuesReferences(first: 1) {
+                        totalCount
+                      }
+                    }
+                  }
+                }
+              `,
+              { prId: pr.node_id }
+            );
+
+            const hasLinkedIssue =
+              result.node.closingIssuesReferences.totalCount > 0;
+
+            core.setOutput("has-linked-issue", hasLinkedIssue ? "true" : "false");
+
+            if (hasLinkedIssue) {
+              core.info("The pull request has a linked issue.");
+            }
+
+      # This token allows the workflow to check core developer membership and
+      # to comment on PRs.
+      - name: Generate issue triage token
+        if: steps.linked-issue.outputs.has-linked-issue != 'true'
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.ISSUE_TRIAGE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.ISSUE_TRIAGE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-issues: write
+          permission-members: read
+
+      - name: Comment when no issue is linked
+        if: steps.linked-issue.outputs.has-linked-issue != 'true'
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const { owner, repo } = context.repo;
+            const marker = "<!-- check-linked-issue -->";
+            const pr = context.payload.pull_request;
+
+            const coreTeam = "project-llzk/core-devs";
+            try {
+              const membership = await github.rest.teams.getMembershipForUserInOrg({
+                org: "project-llzk",
+                team_slug: "core-devs",
+                username: pr.user.login,
+              });
+
+              if (membership.data.state === "active") {
+                core.info(
+                  `${pr.user.login} is a member of ${coreTeam}; skipping linked issue reminder.`
+                );
+                return;
+              }
+            } catch (error) {
+              if (error.status !== 404) {
+                throw error;
+              }
+            }
+
+            // Avoid posting the same warning more than once.
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              {
+                owner,
+                repo,
+                issue_number: pr.number,
+                per_page: 100,
+              }
+            );
+
+            const alreadyCommented = comments.some(
+              comment =>
+                comment.user?.type === "Bot" &&
+                comment.body?.includes(marker)
+            );
+
+            if (alreadyCommented) {
+              core.info("The warning comment already exists.");
+              return;
+            }
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: pr.number,
+              body: [
+                marker,
+                "This pull request is not linked to an issue.",
+                "",
+                "Please link the relevant issue using the **Development** section in the sidebar, or add a closing reference such as:",
+                "",
+                "```",
+                "Closes #123",
+                "```",
+              ].join("\n"),
+            });

--- a/.github/workflows/pr-require-linked-issue.yml
+++ b/.github/workflows/pr-require-linked-issue.yml
@@ -1,7 +1,7 @@
 name: Check for linked issue
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, reopened, ready_for_review]
 
 permissions:

--- a/.github/workflows/pr-require-linked-issue.yml
+++ b/.github/workflows/pr-require-linked-issue.yml
@@ -64,8 +64,13 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
+          echo "Installed repository access:"
           gh api /installation/repositories \
-            --jq '.repositories[] | select(.full_name == "${{ github.repository }}") | .permissions'
+            --jq '.repositories[] | select(.full_name == "${{ github.repository }}") | .full_name'
+
+          echo "Can list issue comments:"
+          gh api /repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments \
+            --jq 'length'
 
       - name: Comment when no issue is linked
         if: steps.linked-issue.outputs.has-linked-issue != 'true'

--- a/.github/workflows/pr-require-linked-issue.yml
+++ b/.github/workflows/pr-require-linked-issue.yml
@@ -69,11 +69,13 @@ jobs:
             const marker = "<!-- check-linked-issue -->";
             const pr = context.payload.pull_request;
 
-            const coreTeam = "project-llzk/core-devs";
+            const org = context.repo.owner;
+            const teamSlug = "core-devs";
+            const coreTeam = `${org}/${teamSlug}`;
             try {
               const membership = await github.rest.teams.getMembershipForUserInOrg({
-                org: "project-llzk",
-                team_slug: "core-devs",
+                org,
+                team_slug: teamSlug,
                 username: pr.user.login,
               });
 

--- a/.github/workflows/pr-require-linked-issue.yml
+++ b/.github/workflows/pr-require-linked-issue.yml
@@ -79,14 +79,12 @@ jobs:
                 username: pr.user.login,
               });
 
-              /*
               if (membership.data.state === "active") {
                 core.info(
                   `${pr.user.login} is a member of ${coreTeam}; skipping linked issue reminder.`
                 );
                 return;
               }
-              */
             } catch (error) {
               core.warning(
                 `Unable to check ${coreTeam} membership for ${pr.user.login} (status: ${error.status ?? "unknown"}). Proceeding as non-member.`

--- a/.github/workflows/pr-require-linked-issue.yml
+++ b/.github/workflows/pr-require-linked-issue.yml
@@ -77,12 +77,14 @@ jobs:
                 username: pr.user.login,
               });
 
+              /*
               if (membership.data.state === "active") {
                 core.info(
                   `${pr.user.login} is a member of ${coreTeam}; skipping linked issue reminder.`
                 );
                 return;
               }
+              */
             } catch (error) {
               if (error.status !== 404) {
                 throw error;

--- a/.github/workflows/pr-require-linked-issue.yml
+++ b/.github/workflows/pr-require-linked-issue.yml
@@ -1,7 +1,7 @@
 name: Check for linked issue
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, ready_for_review]
 
 permissions:

--- a/.github/workflows/pr-require-linked-issue.yml
+++ b/.github/workflows/pr-require-linked-issue.yml
@@ -64,13 +64,8 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          echo "Installed repository access:"
           gh api /installation/repositories \
-            --jq '.repositories[] | select(.full_name == "${{ github.repository }}") | .full_name'
-
-          echo "Can list issue comments:"
-          gh api /repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments \
-            --jq 'length'
+            --jq '.repositories[] | select(.full_name == "${{ github.repository }}") | .permissions'
 
       - name: Comment when no issue is linked
         if: steps.linked-issue.outputs.has-linked-issue != 'true'

--- a/.github/workflows/pr-require-linked-issue.yml
+++ b/.github/workflows/pr-require-linked-issue.yml
@@ -56,7 +56,7 @@ jobs:
           private-key: ${{ secrets.ISSUE_TRIAGE_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
-          permission-issues: write
+          permission-pull-requests: write
           permission-members: read
 
       - name: Show issue triage token permissions

--- a/.github/workflows/pr-require-linked-issue.yml
+++ b/.github/workflows/pr-require-linked-issue.yml
@@ -79,12 +79,14 @@ jobs:
                 username: pr.user.login,
               });
 
+              /*
               if (membership.data.state === "active") {
                 core.info(
                   `${pr.user.login} is a member of ${coreTeam}; skipping linked issue reminder.`
                 );
                 return;
               }
+              */
             } catch (error) {
               core.warning(
                 `Unable to check ${coreTeam} membership for ${pr.user.login} (status: ${error.status ?? "unknown"}). Proceeding as non-member.`

--- a/.github/workflows/pr-require-linked-issue.yml
+++ b/.github/workflows/pr-require-linked-issue.yml
@@ -59,6 +59,14 @@ jobs:
           permission-issues: write
           permission-members: read
 
+      - name: Show issue triage token permissions
+        if: steps.linked-issue.outputs.has-linked-issue != 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh api /installation/repositories \
+            --jq '.repositories[] | select(.full_name == "${{ github.repository }}") | .permissions'
+
       - name: Comment when no issue is linked
         if: steps.linked-issue.outputs.has-linked-issue != 'true'
         uses: actions/github-script@v9


### PR DESCRIPTION
## Summary

Adds a workflow that runs when a PR authored by someone other than `core-devs` is opened or marked ready that will check if an issue has been linked. Posts a reminder comment if no issue is linked.

## Testing

Before adding the linked issue, I temporarily removed the `core-dev` exclusion and changed `pull_request_target` to `pull_request`, then closed and reopened the PR to trigger the workflow.

After adding the linked issue, I deleted the comment and again closed and reopened the PR.

## AI assistance

<!-- Select exactly one option. AI assistance includes generated or substantively modified code, tests, documentation, or design material. -->

- [ ] No AI tools contributed to this PR.
- [x] AI tools contributed to this PR.

<!-- If AI tools contributed, complete all three fields below. Otherwise, write "Not applicable." -->

**Tools used:**

**How the tools contributed:**

**How I verified the contribution:**
