### PR TITLE
Fix FileCheck generation for inline attributes

### DIFF
--- a/changelogs/unreleased/fix__generate-test-checks-inline-attributes.yaml
+++ b/changelogs/unreleased/fix__generate-test-checks-inline-attributes.yaml
@@ -1,0 +1,2 @@
+fixed:
+  - Preserve inline dialect attributes in generated FileCheck patterns.

--- a/changelogs/unreleased/fix__generate-test-checks-inline-attributes.yaml
+++ b/changelogs/unreleased/fix__generate-test-checks-inline-attributes.yaml
@@ -1,2 +1,2 @@
 fixed:
-  - Preserve inline dialect attributes in generated FileCheck patterns.
+  - Keep inline and bodyless dialect attributes literal in generated FileCheck patterns instead of emitting invalid variables.

--- a/scripts/generate-test-checks.py
+++ b/scripts/generate-test-checks.py
@@ -50,8 +50,9 @@ SSA_RE = re.compile(SSA_RE_STR)
 SSA_RESULTS_STR = r'\s*(%' + SSA_RE_STR + r')(:[0-9]+)*(\s*,\s*(%' + SSA_RE_STR + r'))*\s*='
 SSA_RESULTS_RE = re.compile(SSA_RESULTS_STR)
 
-# Regex matching attributes
-ATTR_RE_STR = r'(#[a-zA-Z._-][a-zA-Z0-9._-]*)'
+# Regex matching standalone attribute references, not inline attributes such as
+# `#foo<...>`.
+ATTR_RE_STR = r'(#[a-zA-Z._-][a-zA-Z0-9._-]*)(?![a-zA-Z0-9._-]|<)'
 ATTR_RE = re.compile(ATTR_RE_STR)
 
 # Regex matching the left-hand side of an attribute definition

--- a/scripts/generate-test-checks.py
+++ b/scripts/generate-test-checks.py
@@ -50,8 +50,8 @@ SSA_RE = re.compile(SSA_RE_STR)
 SSA_RESULTS_STR = r'\s*(%' + SSA_RE_STR + r')(:[0-9]+)*(\s*,\s*(%' + SSA_RE_STR + r'))*\s*='
 SSA_RESULTS_RE = re.compile(SSA_RESULTS_STR)
 
-# Regex matching attribute-like tokens without consuming inline attribute bodies.
-# Only references registered by an attribute definition are substituted.
+# Regex matching complete attribute-like tokens without consuming inline bodies.
+# Only exact tokens registered by an attribute definition are substituted.
 ATTR_RE_STR = (
     r'(#[a-zA-Z._-][a-zA-Z0-9._-]*)'
     r'(?![a-zA-Z0-9._$-]|<)'
@@ -225,6 +225,7 @@ def process_attribute_references(line, attribute_namer):
     for component in components:
         m = ATTR_RE.match(component)
         if m:
+            # Preserve inline and unknown tokens; substitute only registered aliases.
             attribute_name = attribute_namer.get_name(m.group(1))
             if attribute_name is None:
                 output_line += m.group(1)

--- a/scripts/generate-test-checks.py
+++ b/scripts/generate-test-checks.py
@@ -50,9 +50,12 @@ SSA_RE = re.compile(SSA_RE_STR)
 SSA_RESULTS_STR = r'\s*(%' + SSA_RE_STR + r')(:[0-9]+)*(\s*,\s*(%' + SSA_RE_STR + r'))*\s*='
 SSA_RESULTS_RE = re.compile(SSA_RESULTS_STR)
 
-# Regex matching attribute references. Only references registered by an
-# attribute definition are substituted; dialect attributes remain literal.
-ATTR_RE_STR = r'(#[a-zA-Z._-][a-zA-Z0-9._-]*)'
+# Regex matching attribute-like references, excluding inline dialect attributes.
+# Only references registered by an attribute definition are substituted.
+ATTR_RE_STR = (
+    r'(#[a-zA-Z._-][a-zA-Z0-9._-]*)'
+    r'(?![a-zA-Z0-9._-]|<)'
+)
 ATTR_RE = re.compile(ATTR_RE_STR)
 
 # Regex matching the left-hand side of an attribute definition

--- a/scripts/generate-test-checks.py
+++ b/scripts/generate-test-checks.py
@@ -50,11 +50,11 @@ SSA_RE = re.compile(SSA_RE_STR)
 SSA_RESULTS_STR = r'\s*(%' + SSA_RE_STR + r')(:[0-9]+)*(\s*,\s*(%' + SSA_RE_STR + r'))*\s*='
 SSA_RESULTS_RE = re.compile(SSA_RESULTS_STR)
 
-# Regex matching attribute-like references, excluding inline dialect attributes.
+# Regex matching attribute-like tokens without consuming inline attribute bodies.
 # Only references registered by an attribute definition are substituted.
 ATTR_RE_STR = (
     r'(#[a-zA-Z._-][a-zA-Z0-9._-]*)'
-    r'(?![a-zA-Z0-9._-]|<)'
+    r'(?![a-zA-Z0-9._$-]|<)'
 )
 ATTR_RE = re.compile(ATTR_RE_STR)
 

--- a/scripts/generate-test-checks.py
+++ b/scripts/generate-test-checks.py
@@ -50,9 +50,9 @@ SSA_RE = re.compile(SSA_RE_STR)
 SSA_RESULTS_STR = r'\s*(%' + SSA_RE_STR + r')(:[0-9]+)*(\s*,\s*(%' + SSA_RE_STR + r'))*\s*='
 SSA_RESULTS_RE = re.compile(SSA_RESULTS_STR)
 
-# Regex matching standalone attribute references, not inline attributes such as
-# `#foo<...>`.
-ATTR_RE_STR = r'(#[a-zA-Z._-][a-zA-Z0-9._-]*)(?![a-zA-Z0-9._-]|<)'
+# Regex matching attribute references. Only references registered by an
+# attribute definition are substituted; dialect attributes remain literal.
+ATTR_RE_STR = r'(#[a-zA-Z._-][a-zA-Z0-9._-]*)'
 ATTR_RE = re.compile(ATTR_RE_STR)
 
 # Regex matching the left-hand side of an attribute definition
@@ -146,11 +146,9 @@ class AttributeNamer:
         self.used_attribute_names.add(attribute_name)
         return attribute_name
 
-    # Get the saved substitution name for the given attribute name. If no name
-    # has been generated for the given attribute yet, the source attribute name
-    # itself is returned.
+    # Get the saved substitution name for the given attribute name, if any.
     def get_name(self, source_attribute_name):
-        return self.map[source_attribute_name] if source_attribute_name in self.map else '?'
+        return self.map.get(source_attribute_name)
 
 # Return the number of SSA results in a line of type
 #   %0, %1, ... = ...
@@ -224,7 +222,11 @@ def process_attribute_references(line, attribute_namer):
     for component in components:
         m = ATTR_RE.match(component)
         if m:
-            output_line += '#[[' + attribute_namer.get_name(m.group(1)) + ']]'
+            attribute_name = attribute_namer.get_name(m.group(1))
+            if attribute_name is None:
+                output_line += m.group(1)
+            else:
+                output_line += '#[[' + attribute_name + ']]'
             output_line += component[len(m.group()):]
         else:
             output_line += component

--- a/test/Transforms/generate-test-checks-inline-attributes.llzk
+++ b/test/Transforms/generate-test-checks-inline-attributes.llzk
@@ -1,8 +1,9 @@
 // RUN: split-file %s %t
 // RUN: python3 %S/../../scripts/generate-test-checks.py %t/inline-attributes.llzk | FileCheck %s --check-prefix=SCRIPT
 
-// The registered #felt alias is replaced only as an exact token. Longer
-// dialect attributes and unregistered bodyless attributes remain literal.
+// The registered #felt alias is replaced only when the complete token is #felt.
+// Tokens continuing with '.', '$', or an inline body, plus unregistered
+// bodyless attributes, remain literal.
 // SCRIPT: // CHECK:
 // SCRIPT-SAME: ATTR_0:
 // SCRIPT: // CHECK-LABEL: module attributes {llzk.named =

--- a/test/Transforms/generate-test-checks-inline-attributes.llzk
+++ b/test/Transforms/generate-test-checks-inline-attributes.llzk
@@ -1,0 +1,13 @@
+// RUN: split-file %s %t
+// RUN: python3 %S/../../scripts/generate-test-checks.py %t/inline-attributes.llzk | FileCheck %s --check-prefix=SCRIPT
+
+// SCRIPT: // CHECK:
+// SCRIPT-SAME: ATTR_0:
+// SCRIPT: // CHECK-LABEL: module attributes {llzk.named =
+// SCRIPT-SAME: ATTR_0]], llzk.fields = [#felt.field<"x", 101>], llzk.main = !struct.type<@Main<[#felt<const 7 : !felt.type<"x">>]>], llzk.lang} {
+// SCRIPT-NEXT: // CHECK-NEXT:  }
+
+//--- inline-attributes.llzk
+#named = affine_map<(d0) -> (d0)>
+module attributes {llzk.named = #named, llzk.fields = [#felt.field<"x", 101>], llzk.main = !struct.type<@Main<[#felt<const 7 : !felt.type<"x">>]>], llzk.lang} {
+}

--- a/test/Transforms/generate-test-checks-inline-attributes.llzk
+++ b/test/Transforms/generate-test-checks-inline-attributes.llzk
@@ -1,6 +1,12 @@
 // RUN: split-file %s %t
 // RUN: python3 %S/../../scripts/generate-test-checks.py %t/inline-attributes.llzk | FileCheck %s --check-prefix=SCRIPT
 
+//--- inline-attributes.llzk
+#felt = affine_map<(d0) -> (d0)>
+module attributes {llzk.named = #felt, llzk.fields = [#felt.field<"x", 101>], llzk.main = !struct.type<@Main<[#felt<const 7 : !felt.type<"x">>]>], llzk.dollar_opaque = #felt$ext<const 7>, llzk.dollar_marker = #felt$ext.marker, llzk.marker = #foo.marker, llzk.lang} {
+}
+
+//--- checks
 // The registered #felt alias is replaced only when the complete token is #felt.
 // Tokens continuing with '.', '$', or an inline body, plus unregistered
 // bodyless attributes, remain literal.
@@ -9,8 +15,3 @@
 // SCRIPT: // CHECK-LABEL: module attributes {llzk.named =
 // SCRIPT-SAME: ATTR_0]], llzk.fields = [#felt{{\.}}field<"x", 101>], llzk.main = !struct.type<@Main<[#felt<const 7 : !felt.type<"x">>]>], llzk.dollar_opaque = #felt{{\$}}ext<const 7>, llzk.dollar_marker = #felt{{\$}}ext.marker, llzk.marker = #foo{{\.}}marker, llzk.lang} {
 // SCRIPT-NEXT: // CHECK-NEXT:  }
-
-//--- inline-attributes.llzk
-#felt = affine_map<(d0) -> (d0)>
-module attributes {llzk.named = #felt, llzk.fields = [#felt.field<"x", 101>], llzk.main = !struct.type<@Main<[#felt<const 7 : !felt.type<"x">>]>], llzk.dollar_opaque = #felt$ext<const 7>, llzk.dollar_marker = #felt$ext.marker, llzk.marker = #foo.marker, llzk.lang} {
-}

--- a/test/Transforms/generate-test-checks-inline-attributes.llzk
+++ b/test/Transforms/generate-test-checks-inline-attributes.llzk
@@ -4,10 +4,10 @@
 // SCRIPT: // CHECK:
 // SCRIPT-SAME: ATTR_0:
 // SCRIPT: // CHECK-LABEL: module attributes {llzk.named =
-// SCRIPT-SAME: ATTR_0]], llzk.fields = [#felt.field<"x", 101>], llzk.main = !struct.type<@Main<[#felt<const 7 : !felt.type<"x">>]>], llzk.lang} {
+// SCRIPT-SAME: ATTR_0]], llzk.fields = [#felt{{\.}}field<"x", 101>], llzk.main = !struct.type<@Main<[#felt<const 7 : !felt.type<"x">>]>], llzk.marker = #foo{{\.}}marker, llzk.lang} {
 // SCRIPT-NEXT: // CHECK-NEXT:  }
 
 //--- inline-attributes.llzk
 #named = affine_map<(d0) -> (d0)>
-module attributes {llzk.named = #named, llzk.fields = [#felt.field<"x", 101>], llzk.main = !struct.type<@Main<[#felt<const 7 : !felt.type<"x">>]>], llzk.lang} {
+module attributes {llzk.named = #named, llzk.fields = [#felt.field<"x", 101>], llzk.main = !struct.type<@Main<[#felt<const 7 : !felt.type<"x">>]>], llzk.marker = #foo.marker, llzk.lang} {
 }

--- a/test/Transforms/generate-test-checks-inline-attributes.llzk
+++ b/test/Transforms/generate-test-checks-inline-attributes.llzk
@@ -8,6 +8,6 @@
 // SCRIPT-NEXT: // CHECK-NEXT:  }
 
 //--- inline-attributes.llzk
-#named = affine_map<(d0) -> (d0)>
-module attributes {llzk.named = #named, llzk.fields = [#felt.field<"x", 101>], llzk.main = !struct.type<@Main<[#felt<const 7 : !felt.type<"x">>]>], llzk.marker = #foo.marker, llzk.lang} {
+#felt = affine_map<(d0) -> (d0)>
+module attributes {llzk.named = #felt, llzk.fields = [#felt.field<"x", 101>], llzk.main = !struct.type<@Main<[#felt<const 7 : !felt.type<"x">>]>], llzk.marker = #foo.marker, llzk.lang} {
 }

--- a/test/Transforms/generate-test-checks-inline-attributes.llzk
+++ b/test/Transforms/generate-test-checks-inline-attributes.llzk
@@ -1,6 +1,8 @@
 // RUN: split-file %s %t
 // RUN: python3 %S/../../scripts/generate-test-checks.py %t/inline-attributes.llzk | FileCheck %s --check-prefix=SCRIPT
 
+// The registered #felt alias is replaced only as an exact token. Longer
+// dialect attributes and unregistered bodyless attributes remain literal.
 // SCRIPT: // CHECK:
 // SCRIPT-SAME: ATTR_0:
 // SCRIPT: // CHECK-LABEL: module attributes {llzk.named =

--- a/test/Transforms/generate-test-checks-inline-attributes.llzk
+++ b/test/Transforms/generate-test-checks-inline-attributes.llzk
@@ -4,10 +4,10 @@
 // SCRIPT: // CHECK:
 // SCRIPT-SAME: ATTR_0:
 // SCRIPT: // CHECK-LABEL: module attributes {llzk.named =
-// SCRIPT-SAME: ATTR_0]], llzk.fields = [#felt{{\.}}field<"x", 101>], llzk.main = !struct.type<@Main<[#felt<const 7 : !felt.type<"x">>]>], llzk.marker = #foo{{\.}}marker, llzk.lang} {
+// SCRIPT-SAME: ATTR_0]], llzk.fields = [#felt{{\.}}field<"x", 101>], llzk.main = !struct.type<@Main<[#felt<const 7 : !felt.type<"x">>]>], llzk.dollar_opaque = #felt{{\$}}ext<const 7>, llzk.dollar_marker = #felt{{\$}}ext.marker, llzk.marker = #foo{{\.}}marker, llzk.lang} {
 // SCRIPT-NEXT: // CHECK-NEXT:  }
 
 //--- inline-attributes.llzk
 #felt = affine_map<(d0) -> (d0)>
-module attributes {llzk.named = #felt, llzk.fields = [#felt.field<"x", 101>], llzk.main = !struct.type<@Main<[#felt<const 7 : !felt.type<"x">>]>], llzk.marker = #foo.marker, llzk.lang} {
+module attributes {llzk.named = #felt, llzk.fields = [#felt.field<"x", 101>], llzk.main = !struct.type<@Main<[#felt<const 7 : !felt.type<"x">>]>], llzk.dollar_opaque = #felt$ext<const 7>, llzk.dollar_marker = #felt$ext.marker, llzk.marker = #foo.marker, llzk.lang} {
 }


### PR DESCRIPTION
## Summary

Fixes #662

Keep inline and bodyless dialect attributes intact when generating FileCheck patterns.

## Related issues

Fixes #662

## Changes

Substitute only complete attribute tokens registered by a standalone attribute definition. Preserve inline, opaque, parameterized, bodyless, dotted, and `$`-containing dialect attributes as literal text; support for `$` in alias definitions remains outside this fix.

## Testing

- `python3 -m py_compile scripts/generate-test-checks.py`
- `test/Transforms/generate-test-checks-inline-attributes.llzk` covers a registered alias, dotted and parameterized inline attributes, bodyless attributes, and `$`-containing dialect namespaces through the actual generator script. Its invocation-level `SCRIPT` checks are in a final split after the generator input.
- Synced with `main` at `df44e8272df4b1381bc8d57ad0989fd4c3b48ce1`.
- PR CI for head `efb42f37f1ea04315815d07315e07aa597625816` passed: [GCC/Clang tests](https://github.com/project-llzk/llzk-lib/actions/runs/31008572270), [debug/release Nix checks](https://github.com/project-llzk/llzk-lib/actions/runs/31008572376), [docs](https://github.com/project-llzk/llzk-lib/actions/runs/31008572427), [changelog](https://github.com/project-llzk/llzk-lib/actions/runs/31008572701), and test-result publication all passed.
- Exact-head replay in [fork CI](https://github.com/1sgtpepper/llzk-lib/actions/runs/31008634921) passed: fresh generator output passes the focused `SCRIPT` contract for the inline-attribute fixture at head `efb42f37f1ea04315815d07315e07aa597625816`.
- The generator's existing usage documentation remains accurate; this fix only corrects token classification for generated checks, and the exact-token invariant is documented beside the regex.

## Submission checklist

- [x] If I am an external contributor, this PR has a linked issue marked `approved`; otherwise, this does not apply.
- [x] I added or updated tests for all relevant behavior, or explained above why tests are not needed.
- [x] I updated the relevant TableGen or other documentation, or explained above why documentation was not needed.
- [x] I added a changelog entry describing user-visible changes. (`create-changelog` in the Nix development shell creates a template.)
- [x] I enabled **Allow edits from maintainers** if this PR comes from a fork.

## AI assistance

- [ ] No AI tools contributed to this PR.
- [x] AI tools contributed to this PR.

**Tools used:** Codex

**How the tools contributed:** Implementation and review help.

**How I verified the contribution:** Final changes reviewed.
