### PR TITLE
Invalidate array aliases across dynamic and constant writes

### DIFF
--- a/changelogs/unreleased/fix__dynamic-array-alias-invalidation.yaml
+++ b/changelogs/unreleased/fix__dynamic-array-alias-invalidation.yaml
@@ -1,0 +1,2 @@
+fixed:
+  - Avoid stale array-read reuse when a constant-index write may alias an earlier dynamic-index write.

--- a/lib/Transforms/LLZKRedundantReadAndWriteEliminationPass.cpp
+++ b/lib/Transforms/LLZKRedundantReadAndWriteEliminationPass.cpp
@@ -158,13 +158,10 @@ namespace {
 /// elimination until they become known and can be eliminated when redundant operations
 /// are performed.
 ///
-/// A node may have "constant identifiers" as children (member refs, constant indices)
-/// or a single non-constant child index (just an mlir::Value), as the dynamic
-/// index may or may not alias any constant identifiers. If a dynamic index is
-/// added, the user should clear the prior known children to prevent accidental aliasing.
-///
-/// Does not allow mixing of constant and non-constant child indices, as we
-/// do not know if they alias.
+/// Children may represent constant access components (member refs, constant indices)
+/// or dynamic SSA values. Dynamic children may alias constant siblings, so array
+/// writes clear all children for a dynamic index and only dynamic siblings for a
+/// constant index.
 class ReferenceNode {
 public:
   template <typename IdType> static std::shared_ptr<ReferenceNode> create(IdType id, Value v) {
@@ -179,6 +176,7 @@ public:
     ReferenceNode copy(identifier, storedValue);
     copy.updateLastWrite(lastWrite);
     if (withChildren) {
+      copy.dynamicChildCount = dynamicChildCount;
       for (const auto &[id, child] : children) {
         copy.children[id] = child->clone(withChildren);
       }
@@ -191,6 +189,9 @@ public:
   createChild(IdType id, Value storedVal, const std::shared_ptr<ReferenceNode> &valTree = nullptr) {
     std::shared_ptr<ReferenceNode> child = create(id, storedVal);
     child->setCurrentValue(storedVal, valTree);
+    if (child->identifier.isValue() && children.find(child->identifier) == children.end()) {
+      ++dynamicChildCount;
+    }
     children[child->identifier] = child;
     return child;
   }
@@ -233,21 +234,50 @@ public:
       // Overwrite our current set of children with new children, since we overwrote
       // the stored value.
       children = valTree->children;
+      dynamicChildCount = valTree->dynamicChildCount;
     }
   }
 
-  void invalidateChildren() { children.clear(); }
+  void invalidateChildren() {
+    children.clear();
+    dynamicChildCount = 0;
+  }
 
-  bool invalidateNonIntegerOffsetChildren() {
+  /// @brief Remove dynamic-index children before descending through a constant index.
+  ///
+  /// A constant-index write can alias an existing dynamic-index child, but not a
+  /// different constant-index child.
+  void invalidateDynamicChildren() {
+    if (dynamicChildCount == 0) {
+      return;
+    }
     SmallVector<ReferenceID> invalidChildren;
     for (const auto &[id, _] : children) {
-      if (!id.isAttribute() || !isa<IntegerAttr>(id.getAttribute())) {
+      if (id.isValue()) {
         invalidChildren.push_back(id);
       }
     }
     for (const ReferenceID &id : invalidChildren) {
       children.erase(id);
     }
+    dynamicChildCount = 0;
+  }
+
+  bool invalidateNonIntegerOffsetChildren() {
+    SmallVector<ReferenceID> invalidChildren;
+    size_t invalidDynamicChildCount = 0;
+    for (const auto &[id, _] : children) {
+      if (!id.isAttribute() || !isa<IntegerAttr>(id.getAttribute())) {
+        invalidChildren.push_back(id);
+        if (id.isValue()) {
+          ++invalidDynamicChildCount;
+        }
+      }
+    }
+    for (const ReferenceID &id : invalidChildren) {
+      children.erase(id);
+    }
+    dynamicChildCount -= invalidDynamicChildCount;
     return !invalidChildren.empty();
   }
 
@@ -299,6 +329,9 @@ public:
         auto &rhsChild = it->second;
         if (auto gcs = greatestCommonSubtree(lhsChild, rhsChild)) {
           res->children[id] = gcs;
+          if (id.isValue()) {
+            ++res->dynamicChildCount;
+          }
         }
       }
     }
@@ -310,10 +343,14 @@ private:
   mlir::Value storedValue;
   Operation *lastWrite;
   DenseMap<ReferenceID, std::shared_ptr<ReferenceNode>> children;
+  // Number of direct dynamic children. Keep it synchronized with every children
+  // mutation so constant-only invalidation remains independent of child fanout.
+  size_t dynamicChildCount;
 
   template <typename IdType>
   ReferenceNode(IdType id, Value initialVal)
-      : identifier(std::move(id)), storedValue(initialVal), lastWrite(nullptr), children() {}
+      : identifier(std::move(id)), storedValue(initialVal), lastWrite(nullptr), children(),
+        dynamicChildCount(0) {}
 };
 
 using ValueMap = DenseMap<mlir::Value, std::shared_ptr<ReferenceNode>>;
@@ -718,11 +755,9 @@ class PassImpl : public llzk::impl::RedundantReadAndWriteEliminationPassBase<Pas
       readVals.push_back(resVal);
     };
 
-    // Write a scalar value (for writearr) or a subarray value (for insertarr)
-    // to an array. The unique part of this operation relative to others is that
-    // we may receive a variable index (i.e., not a constant). In this case, we
-    // invalidate adjacent subtree state because the variable index may alias
-    // another element.
+    // Handle array.write (scalar) and array.insert (subarray) with one or more
+    // indices. Dynamic indices may alias any sibling; constant indices only
+    // invalidate dynamic-index siblings.
     auto doArrayWriteLike = [&]<HasInterface<ArrayAccessOpInterface> OpClass>(OpClass writearr) {
       std::shared_ptr<ReferenceNode> currValTree = tryGetValTree(translate(writearr.getArrRef()));
       if (currValTree == nullptr) {
@@ -733,9 +768,11 @@ class PassImpl : public llzk::impl::RedundantReadAndWriteEliminationPassBase<Pas
 
       for (Value origIdx : writearr.getIndices()) {
         Value idxVal = translate(origIdx);
-        // This write will invalidate all children, since it may reference
-        // any number of them.
-        if (ReferenceID(idxVal).isValue()) {
+        // A dynamic index may alias any sibling. A constant index only aliases
+        // a dynamic sibling, so preserve unrelated constant-index facts.
+        if (ReferenceID(idxVal).isConst()) {
+          currValTree->invalidateDynamicChildren();
+        } else {
           LLVM_DEBUG(llvm::dbgs() << writearr.getOperationName() << ": invalidate alias\n");
           currValTree->invalidateChildren();
         }

--- a/test/Transforms/RedundantAndUnusedElim/array_dynamic_constant_alias.llzk
+++ b/test/Transforms/RedundantAndUnusedElim/array_dynamic_constant_alias.llzk
@@ -1,0 +1,174 @@
+// RUN: llzk-opt -llzk-duplicate-read-write-elim %s 2>&1 | FileCheck %s
+
+module attributes {llzk.lang} {
+  // The later constant-index write may overwrite the element selected by %idx,
+  // so the final dynamic read must remain.
+  function.def @dynamic_then_constant_alias(%idx: index) -> !felt.type {
+    %first = felt.const 1
+    %second = felt.const 2
+    %arr = array.new %first, %first : !array.type<2 x !felt.type>
+    array.write %arr[%idx] = %first : !array.type<2 x !felt.type>, !felt.type
+    %zero = arith.constant 0 : index
+    array.write %arr[%zero] = %second : !array.type<2 x !felt.type>, !felt.type
+    %observed = array.read %arr[%idx] : !array.type<2 x !felt.type>, !felt.type
+    function.return %observed : !felt.type
+  }
+
+  // The dynamic write may overwrite the earlier constant-index element, so the
+  // final constant read must remain.
+  function.def @constant_then_dynamic_alias(%idx: index) -> !felt.type {
+    %first = felt.const 1
+    %second = felt.const 2
+    %third = felt.const 3
+    %arr = array.new %first, %first : !array.type<2 x !felt.type>
+    %zero = arith.constant 0 : index
+    array.write %arr[%zero] = %second : !array.type<2 x !felt.type>, !felt.type
+    array.write %arr[%idx] = %third : !array.type<2 x !felt.type>, !felt.type
+    %observed = array.read %arr[%zero] : !array.type<2 x !felt.type>, !felt.type
+    function.return %observed : !felt.type
+  }
+
+  // Distinct known constant indices keep the first fact valid, so the final
+  // read can be removed.
+  function.def @constant_index_reuse() -> !felt.type {
+    %first = felt.const 1
+    %second = felt.const 2
+    %third = felt.const 3
+    %arr = array.new %first, %first : !array.type<2 x !felt.type>
+    %zero = arith.constant 0 : index
+    %one = arith.constant 1 : index
+    array.write %arr[%zero] = %second : !array.type<2 x !felt.type>, !felt.type
+    array.write %arr[%one] = %third : !array.type<2 x !felt.type>, !felt.type
+    %observed = array.read %arr[%zero] : !array.type<2 x !felt.type>, !felt.type
+    function.return %observed : !felt.type
+  }
+
+  // An inserted subarray can carry a dynamic child into the destination tree.
+  // A later constant write must invalidate that copied alias before descending.
+  function.def @inserted_dynamic_subarray_alias(%idx: index) -> !felt.type {
+    %one = felt.const 1
+    %two = felt.const 2
+    %row = array.new %one, %one : !array.type<2 x !felt.type>
+    array.write %row[%idx] = %one : !array.type<2 x !felt.type>, !felt.type
+    %matrix = array.new : !array.type<2,2 x !felt.type>
+    %zero = arith.constant 0 : index
+    array.insert %matrix[%zero] = %row :
+        !array.type<2,2 x !felt.type>, !array.type<2 x !felt.type>
+    array.write %matrix[%zero, %zero] = %two :
+        !array.type<2,2 x !felt.type>, !felt.type
+    %observed = array.read %matrix[%zero, %idx] :
+        !array.type<2,2 x !felt.type>, !felt.type
+    function.return %observed : !felt.type
+  }
+
+  // The same alias rule applies to array.insert; each supplied index is
+  // invalidated independently. The final extract must remain because the
+  // later constant-index insert may overwrite the subarray selected by %idx
+  // at the second index.
+  function.def @dynamic_then_constant_insert_alias(%idx: index) -> !array.type<2 x !felt.type> {
+    %one = felt.const 1
+    %two = felt.const 2
+    %first_row = array.new %one, %one : !array.type<2 x !felt.type>
+    %second_row = array.new %two, %two : !array.type<2 x !felt.type>
+    %matrix = array.new : !array.type<2,2,2 x !felt.type>
+    %zero = arith.constant 0 : index
+    array.insert %matrix[%zero, %idx] = %first_row :
+        !array.type<2,2,2 x !felt.type>, !array.type<2 x !felt.type>
+    array.insert %matrix[%zero, %zero] = %second_row :
+        !array.type<2,2,2 x !felt.type>, !array.type<2 x !felt.type>
+    %observed = array.extract %matrix[%zero, %idx] : !array.type<2,2,2 x !felt.type>
+    function.return %observed : !array.type<2 x !felt.type>
+  }
+
+  // Preserve a dynamic child through branch-state cloning before a branch-local
+  // constant write invalidates possible aliases and keeps the dynamic read live.
+  function.def @dynamic_alias_through_if(%idx: index, %cond: i1) -> !felt.type {
+    %first = felt.const 1
+    %second = felt.const 2
+    %arr = array.new %first, %first : !array.type<2 x !felt.type>
+    array.write %arr[%idx] = %first : !array.type<2 x !felt.type>, !felt.type
+    %observed = scf.if %cond -> !felt.type {
+      %branch_zero = arith.constant 0 : index
+      array.write %arr[%branch_zero] = %second : !array.type<2 x !felt.type>, !felt.type
+      %branch_observed = array.read %arr[%idx] : !array.type<2 x !felt.type>, !felt.type
+      scf.yield %branch_observed : !felt.type
+    } else {
+      scf.yield %first : !felt.type
+    }
+    function.return %observed : !felt.type
+  }
+}
+
+// CHECK-LABEL: module attributes {llzk.lang} {
+// CHECK-NEXT:    function.def @dynamic_then_constant_alias(%[[VAL_0:[0-9a-zA-Z_\.]+]]: index) -> !felt.type {
+// CHECK-NEXT:      %[[VAL_1:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:      %[[VAL_2:[0-9a-zA-Z_\.]+]] = felt.const  2
+// CHECK-NEXT:      %[[VAL_3:[0-9a-zA-Z_\.]+]] = array.new %[[VAL_1]], %[[VAL_1]] : <2 x !felt.type>
+// CHECK-NEXT:      array.write %[[VAL_3]]{{\[}}%[[VAL_0]]] = %[[VAL_1]] : <2 x !felt.type>, !felt.type
+// CHECK-NEXT:      %[[VAL_4:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:      array.write %[[VAL_3]]{{\[}}%[[VAL_4]]] = %[[VAL_2]] : <2 x !felt.type>, !felt.type
+// CHECK-NEXT:      %[[VAL_5:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_3]]{{\[}}%[[VAL_0]]] : <2 x !felt.type>, !felt.type
+// CHECK-NEXT:      function.return %[[VAL_5]] : !felt.type
+// CHECK-NEXT:    }
+// CHECK-NEXT:    function.def @constant_then_dynamic_alias(%[[VAL_6:[0-9a-zA-Z_\.]+]]: index) -> !felt.type {
+// CHECK-NEXT:      %[[VAL_7:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:      %[[VAL_8:[0-9a-zA-Z_\.]+]] = felt.const  2
+// CHECK-NEXT:      %[[VAL_9:[0-9a-zA-Z_\.]+]] = felt.const  3
+// CHECK-NEXT:      %[[VAL_10:[0-9a-zA-Z_\.]+]] = array.new %[[VAL_7]], %[[VAL_7]] : <2 x !felt.type>
+// CHECK-NEXT:      %[[VAL_11:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:      array.write %[[VAL_10]]{{\[}}%[[VAL_11]]] = %[[VAL_8]] : <2 x !felt.type>, !felt.type
+// CHECK-NEXT:      array.write %[[VAL_10]]{{\[}}%[[VAL_6]]] = %[[VAL_9]] : <2 x !felt.type>, !felt.type
+// CHECK-NEXT:      %[[VAL_12:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_10]]{{\[}}%[[VAL_11]]] : <2 x !felt.type>, !felt.type
+// CHECK-NEXT:      function.return %[[VAL_12]] : !felt.type
+// CHECK-NEXT:    }
+// CHECK-NEXT:    function.def @constant_index_reuse() -> !felt.type {
+// CHECK-NEXT:      %[[VAL_13:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:      %[[VAL_14:[0-9a-zA-Z_\.]+]] = felt.const  2
+// CHECK-NEXT:      %[[VAL_15:[0-9a-zA-Z_\.]+]] = felt.const  3
+// CHECK-NEXT:      %[[VAL_16:[0-9a-zA-Z_\.]+]] = array.new %[[VAL_13]], %[[VAL_13]] : <2 x !felt.type>
+// CHECK-NEXT:      %[[VAL_17:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:      %[[VAL_18:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:      array.write %[[VAL_16]]{{\[}}%[[VAL_17]]] = %[[VAL_14]] : <2 x !felt.type>, !felt.type
+// CHECK-NEXT:      array.write %[[VAL_16]]{{\[}}%[[VAL_18]]] = %[[VAL_15]] : <2 x !felt.type>, !felt.type
+// CHECK-NEXT:      function.return %[[VAL_14]] : !felt.type
+// CHECK-NEXT:    }
+// CHECK-NEXT:    function.def @inserted_dynamic_subarray_alias(%[[VAL_19:[0-9a-zA-Z_\.]+]]: index) -> !felt.type {
+// CHECK-NEXT:      %[[VAL_20:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:      %[[VAL_21:[0-9a-zA-Z_\.]+]] = felt.const  2
+// CHECK-NEXT:      %[[VAL_22:[0-9a-zA-Z_\.]+]] = array.new %[[VAL_20]], %[[VAL_20]] : <2 x !felt.type>
+// CHECK-NEXT:      array.write %[[VAL_22]]{{\[}}%[[VAL_19]]] = %[[VAL_20]] : <2 x !felt.type>, !felt.type
+// CHECK-NEXT:      %[[VAL_23:[0-9a-zA-Z_\.]+]] = array.new  : <2,2 x !felt.type>
+// CHECK-NEXT:      %[[VAL_24:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:      array.insert %[[VAL_23]]{{\[}}%[[VAL_24]]] = %[[VAL_22]] : <2,2 x !felt.type>, <2 x !felt.type>
+// CHECK-NEXT:      array.write %[[VAL_23]]{{\[}}%[[VAL_24]], %[[VAL_24]]] = %[[VAL_21]] : <2,2 x !felt.type>, !felt.type
+// CHECK-NEXT:      %[[VAL_25:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_23]]{{\[}}%[[VAL_24]], %[[VAL_19]]] : <2,2 x !felt.type>, !felt.type
+// CHECK-NEXT:      function.return %[[VAL_25]] : !felt.type
+// CHECK-NEXT:    }
+// CHECK-NEXT:    function.def @dynamic_then_constant_insert_alias(%[[VAL_26:[0-9a-zA-Z_\.]+]]: index) -> !array.type<2 x !felt.type> {
+// CHECK-NEXT:      %[[VAL_27:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:      %[[VAL_28:[0-9a-zA-Z_\.]+]] = felt.const  2
+// CHECK-NEXT:      %[[VAL_29:[0-9a-zA-Z_\.]+]] = array.new %[[VAL_27]], %[[VAL_27]] : <2 x !felt.type>
+// CHECK-NEXT:      %[[VAL_30:[0-9a-zA-Z_\.]+]] = array.new %[[VAL_28]], %[[VAL_28]] : <2 x !felt.type>
+// CHECK-NEXT:      %[[VAL_31:[0-9a-zA-Z_\.]+]] = array.new  : <2,2,2 x !felt.type>
+// CHECK-NEXT:      %[[VAL_32:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:      array.insert %[[VAL_31]]{{\[}}%[[VAL_32]], %[[VAL_26]]] = %[[VAL_29]] : <2,2,2 x !felt.type>, <2 x !felt.type>
+// CHECK-NEXT:      array.insert %[[VAL_31]]{{\[}}%[[VAL_32]], %[[VAL_32]]] = %[[VAL_30]] : <2,2,2 x !felt.type>, <2 x !felt.type>
+// CHECK-NEXT:      %[[VAL_33:[0-9a-zA-Z_\.]+]] = array.extract %[[VAL_31]]{{\[}}%[[VAL_32]], %[[VAL_26]]] : <2,2,2 x !felt.type>
+// CHECK-NEXT:      function.return %[[VAL_33]] : !array.type<2 x !felt.type>
+// CHECK-NEXT:    }
+// CHECK-NEXT:    function.def @dynamic_alias_through_if(%[[VAL_34:[0-9a-zA-Z_\.]+]]: index, %[[VAL_35:[0-9a-zA-Z_\.]+]]: i1) -> !felt.type {
+// CHECK-NEXT:      %[[VAL_36:[0-9a-zA-Z_\.]+]] = felt.const  1
+// CHECK-NEXT:      %[[VAL_37:[0-9a-zA-Z_\.]+]] = felt.const  2
+// CHECK-NEXT:      %[[VAL_38:[0-9a-zA-Z_\.]+]] = array.new %[[VAL_36]], %[[VAL_36]] : <2 x !felt.type>
+// CHECK-NEXT:      array.write %[[VAL_38]]{{\[}}%[[VAL_34]]] = %[[VAL_36]] : <2 x !felt.type>, !felt.type
+// CHECK-NEXT:      %[[VAL_39:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_35]] -> (!felt.type) {
+// CHECK-NEXT:        %[[VAL_40:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        array.write %[[VAL_38]]{{\[}}%[[VAL_40]]] = %[[VAL_37]] : <2 x !felt.type>, !felt.type
+// CHECK-NEXT:        %[[VAL_41:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_38]]{{\[}}%[[VAL_34]]] : <2 x !felt.type>, !felt.type
+// CHECK-NEXT:        scf.yield %[[VAL_41]] : !felt.type
+// CHECK-NEXT:      } else {
+// CHECK-NEXT:        scf.yield %[[VAL_36]] : !felt.type
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.return %[[VAL_39]] : !felt.type
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }


### PR DESCRIPTION
## Summary

Fixes #666.

Prevent stale array-read reuse when a constant-index write may alias an earlier dynamic-index write, while keeping constant-only invalidation independent of tracked array width.

## Changes

For both `array.write` and `array.insert`, a dynamic-index write invalidates all sibling facts, while a constant-index write invalidates only dynamic-index siblings. The rule is applied independently for every supplied index, so facts for distinct known constant indices remain reusable. `ReferenceNode` tracks exact direct dynamic-child presence so constant-only invalidation returns without scanning retained constant children; the bookkeeping is preserved through child creation, subtree replacement, cloning, CFG intersection, and full invalidation.

## Testing

- `test/Transforms/RedundantAndUnusedElim/array_dynamic_constant_alias.llzk` covers dynamic-to-constant and constant-to-dynamic `array.write` aliasing, distinct constant-index reuse, a copied dynamic subarray, a later-depth multi-index `array.insert` alias, and a branch-local constant write followed by a dynamic-index read that stays live through branch-state cloning. The complete transformed module is checked with 73 committed checks.
- The branch is one feature commit on main at `73933dad61360960e45ec3def678de5bc04d7e0e`; current head is `5eec39ad41c4baf781533af28dc43ec8a66a1135`.
- Current-head CI passed: [GCC/Clang tests](https://github.com/project-llzk/llzk-lib/actions/runs/31030354283), [debug/release Nix checks](https://github.com/project-llzk/llzk-lib/actions/runs/31030350035), [clang-format](https://github.com/project-llzk/llzk-lib/actions/runs/31030352114), [docs](https://github.com/project-llzk/llzk-lib/actions/runs/31030350027), and [changelog](https://github.com/project-llzk/llzk-lib/actions/runs/31030351589) all passed.
- Exact-head replay in [fork CI](https://github.com/1sgtpepper/llzk-lib/actions/runs/31030402426) passed: the committed and freshly generated complete checks both pass against this head, with 73/73 check lines.

## Submission checklist

- [x] If I am an external contributor, the linked issue is approved; otherwise, this does not apply.
- [x] I added or updated tests for all relevant behavior, or explained above why tests are not needed.
- [x] I updated the relevant TableGen or other documentation, or explained above why documentation was not needed.
- [x] I added a changelog entry describing user-visible changes. (`create-changelog` in the Nix development shell creates a template.)
- [x] I enabled **Allow edits from maintainers** if this PR comes from a fork.

## Assistance disclosure

- [x] Automated development assistance contributed to this PR.

**How it contributed:** Implementation and review help.

**How I verified the contribution:** Final changes reviewed.
