### PR TITLE
Guard recursive purposeless-constrain analysis

### DIFF
--- a/changelogs/unreleased/fix__recursive-purposeless-constrain.yaml
+++ b/changelogs/unreleased/fix__recursive-purposeless-constrain.yaml
@@ -1,0 +1,2 @@
+fixed:
+  - Ensure cyclic constrain-call graphs terminate without removing their calls during duplicate operation elimination.

--- a/lib/Transforms/LLZKRedundantOperationEliminationPass.cpp
+++ b/lib/Transforms/LLZKRedundantOperationEliminationPass.cpp
@@ -183,7 +183,13 @@ class PassImpl : public llzk::impl::RedundantOperationEliminationPassBase<PassIm
     }
   }
 
-  bool isPurposelessConstrainFunc(SymbolTableCollection &symbolTables, FuncDefOp fn) {
+  /// Classify \p fn as removable when it is a struct constrain function without
+  /// explicit constraints or unknown/mutating effects. The active set tracks
+  /// only the current call path, so a repeated function identifies a cycle
+  /// while an acyclic callee can still be classified normally.
+  bool isPurposelessConstrainFunc(
+      SymbolTableCollection &symbolTables, FuncDefOp fn, DenseSet<Operation *> &activeFunctions
+  ) {
     if (!fn.isStructConstrain()) {
       return false;
     }
@@ -192,6 +198,11 @@ class PassImpl : public llzk::impl::RedundantOperationEliminationPassBase<PassIm
     // ram.store. The WitnessGen verifier enforces that boundary unless the
     // callee is explicitly marked allow_witness.
     if (fn.hasAllowWitnessAttr()) {
+      return false;
+    }
+    if (!activeFunctions.insert(fn.getOperation()).second) {
+      // A recursive call path cannot be proven purposeless; retain the call
+      // conservatively.
       return false;
     }
 
@@ -204,7 +215,7 @@ class PassImpl : public llzk::impl::RedundantOperationEliminationPassBase<PassIm
         res = false;
         return WalkResult::interrupt();
       } else if (auto callOp = dyn_cast<CallOp>(op)) {
-        if (!callsPurposelessConstrainFunc(symbolTables, callOp)) {
+        if (!callsPurposelessConstrainFunc(symbolTables, callOp, activeFunctions)) {
           res = false;
           return WalkResult::interrupt();
         }
@@ -221,12 +232,17 @@ class PassImpl : public llzk::impl::RedundantOperationEliminationPassBase<PassIm
       }
       return WalkResult::advance();
     });
+    activeFunctions.erase(fn.getOperation());
     return res;
   }
 
-  bool callsPurposelessConstrainFunc(SymbolTableCollection &symbolTables, CallOp call) {
+  /// Resolve and classify a direct constrain call; unresolved calls are retained.
+  bool callsPurposelessConstrainFunc(
+      SymbolTableCollection &symbolTables, CallOp call, DenseSet<Operation *> &activeFunctions
+  ) {
     auto callLookup = resolveCallable<FuncDefOp>(symbolTables, call);
-    return succeeded(callLookup) && isPurposelessConstrainFunc(symbolTables, callLookup->get());
+    return succeeded(callLookup) &&
+           isPurposelessConstrainFunc(symbolTables, callLookup->get(), activeFunctions);
   }
 
   void runOnFunc(SymbolTableCollection &symbolTables, CallableOpInterface callable) {
@@ -242,10 +258,12 @@ class PassImpl : public llzk::impl::RedundantOperationEliminationPassBase<PassIm
         return true;
       }
 
-      if (auto callOp = dyn_cast<CallOp>(op);
-          callOp && callsPurposelessConstrainFunc(symbolTables, callOp)) {
-        redundantOps.push_back(op);
-        return true;
+      if (auto callOp = dyn_cast<CallOp>(op)) {
+        DenseSet<Operation *> activeFunctions;
+        if (callsPurposelessConstrainFunc(symbolTables, callOp, activeFunctions)) {
+          redundantOps.push_back(op);
+          return true;
+        }
       }
       return false;
     };

--- a/test/Transforms/RedundantAndUnusedElim/recursive_purposeless_constrain_repro.llzk
+++ b/test/Transforms/RedundantAndUnusedElim/recursive_purposeless_constrain_repro.llzk
@@ -1,0 +1,109 @@
+// RUN: llzk-opt -llzk-duplicate-op-elim %s 2>&1 | FileCheck %s
+
+// Mutually recursive constrain calls are valid in LLZK. The pass must complete
+// without classifying either call as purposeless.
+module attributes {llzk.lang} {
+  struct.def @CycleA {
+    function.def @compute(%other: !struct.type<@CycleB>) -> !struct.type<@CycleA> {
+      %self = struct.new : !struct.type<@CycleA>
+      function.return %self : !struct.type<@CycleA>
+    }
+
+    function.def @constrain(
+        %self: !struct.type<@CycleA>, %other: !struct.type<@CycleB>
+    ) {
+      function.call @CycleB::@constrain(%other, %self) :
+          (!struct.type<@CycleB>, !struct.type<@CycleA>) -> ()
+      function.return
+    }
+  }
+
+  struct.def @CycleB {
+    function.def @compute(%other: !struct.type<@CycleA>) -> !struct.type<@CycleB> {
+      %self = struct.new : !struct.type<@CycleB>
+      function.return %self : !struct.type<@CycleB>
+    }
+
+    function.def @constrain(
+        %self: !struct.type<@CycleB>, %other: !struct.type<@CycleA>
+    ) {
+      function.call @CycleA::@constrain(%other, %self) :
+          (!struct.type<@CycleA>, !struct.type<@CycleB>) -> ()
+      function.return
+    }
+  }
+
+  // An acyclic effect-free constrain call is removable because its callee has
+  // no nested call or effectful operation. Repeating the same call verifies
+  // that separate call sites remain independently removable.
+  struct.def @ReadOnlyCallee {
+    function.def @compute() -> !struct.type<@ReadOnlyCallee> {
+      %self = struct.new : !struct.type<@ReadOnlyCallee>
+      function.return %self : !struct.type<@ReadOnlyCallee>
+    }
+
+    function.def @constrain(%self: !struct.type<@ReadOnlyCallee>) {
+      function.return
+    }
+  }
+
+  struct.def @ReadOnlyCaller {
+    function.def @compute(%callee: !struct.type<@ReadOnlyCallee>) -> !struct.type<@ReadOnlyCaller> {
+      %self = struct.new : !struct.type<@ReadOnlyCaller>
+      function.return %self : !struct.type<@ReadOnlyCaller>
+    }
+
+    function.def @constrain(
+        %self: !struct.type<@ReadOnlyCaller>, %callee: !struct.type<@ReadOnlyCallee>
+    ) {
+      function.call @ReadOnlyCallee::@constrain(%callee) :
+          (!struct.type<@ReadOnlyCallee>) -> ()
+      function.call @ReadOnlyCallee::@constrain(%callee) :
+          (!struct.type<@ReadOnlyCallee>) -> ()
+      function.return
+    }
+  }
+}
+
+// The complete emitted module is checked so the cycle-retention assertion does
+// not hide unrelated output changes.
+// CHECK-LABEL: module attributes {llzk.lang} {
+// CHECK-NEXT:    struct.def @CycleA {
+// CHECK-NEXT:      function.def @compute(%[[CA_COMPUTE_OTHER:[0-9a-zA-Z_\.]+]]: !struct.type<@CycleB>) -> !struct.type<@CycleA> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[CA_COMPUTE_SELF:[0-9a-zA-Z_\.]+]] = struct.new : <@CycleA>
+// CHECK-NEXT:        function.return %[[CA_COMPUTE_SELF]] : !struct.type<@CycleA>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.def @constrain(%[[CA_SELF:[0-9a-zA-Z_\.]+]]: !struct.type<@CycleA>, %[[CA_OTHER:[0-9a-zA-Z_\.]+]]: !struct.type<@CycleB>) attributes {function.allow_constraint} {
+// CHECK-NEXT:        function.call @CycleB::@constrain(%[[CA_OTHER]], %[[CA_SELF]]) : (!struct.type<@CycleB>, !struct.type<@CycleA>) -> ()
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:    struct.def @CycleB {
+// CHECK-NEXT:      function.def @compute(%[[CB_COMPUTE_OTHER:[0-9a-zA-Z_\.]+]]: !struct.type<@CycleA>) -> !struct.type<@CycleB> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[CB_COMPUTE_SELF:[0-9a-zA-Z_\.]+]] = struct.new : <@CycleB>
+// CHECK-NEXT:        function.return %[[CB_COMPUTE_SELF]] : !struct.type<@CycleB>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.def @constrain(%[[CB_SELF:[0-9a-zA-Z_\.]+]]: !struct.type<@CycleB>, %[[CB_OTHER:[0-9a-zA-Z_\.]+]]: !struct.type<@CycleA>) attributes {function.allow_constraint} {
+// CHECK-NEXT:        function.call @CycleA::@constrain(%[[CB_OTHER]], %[[CB_SELF]]) : (!struct.type<@CycleA>, !struct.type<@CycleB>) -> ()
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:    struct.def @ReadOnlyCallee {
+// CHECK-NEXT:      function.def @compute() -> !struct.type<@ReadOnlyCallee> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[ROC_COMPUTE_SELF:[0-9a-zA-Z_\.]+]] = struct.new : <@ReadOnlyCallee>
+// CHECK-NEXT:        function.return %[[ROC_COMPUTE_SELF]] : !struct.type<@ReadOnlyCallee>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.def @constrain(%[[ROC_SELF:[0-9a-zA-Z_\.]+]]: !struct.type<@ReadOnlyCallee>) attributes {function.allow_constraint} {
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:    struct.def @ReadOnlyCaller {
+// CHECK-NEXT:      function.def @compute(%[[ROC_CALLER_COMPUTE_CALLEE:[0-9a-zA-Z_\.]+]]: !struct.type<@ReadOnlyCallee>) -> !struct.type<@ReadOnlyCaller> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[ROC_CALLER_COMPUTE_SELF:[0-9a-zA-Z_\.]+]] = struct.new : <@ReadOnlyCaller>
+// CHECK-NEXT:        function.return %[[ROC_CALLER_COMPUTE_SELF]] : !struct.type<@ReadOnlyCaller>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.def @constrain(%[[ROC_CALLER_SELF:[0-9a-zA-Z_\.]+]]: !struct.type<@ReadOnlyCaller>, %[[ROC_CALLER_CALLEE:[0-9a-zA-Z_\.]+]]: !struct.type<@ReadOnlyCallee>) attributes {function.allow_constraint} {
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }


### PR DESCRIPTION
## Summary

Fixes #667.

Prevent recursive constrain-call analysis from recursing without bound while preserving calls that cannot be proven purposeless.

## Changes

Track the current constrain-function call path during purposeless-call analysis. A repeated function is retained conservatively as a cycle; an acyclic effect-free/read-only constrain call remains removable. The active-path entry is removed after each classification so separate call sites do not affect one another.

## Testing

- `test/Transforms/RedundantAndUnusedElim/recursive_purposeless_constrain_repro.llzk` covers mutual-cycle retention and acyclic effect-free-call removal with complete transformed-module checks; the committed block contains 40 checks.
- The branch is one feature commit on main at `73933dad61360960e45ec3def678de5bc04d7e0e`; current head is `93d19a0ebbe9f508752f1aeb9e67d6a43ef8e61e`.
- Current-head CI passed: [GCC/Clang tests](https://github.com/project-llzk/llzk-lib/actions/runs/31030346353), [debug/release Nix checks](https://github.com/project-llzk/llzk-lib/actions/runs/31030346474), [clang-format](https://github.com/project-llzk/llzk-lib/actions/runs/31030349791), [docs](https://github.com/project-llzk/llzk-lib/actions/runs/31030346427), and [changelog](https://github.com/project-llzk/llzk-lib/actions/runs/31030346983) all passed.
- Exact-head replay in [fork CI](https://github.com/1sgtpepper/llzk-lib/actions/runs/31030402426) passed: the committed and freshly generated complete checks both pass against this head, with 40/40 check lines.
- No public pass, TableGen, or CLI documentation changed; the existing pass description remains accurate, and the recursive call-path invariant is documented beside the implementation.

## Submission checklist

- [x] If I am an external contributor, this PR has a linked issue marked `approved`; otherwise, this does not apply.
- [x] I added or updated tests for all relevant behavior, or explained above why tests are not needed.
- [x] I updated the relevant TableGen or other documentation, or explained above why documentation was not needed.
- [x] I added a changelog entry describing user-visible changes. (`create-changelog` in the Nix development shell creates a template.)
- [x] I enabled **Allow edits from maintainers** if this PR comes from a fork.

## Assistance disclosure

- [x] Automated development assistance contributed to this PR.

**How it contributed:** Implementation and review help.

**How I verified the contribution:** Final changes reviewed.
