### PR TITLE
Fix poly lowering for non-Felt equalities

### DIFF
--- a/changelogs/unreleased/fix__poly-lowering-non-felt-equality.yaml
+++ b/changelogs/unreleased/fix__poly-lowering-non-felt-equality.yaml
@@ -1,0 +1,2 @@
+fixed:
+  - Preserve valid non-Felt equality constraints during polynomial lowering.

--- a/lib/Transforms/LLZKPolyLoweringPass.cpp
+++ b/lib/Transforms/LLZKPolyLoweringPass.cpp
@@ -431,6 +431,11 @@ class PassImpl : public llzk::impl::PolyLoweringPassBase<PassImpl> {
     bool failedCheck = false;
 
     constrainFunc.walk([&](EmitEqualityOp eqOp) {
+      if (!llvm::isa<FeltType>(eqOp.getLhs().getType()) ||
+          !llvm::isa<FeltType>(eqOp.getRhs().getType())) {
+        return;
+      }
+
       DenseMap<Value, unsigned> checkMemo;
       unsigned lhsDegree = getDegree(eqOp.getLhs(), checkMemo);
       unsigned rhsDegree = getDegree(eqOp.getRhs(), checkMemo);
@@ -962,6 +967,11 @@ class PassImpl : public llzk::impl::PolyLoweringPassBase<PassImpl> {
 
       // Lower equality constraints
       constrainFunc.walk([&](EmitEqualityOp constraintOp) {
+        if (!llvm::isa<FeltType>(constraintOp.getLhs().getType()) ||
+            !llvm::isa<FeltType>(constraintOp.getRhs().getType())) {
+          return;
+        }
+
         auto &lhsOperand = constraintOp.getLhsMutable();
         auto &rhsOperand = constraintOp.getRhsMutable();
         unsigned degreeLhs = getDegree(lhsOperand.get(), degreeMemo);

--- a/test/Transforms/PolyLowering/poly_lowering_non_felt_equality.llzk
+++ b/test/Transforms/PolyLowering/poly_lowering_non_felt_equality.llzk
@@ -1,0 +1,74 @@
+// RUN: llzk-opt -split-input-file -llzk-poly-lowering-pass="max-degree=2" --verify-each %s | FileCheck --enable-var-scope %s
+
+module attributes {llzk.lang} {
+  struct.def @IndexEquality {
+    function.def @compute(
+        %arr: !array.type<? x !felt.type>,
+        %idx: index
+    ) -> !struct.type<@IndexEquality> {
+      %self = struct.new : !struct.type<@IndexEquality>
+      function.return %self : !struct.type<@IndexEquality>
+    }
+
+    function.def @constrain(
+        %self: !struct.type<@IndexEquality>,
+        %arr: !array.type<? x !felt.type>,
+        %idx: index
+    ) {
+      %dim = arith.constant 0 : index
+      %len = array.len %arr, %dim : !array.type<? x !felt.type>
+      constrain.eq %len, %idx : index, index
+      function.return
+    }
+  }
+}
+// CHECK-LABEL: module attributes {llzk.lang} {
+// CHECK-NEXT:    struct.def @IndexEquality {
+// CHECK-NEXT:      function.def @compute(%[[ARR_ARG:[0-9a-zA-Z_\.]+]]: !array.type<? x !felt.type>, %[[COMPUTE_IDX:[0-9a-zA-Z_\.]+]]: index) -> !struct.type<@IndexEquality> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[SELF:[0-9a-zA-Z_\.]+]] = struct.new : <@IndexEquality>
+// CHECK-NEXT:        function.return %[[SELF]] : !struct.type<@IndexEquality>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.def @constrain(%[[ARG:[0-9a-zA-Z_\.]+]]: !struct.type<@IndexEquality>, %[[ARR:[0-9a-zA-Z_\.]+]]: !array.type<? x !felt.type>, %[[IDX:[0-9a-zA-Z_\.]+]]: index) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[DIM:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[LEN:[0-9a-zA-Z_\.]+]] = array.len %[[ARR]], %[[DIM]] : <? x !felt.type>
+// CHECK-NEXT:        constrain.eq %[[LEN]], %[[IDX]] : index, index
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }
+// -----
+
+module attributes {llzk.lang} {
+  struct.def @BooleanEquality {
+    function.def @compute(%idx: index) -> !struct.type<@BooleanEquality> {
+      %self = struct.new : !struct.type<@BooleanEquality>
+      function.return %self : !struct.type<@BooleanEquality>
+    }
+
+    function.def @constrain(
+        %self: !struct.type<@BooleanEquality>,
+        %idx: index
+    ) {
+      %zero = arith.constant 0 : index
+      %in_range = arith.cmpi sge, %idx, %zero : index
+      %true = arith.constant true
+      constrain.eq %in_range, %true : i1, i1
+      function.return
+    }
+  }
+}
+// CHECK-LABEL: module attributes {llzk.lang} {
+// CHECK-NEXT:    struct.def @BooleanEquality {
+// CHECK-NEXT:      function.def @compute(%[[COMPUTE_IDX:[0-9a-zA-Z_\.]+]]: index) -> !struct.type<@BooleanEquality> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[SELF:[0-9a-zA-Z_\.]+]] = struct.new : <@BooleanEquality>
+// CHECK-NEXT:        function.return %[[SELF]] : !struct.type<@BooleanEquality>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.def @constrain(%[[ARG:[0-9a-zA-Z_\.]+]]: !struct.type<@BooleanEquality>, %[[IDX:[0-9a-zA-Z_\.]+]]: index) attributes {function.allow_constraint} {
+// CHECK-NEXT:        %[[ZERO:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[IN_RANGE:[0-9a-zA-Z_\.]+]] = arith.cmpi sge, %[[IDX]], %[[ZERO]] : index
+// CHECK-NEXT:        %[[TRUE:[0-9a-zA-Z_\.]+]] = arith.constant true
+// CHECK-NEXT:        constrain.eq %[[IN_RANGE]], %[[TRUE]] : i1, i1
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }


### PR DESCRIPTION
## Summary

Fixes #642

Poly lowering now preserves valid non-Felt equality constraints instead of passing them to Felt-only degree analysis.

## Related issues

Fixes #642

## Changes

- Skip degree analysis when either equality operand is non-Felt.
- Preserve existing Felt equality lowering.
- Add regression coverage for `index` and `i1` equality constraints.
- Add the required unreleased changelog entry.
- No syntax or API documentation changes are needed.

## Testing

- `cmake --build build --target check-lit` — CI passed 373 tests with no unexpected failures.
- `git diff --check` — passed.
- The focused `poly_lowering_non_felt_equality.llzk` test passed in both Clang and GCC CI jobs.
- [Fork-only exact-head FileCheck validation](https://github.com/1sgtpepper/llzk-lib/actions/runs/30801471833) — `llzk-opt` built from reviewed head `cd901b91`; the producer output and `scripts/generate-test-checks.py` output were archived, and their normalized 29-line check blocks matched the committed test with no differences.

## Submission checklist

- [x] If I am an external contributor, this PR has a linked issue marked `approved`; otherwise, this does not apply.
- [x] I added or updated tests for all relevant behavior, or explained above why tests are not needed.
- [x] I updated the relevant TableGen or other documentation, or explained above why documentation is not needed.
- [x] I added a changelog entry describing user-visible changes.
- [x] I enabled **Allow edits from maintainers** if this PR comes from a fork.

## AI assistance

- [ ] No AI tools contributed to this PR.
- [x] AI tools contributed to this PR.

**Tools used:** Codex

**How the tools contributed:** Implementation.

**How I verified the contribution:** Full lit suite, focused FileCheck validation, and exact-head fork CI comparison passed.