### PR TITLE
Assorted PCL backend bugfixes

### DIFF
--- a/backends/pcl/lib/Conversion/PCLLoweringPass.cpp
+++ b/backends/pcl/lib/Conversion/PCLLoweringPass.cpp
@@ -46,6 +46,7 @@
 
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
+#include <mlir/Dialect/SCF/IR/SCF.h>
 #include <mlir/IR/Attributes.h>
 #include <mlir/IR/Builders.h>
 #include <mlir/IR/BuiltinAttributes.h>
@@ -64,6 +65,7 @@
 #include <llvm/ADT/APInt.h>
 #include <llvm/ADT/DenseMap.h>
 #include <llvm/ADT/DenseMapInfo.h>
+#include <llvm/ADT/DenseSet.h>
 #include <llvm/ADT/EquivalenceClasses.h>
 #include <llvm/ADT/SmallVector.h>
 #include <llvm/ADT/SmallVectorExtras.h>
@@ -94,7 +96,7 @@ using namespace llzk::component;
 namespace {
 
 /// Returns a flat representation of the fully qualified name of the struct.
-static std::string flatStructName(StructDefOp op) {
+template <typename Op> static std::string flatStructName(Op op) {
   auto fqn = op.getFullyQualifiedName();
   std::string name;
   llvm::raw_string_ostream o(name);
@@ -394,7 +396,7 @@ template <typename T, typename Fn> SmallVector<T> mapOutputMembers(StructDefOp o
   return out;
 }
 
-/// Converts `function.return` ops into pcl return ops.
+/// Converts `function.return` ops inside `@constrain` functions into func return ops.
 struct ConvertReturnOp : public OpConversionPattern<ReturnOp> {
   using OpConversionPattern<ReturnOp>::OpConversionPattern;
 
@@ -402,13 +404,29 @@ struct ConvertReturnOp : public OpConversionPattern<ReturnOp> {
   matchAndRewrite(ReturnOp op, OpAdaptor, ConversionPatternRewriter &rewriter) const override {
     auto structDefOp = op->getParentOfType<StructDefOp>();
     if (!structDefOp) {
-      return op->emitOpError() << "must have a struct op parent";
+      return failure();
     }
     auto values = mapOutputMembers<Value>(structDefOp, [&rewriter](MemberDefOp memberDef) {
       return rewriter.create<pcl::VarOp>(memberDef.getLoc(), memberDef.getName(), /*public=*/true);
     });
 
     rewriter.replaceOpWithNewOp<func::ReturnOp>(op, values);
+    return success();
+  }
+};
+
+/// Converts `function.return` ops inside free functions into func return ops.
+struct ConvertFreeFuncReturnOp : public OpConversionPattern<ReturnOp> {
+  using OpConversionPattern<ReturnOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(ReturnOp op, OpAdaptor adaptor, ConversionPatternRewriter &rewriter) const override {
+    auto structDefOp = op->getParentOfType<StructDefOp>();
+    if (structDefOp) {
+      return failure();
+    }
+
+    rewriter.replaceOpWithNewOp<func::ReturnOp>(op, adaptor.getOperands());
     return success();
   }
 };
@@ -435,8 +453,70 @@ public:
   }
 };
 
+/// Base class for patterns that copy the body of a function.
+template <typename Op, typename Impl> struct BodyCopier {
+private:
+  BodyCopier() = default;
+
+public:
+  LogicalResult copyBody(Op op, ConversionPatternRewriter &rewriter) const {
+    FailureOr<FuncDefOp> srcFuncOp = static_cast<const Impl *>(this)->getFuncOp(op);
+    if (failed(srcFuncOp)) {
+      return failure();
+    }
+
+    unsigned baseOffset = static_cast<const Impl *>(this)->baseOffset();
+
+    SmallVector<Type> inputs(
+        srcFuncOp->getNumArguments() - baseOffset, pcl::FeltType::get(rewriter.getContext())
+    );
+    SmallVector<Type> outputs = static_cast<const Impl *>(this)->outputTypes(op);
+
+    auto funcOp = func::FuncOp::create(
+        op.getLoc(), flatStructName(op), rewriter.getFunctionType(inputs, outputs)
+    );
+    funcOp.addEntryBlock();
+    IRMapping mapping;
+    for (auto arg : srcFuncOp->getArguments().take_front(baseOffset)) {
+      mapping.map(arg, Value());
+    }
+    for (auto [srcArg, dstArg] :
+         llvm::zip_equal(srcFuncOp->getArguments().drop_front(baseOffset), funcOp.getArguments())) {
+      auto argType = srcArg.getType();
+      if (!llvm::isa<FeltType>(argType)) {
+        return srcFuncOp->emitError() << "function's args are expected to be felts. Found "
+                                      << argType << "for arg #: " << srcArg.getArgNumber();
+      }
+      mapping.map(srcArg, dstArg);
+    }
+
+    if (!srcFuncOp->getBody().hasOneBlock()) {
+      return srcFuncOp->emitError(
+          "llzk-to-pcl conversion assumes the constrain function body has 1 block"
+      );
+    }
+    rewriter.cloneRegionBefore(
+        srcFuncOp->getRegion(), funcOp.getRegion(), funcOp.getRegion().end(), mapping
+    );
+    rewriter.mergeBlocks(&funcOp.getRegion().back(), &funcOp.getRegion().front());
+
+    rewriter.eraseOp(op);
+    {
+      OpBuilder::InsertionGuard guard(rewriter);
+      rewriter.setInsertionPointToEnd(
+          &static_cast<const Impl *>(this)->getRoot()->getRegion(0).front()
+      );
+      rewriter.insert(funcOp);
+    }
+
+    return success();
+  }
+  friend Impl;
+};
+
 /// Converts `struct.def` ops into pcl modules (represented with `func.def` ops).
-class ConvertStructDefOp : public OpConversionPattern<StructDefOp> {
+class ConvertStructDefOp : public OpConversionPattern<StructDefOp>,
+                           public BodyCopier<StructDefOp, ConvertStructDefOp> {
   ModuleOp root;
 
 public:
@@ -447,56 +527,67 @@ public:
   )
       : OpConversionPattern(tc, context, patBenefit), root(rootMod) {}
 
-  LogicalResult
-  matchAndRewrite(StructDefOp op, OpAdaptor, ConversionPatternRewriter &rewriter) const override {
+  FailureOr<FuncDefOp> getFuncOp(StructDefOp op) const {
     auto constrainFuncOp = op.getConstrainFuncOp();
     if (!constrainFuncOp) {
       return op.emitOpError() << "must have a @" << FUNC_NAME_CONSTRAIN
                               << " function for converting to pcl";
     }
+    return constrainFuncOp;
+  }
 
-    SmallVector<Type> inputs(
-        constrainFuncOp.getNumArguments() - 1, pcl::FeltType::get(rewriter.getContext())
-    );
+  unsigned int baseOffset() const { return 1; }
 
-    auto outputs = mapOutputMembers<Type>(op, [ctx = rewriter.getContext()](MemberDefOp) {
+  llvm::SmallVector<Type> outputTypes(StructDefOp op) const {
+    return mapOutputMembers<Type>(op, [ctx = op.getContext()](MemberDefOp) {
       return pcl::FeltType::get(ctx);
     });
+  }
 
-    auto funcOp = func::FuncOp::create(
-        op.getLoc(), flatStructName(op), rewriter.getFunctionType(inputs, outputs)
+  ModuleOp getRoot() const { return root; }
+
+  LogicalResult
+  matchAndRewrite(StructDefOp op, OpAdaptor, ConversionPatternRewriter &rewriter) const override {
+    return copyBody(op, rewriter);
+  }
+};
+
+class ConvertFreeFunction : public OpConversionPattern<FuncDefOp>,
+                            public BodyCopier<FuncDefOp, ConvertFreeFunction> {
+  llvm::DenseSet<FuncDefOp> &funcs;
+  ModuleOp root;
+
+public:
+  ConvertFreeFunction(
+      MLIRContext *context, llvm::DenseSet<FuncDefOp> &usedFreeFunctions, ModuleOp rootOp,
+      PatternBenefit patBenefit = 1
+  )
+      : OpConversionPattern(context, patBenefit), funcs(usedFreeFunctions), root(rootOp) {}
+  ConvertFreeFunction(
+      const TypeConverter &tc, MLIRContext *context, llvm::DenseSet<FuncDefOp> &usedFreeFunctions,
+      ModuleOp rootOp, PatternBenefit patBenefit = 1
+  )
+      : OpConversionPattern(tc, context, patBenefit), funcs(usedFreeFunctions), root(rootOp) {}
+
+  FailureOr<FuncDefOp> getFuncOp(FuncDefOp op) const { return op; }
+
+  unsigned int baseOffset() const { return 0; }
+
+  llvm::SmallVector<Type> outputTypes(FuncDefOp op) const {
+    return llvm::SmallVector<Type>(
+        op.getFunctionType().getNumResults(), pcl::FeltType::get(op.getContext())
     );
-    funcOp.addEntryBlock();
-    IRMapping mapping;
-    mapping.map(constrainFuncOp.getArgument(0), Value());
-    for (auto [srcArg, dstArg] :
-         llvm::zip_equal(constrainFuncOp.getArguments().drop_front(), funcOp.getArguments())) {
-      auto argType = srcArg.getType();
-      if (!llvm::isa<FeltType>(argType)) {
-        return constrainFuncOp.emitError()
-               << "Constrain function's args are expected to be felts. Found " << argType
-               << "for arg #: " << srcArg.getArgNumber();
-      }
-      mapping.map(srcArg, dstArg);
-    }
+  }
 
-    if (!constrainFuncOp.getBody().hasOneBlock()) {
-      return constrainFuncOp.emitError(
-          "llzk-to-pcl conversion assumes the constrain function body has 1 block"
-      );
-    }
-    rewriter.cloneRegionBefore(
-        constrainFuncOp.getRegion(), funcOp.getRegion(), funcOp.getRegion().end(), mapping
-    );
-    rewriter.mergeBlocks(&funcOp.getRegion().back(), &funcOp.getRegion().front());
+  ModuleOp getRoot() const { return root; }
 
-    rewriter.eraseOp(op);
-    {
-      OpBuilder::InsertionGuard guard(rewriter);
-      rewriter.setInsertionPointToEnd(&root->getRegion(0).front());
-      rewriter.insert(funcOp);
+  LogicalResult
+  matchAndRewrite(FuncDefOp op, OpAdaptor, ConversionPatternRewriter &rewriter) const override {
+    // Don't convert functions outside the set.
+    if (!funcs.contains(op)) {
+      return failure();
     }
-    return success();
+    return copyBody(op, rewriter);
   }
 };
 
@@ -545,12 +636,8 @@ struct ConvertConstrainCall : public OpConversionPattern<CallOp> {
   ) const override {
     SymbolTableCollection tables;
     auto callee = op.getCalleeTarget(tables);
-    if (failed(callee)) {
-      return failure();
-    }
-
-    if (!callee->get().isStructConstrain()) {
-      // We only care about constrain functions.
+    // We only care about constrain functions.
+    if (failed(callee) || !callee->get().isStructConstrain()) {
       return failure();
     }
 
@@ -590,6 +677,56 @@ struct ConvertConstrainCall : public OpConversionPattern<CallOp> {
   }
 };
 
+/// Converts calls to free functions. Only `function.call` ops inside functions that need to be
+/// converted are marked illegal, so the pattern only needs to check if the callee is not a contrain
+/// call.
+struct ConvertFreeFunctionCall : public OpConversionPattern<CallOp> {
+  using OpConversionPattern<CallOp>::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      CallOp op, OpAdaptor adaptor, ConversionPatternRewriter &rewriter
+  ) const override {
+    SymbolTableCollection tables;
+    auto callee = op.getCalleeTarget(tables);
+    if (failed(callee) || callee->get().isStructConstrain()) {
+      return failure();
+    }
+
+    SmallVector<Type> resultTypes(op.getNumResults(), pcl::FeltType::get(getContext()));
+    auto calleeName = flatStructName(callee->get());
+    rewriter.replaceOpWithNewOp<func::CallOp>(
+        op, calleeName, TypeRange(resultTypes), adaptor.getArgOperands()
+    );
+    return success();
+  }
+};
+
+class RemoveFreeFunction : public OpConversionPattern<FuncDefOp> {
+  llvm::DenseSet<FuncDefOp> &funcs;
+
+public:
+  RemoveFreeFunction(
+      MLIRContext *context, llvm::DenseSet<FuncDefOp> &usedFreeFunctions,
+      PatternBenefit patBenefit = 1
+  )
+      : OpConversionPattern(context, patBenefit), funcs(usedFreeFunctions) {}
+  RemoveFreeFunction(
+      const TypeConverter &tc, MLIRContext *context, llvm::DenseSet<FuncDefOp> &usedFreeFunctions,
+      PatternBenefit patBenefit = 1
+  )
+      : OpConversionPattern(tc, context, patBenefit), funcs(usedFreeFunctions) {}
+  LogicalResult
+  matchAndRewrite(FuncDefOp op, OpAdaptor, ConversionPatternRewriter &rewriter) const override {
+    // Remove any op that is NOT in the set.
+    if (funcs.contains(op)) {
+      return failure();
+    }
+
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
 /// Populates the set with the patterns used in step 1 of the conversion.
 static void populateStep1ConversionPatterns(
     const TypeConverter &tc, RewritePatternSet &patterns, MLIRContext *ctx, NonDetOpNames &names
@@ -615,7 +752,9 @@ static void populateStep1ConversionPatterns(
       ConvertSelfMemberReadOpOfSubcmp,
       ConvertSubcmpMemberReadOp,
       ConvertReturnOp,
-      ConvertConstrainCall
+      ConvertFreeFuncReturnOp,
+      ConvertConstrainCall,
+      ConvertFreeFunctionCall
       // clang-format on
       >(tc, ctx);
   patterns.add<ConvertNonDetOp>(tc, ctx, names);
@@ -623,9 +762,12 @@ static void populateStep1ConversionPatterns(
 
 /// Populates the set with the patterns used in step 2 of the conversion.
 static void populateStep2ConversionPatterns(
-    const TypeConverter &tc, RewritePatternSet &patterns, MLIRContext *ctx, ModuleOp root
+    const TypeConverter &tc, RewritePatternSet &patterns, MLIRContext *ctx, ModuleOp root,
+    llvm::DenseSet<FuncDefOp> &usedFreeFunctions
 ) {
   patterns.add<ConvertStructDefOp>(tc, ctx, root);
+  patterns.add<RemoveFreeFunction>(tc, ctx, usedFreeFunctions);
+  patterns.add<ConvertFreeFunction>(tc, ctx, usedFreeFunctions, root);
 }
 
 /// Populates the set with the patterns used in step 3 of the conversion.
@@ -640,11 +782,18 @@ static void populateStep3ConversionPatterns(
 ///
 /// An operation is legal in Step 1 if its located outside the
 /// `constrain` function of a struct.
-static bool isStep1LegalOp(Operation *op) {
+static bool isStep1LegalOp(Operation *op, llvm::DenseSet<FuncDefOp> &usedFreeFunctions) {
   auto structDefOp = op->getParentOfType<StructDefOp>();
   if (!structDefOp) {
-    // Legal because is not within a struct definition.
-    return true;
+    auto funcDefOp = op->getParentOfType<FuncDefOp>();
+    if (!funcDefOp) {
+      // Legal because is not within a struct nor a free function definition.
+      return true;
+    }
+
+    // If the op is inside a free function, check if the function is in the set.
+    // If the function is in the set, then the op is illegal.
+    return !usedFreeFunctions.contains(funcDefOp);
   }
   auto funcDefOp = op->getParentOfType<FuncDefOp>();
   if (!funcDefOp) {
@@ -656,17 +805,22 @@ static bool isStep1LegalOp(Operation *op) {
 }
 
 /// Populates the conversion target with the legallity expected of step 1 of the conversion.
-static void populateStep1ConversionTarget(ConversionTarget &target, NonDetOpNames &names) {
+static void populateStep1ConversionTarget(
+    ConversionTarget &target, NonDetOpNames &names, llvm::DenseSet<FuncDefOp> &usedFreeFunctions
+) {
   target.addLegalDialect<pcl::PCLDialect, func::FuncDialect>();
   target.addLegalOp<ModuleOp, UnrealizedConversionCastOp>();
   target.addDynamicallyLegalDialect<
       BoolDialect, FeltDialect, CastDialect, arith::ArithDialect, ConstrainDialect,
       array::ArrayDialect, global::GlobalDialect, include::IncludeDialect, pod::PODDialect,
       polymorphic::PolymorphicDialect, ram::RAMDialect, smt::SMTDialect, string::StringDialect,
-      verif::VerifDialect, LLZKDialect, StructDialect, FunctionDialect>(isStep1LegalOp);
+      verif::VerifDialect, LLZKDialect, StructDialect, FunctionDialect, scf::SCFDialect>(
+      [&usedFreeFunctions](Operation *op) { return isStep1LegalOp(op, usedFreeFunctions); }
+  );
+  target.addLegalOp<FuncDefOp>();
 
-  target.addDynamicallyLegalOp<NonDetOp>([&names](NonDetOp op) {
-    return isStep1LegalOp(op) && names.find(op) == names.end();
+  target.addDynamicallyLegalOp<NonDetOp>([&names, &usedFreeFunctions](NonDetOp op) {
+    return isStep1LegalOp(op, usedFreeFunctions) && names.find(op) == names.end();
   });
 }
 
@@ -674,10 +828,10 @@ static void populateStep1ConversionTarget(ConversionTarget &target, NonDetOpName
 static void populateStep2ConversionTarget(ConversionTarget &target) {
   target.addLegalDialect<pcl::PCLDialect>();
   target.addLegalOp<ModuleOp, func::FuncOp, func::CallOp, func::ReturnOp>();
-  target.addIllegalOp<StructDefOp>();
+  target.addIllegalOp<StructDefOp, FuncDefOp>();
 }
 
-/// Populates the conversion target with the legalluty expected of step 3 of the conversion.
+/// Populates the conversion target with the legallity expected of step 3 of the conversion.
 static void populateStep3ConversionTarget(
     ConversionTarget &target, DupVarsReplacements &replacements, ModuleOp root
 ) {
@@ -888,28 +1042,72 @@ class PassImpl : public pcl::impl::PCLLoweringPassBase<PassImpl> {
     return replacements;
   }
 
+  /// Collects the call-graph from the constrain functions (excluding the `@constrain` functions
+  /// themselves). Since we only care if a given `function.def` is part of the graph or not we
+  /// return the set of vertices.
+  llvm::DenseSet<FuncDefOp> collectConstrainCallGraph() {
+    llvm::SmallVector<FuncDefOp> WL;
+    llvm::DenseSet<FuncDefOp> funcs;
+    mlir::SymbolTableCollection tables;
+
+    // Fill the worklist with the initial set of functions.
+    getOperation()->walk([&WL, &funcs, &tables](StructDefOp structOp) {
+      auto f = structOp.getConstrainFuncOp();
+      if (!f) {
+        return;
+      }
+
+      f.walk([&WL, &funcs, &tables](CallOp callOp) {
+        auto callee = callOp.getCalleeTarget(tables);
+        // Ignore it if the lookup failed, is a @constrain function, or is already in the set.
+        if (failed(callee) || callee->get().isStructConstrain() || funcs.contains(callee->get())) {
+          return;
+        }
+        funcs.insert(callee->get());
+        WL.push_back(callee->get());
+      });
+    });
+
+    // Complete the graph using the worklist.
+    while (!WL.empty()) {
+      auto next = WL[WL.size() - 1];
+      WL.pop_back();
+
+      next.walk([&WL, &funcs, &tables](CallOp op) {
+        auto callee = op.getCalleeTarget(tables);
+        if (failed(callee) || funcs.contains(callee->get())) {
+          return;
+        }
+        funcs.insert(callee->get());
+        WL.push_back(callee->get());
+      });
+    }
+
+    return funcs;
+  }
+
   /// Step 1 converts the body of each struct to PCL operations.
   ///
   /// This conversion is performed before moving the body to a function because
   /// that way the IR can access information about the members of the struct.
-  LogicalResult runStep1() {
+  LogicalResult runStep1(llvm::DenseSet<FuncDefOp> &usedFreeFunctions) {
     auto nonDetNames = collectNonDetOpNames();
     ConversionTarget target(getContext());
     RewritePatternSet patterns(&getContext());
     PCLTypeConverter tc;
     populateStep1ConversionPatterns(tc, patterns, &getContext(), nonDetNames);
-    populateStep1ConversionTarget(target, nonDetNames);
+    populateStep1ConversionTarget(target, nonDetNames, usedFreeFunctions);
 
     return applyFullConversion(getOperation(), target, std::move(patterns));
   }
 
   /// Step 2 converts the struct to a function, moving the contents of the @constrain function
   /// into the body of the new function.
-  LogicalResult runStep2() {
+  LogicalResult runStep2(llvm::DenseSet<FuncDefOp> &usedFreeFunctions) {
     ConversionTarget target(getContext());
     RewritePatternSet patterns(&getContext());
     PCLTypeConverter tc;
-    populateStep2ConversionPatterns(tc, patterns, &getContext(), getOperation());
+    populateStep2ConversionPatterns(tc, patterns, &getContext(), getOperation(), usedFreeFunctions);
     populateStep2ConversionTarget(target);
 
     return applyFullConversion(getOperation(), target, std::move(patterns));
@@ -948,13 +1146,14 @@ class PassImpl : public pcl::impl::PCLLoweringPassBase<PassImpl> {
       signalPassFailure();
       return;
     }
+    auto usedFreeFunctions = collectConstrainCallGraph();
 
-    if (failed(runStep1())) {
+    if (failed(runStep1(usedFreeFunctions))) {
       signalPassFailure();
       return;
     }
 
-    if (failed(runStep2())) {
+    if (failed(runStep2(usedFreeFunctions))) {
       signalPassFailure();
       return;
     }

--- a/backends/pcl/lib/Conversion/PCLLoweringPass.cpp
+++ b/backends/pcl/lib/Conversion/PCLLoweringPass.cpp
@@ -96,7 +96,7 @@ using namespace llzk::component;
 namespace {
 
 /// Returns a flat representation of the fully qualified name of the struct.
-template <typename Op> static std::string flatStructName(Op op) {
+template <typename Op> static std::string flatFullyQualifiedName(Op op) {
   auto fqn = op.getFullyQualifiedName();
   std::string name;
   llvm::raw_string_ostream o(name);
@@ -419,10 +419,10 @@ struct ConvertReturnOp : public OpConversionPattern<ReturnOp> {
 struct ConvertFreeFuncReturnOp : public OpConversionPattern<ReturnOp> {
   using OpConversionPattern<ReturnOp>::OpConversionPattern;
 
-  LogicalResult
-  matchAndRewrite(ReturnOp op, OpAdaptor adaptor, ConversionPatternRewriter &rewriter) const override {
-    auto structDefOp = op->getParentOfType<StructDefOp>();
-    if (structDefOp) {
+  LogicalResult matchAndRewrite(
+      ReturnOp op, OpAdaptor adaptor, ConversionPatternRewriter &rewriter
+  ) const override {
+    if (op->getParentOfType<StructDefOp>()) {
       return failure();
     }
 
@@ -473,7 +473,7 @@ public:
     SmallVector<Type> outputs = static_cast<const Impl *>(this)->outputTypes(op);
 
     auto funcOp = func::FuncOp::create(
-        op.getLoc(), flatStructName(op), rewriter.getFunctionType(inputs, outputs)
+        op.getLoc(), flatFullyQualifiedName(op), rewriter.getFunctionType(inputs, outputs)
     );
     funcOp.addEntryBlock();
     IRMapping mapping;
@@ -660,7 +660,7 @@ struct ConvertConstrainCall : public OpConversionPattern<CallOp> {
       return memberDefOp.hasPublicAttr();
     });
     SmallVector<Type> resultTypes(publicMembers.size(), pcl::FeltType::get(getContext()));
-    auto calleeName = flatStructName(defOp->get());
+    auto calleeName = flatFullyQualifiedName(defOp->get());
     auto call = rewriter.create<func::CallOp>(
         op.getLoc(), calleeName, TypeRange(resultTypes), adaptor.getArgOperands().drop_front()
     );
@@ -693,7 +693,7 @@ struct ConvertFreeFunctionCall : public OpConversionPattern<CallOp> {
     }
 
     SmallVector<Type> resultTypes(op.getNumResults(), pcl::FeltType::get(getContext()));
-    auto calleeName = flatStructName(callee->get());
+    auto calleeName = flatFullyQualifiedName(callee->get());
     rewriter.replaceOpWithNewOp<func::CallOp>(
         op, calleeName, TypeRange(resultTypes), adaptor.getArgOperands()
     );
@@ -701,6 +701,7 @@ struct ConvertFreeFunctionCall : public OpConversionPattern<CallOp> {
   }
 };
 
+/// Removes any `function.def` operation that is not in the given set of used free functions.
 class RemoveFreeFunction : public OpConversionPattern<FuncDefOp> {
   llvm::DenseSet<FuncDefOp> &funcs;
 
@@ -783,25 +784,25 @@ static void populateStep3ConversionPatterns(
 /// An operation is legal in Step 1 if its located outside the
 /// `constrain` function of a struct.
 static bool isStep1LegalOp(Operation *op, llvm::DenseSet<FuncDefOp> &usedFreeFunctions) {
-  auto structDefOp = op->getParentOfType<StructDefOp>();
-  if (!structDefOp) {
+  if (auto structDefOp = op->getParentOfType<StructDefOp>()) {
     auto funcDefOp = op->getParentOfType<FuncDefOp>();
     if (!funcDefOp) {
-      // Legal because is not within a struct nor a free function definition.
+      // Legal because is not within a function definition.
       return true;
     }
-
-    // If the op is inside a free function, check if the function is in the set.
-    // If the function is in the set, then the op is illegal.
-    return !usedFreeFunctions.contains(funcDefOp);
+    // Legal if the containing function definition is not the struct's constrain function.
+    return structDefOp.getConstrainFuncOp() != funcDefOp;
   }
+
   auto funcDefOp = op->getParentOfType<FuncDefOp>();
   if (!funcDefOp) {
-    // Legal because is not within a function definition.
+    // Legal because is not within a struct nor a free function definition.
     return true;
   }
-  // Legal if the containing function definition is not the struct's constrain function.
-  return structDefOp.getConstrainFuncOp() != funcDefOp;
+
+  // If the op is inside a free function, check if the function is in the set.
+  // If the function is in the set, then the op is illegal.
+  return !usedFreeFunctions.contains(funcDefOp);
 }
 
 /// Populates the conversion target with the legallity expected of step 1 of the conversion.
@@ -831,7 +832,7 @@ static void populateStep2ConversionTarget(ConversionTarget &target) {
   target.addIllegalOp<StructDefOp, FuncDefOp>();
 }
 
-/// Populates the conversion target with the legallity expected of step 3 of the conversion.
+/// Populates the conversion target with the legality expected of step 3 of the conversion.
 static void populateStep3ConversionTarget(
     ConversionTarget &target, DupVarsReplacements &replacements, ModuleOp root
 ) {
@@ -1070,7 +1071,7 @@ class PassImpl : public pcl::impl::PCLLoweringPassBase<PassImpl> {
 
     // Complete the graph using the worklist.
     while (!WL.empty()) {
-      auto next = WL[WL.size() - 1];
+      auto next = WL.back();
       WL.pop_back();
 
       next.walk([&WL, &funcs, &tables](CallOp op) {

--- a/backends/pcl/lib/Conversion/PCLLoweringPass.cpp
+++ b/backends/pcl/lib/Conversion/PCLLoweringPass.cpp
@@ -716,6 +716,7 @@ public:
       PatternBenefit patBenefit = 1
   )
       : OpConversionPattern(tc, context, patBenefit), funcs(usedFreeFunctions) {}
+
   LogicalResult
   matchAndRewrite(FuncDefOp op, OpAdaptor, ConversionPatternRewriter &rewriter) const override {
     // Remove any op that is NOT in the set.

--- a/backends/pcl/lib/Target/PCL.cpp
+++ b/backends/pcl/lib/Target/PCL.cpp
@@ -21,6 +21,8 @@
 #include <mlir/Support/LLVM.h>
 #include <mlir/Support/LogicalResult.h>
 
+#include <llvm/ADT/ArrayRef.h>
+#include <llvm/ADT/STLExtras.h>
 #include <llvm/ADT/SmallVectorExtras.h>
 #include <llvm/ADT/StringRef.h>
 #include <llvm/ADT/TypeSwitch.h>
@@ -84,10 +86,48 @@ LogicalResult prologue(ModuleOp mod, pcl::Sexps &S) {
   return success();
 }
 
+/// Maps values to s-expressions to avoid generating duplicates.
+class SexpCache {
+  llvm::DenseMap<Value, pcl::Sexp> cache;
+
+public:
+  /// If the s-expression is a success, map it to the value.
+  ///
+  /// Returns the s-expression intact to faciliate using this method
+  /// as a pass-through.
+  FailureOr<pcl::Sexp> map(Value v, FailureOr<pcl::Sexp> s) {
+    if (succeeded(s)) {
+      cache.insert({v, *s});
+    }
+    return s;
+  }
+
+  /// Tries to get the s-expression representing the given value.
+  ///
+  /// Returns failure if it's not present.
+  FailureOr<pcl::Sexp> get(Value v) {
+    auto it = cache.find(v);
+    if (it == cache.end()) {
+      return failure();
+    }
+    return it->second;
+  }
+};
+
+/// Macro for querying the s-expressions cache, returning if present.
+#define TRY_CACHE(v)                                                                               \
+  {                                                                                                \
+    auto _cached_sexp = C.get(v);                                                                  \
+    if (succeeded(_cached_sexp)) {                                                                 \
+      return _cached_sexp;                                                                         \
+    }                                                                                              \
+  }
+
 /// Handles emission of the s-expressions representing a PCL module by a `func.func` operation.
 class ModuleEmitter {
   NameState ns;
   func::FuncOp func;
+  SexpCache C;
 
   /// Helper for getting the inputs of the module.
   ArrayRef<BlockArgument> inputs() { return func.getBody().front().getArguments(); }
@@ -179,7 +219,8 @@ class ModuleEmitter {
   }
 
   /// Helper for emitting an unary expression's s-expressions.
-  template<typename Op> FailureOr<pcl::Sexp> emitUnaryExpr(llvm::StringLiteral sym, Op op, pcl::Sexps &S) {
+  template <typename Op>
+  FailureOr<pcl::Sexp> emitUnaryExpr(llvm::StringLiteral sym, Op op, pcl::Sexps &S) {
     auto vs = emitExpr(op.getValue(), S);
     if (failed(vs)) {
       return failure();
@@ -202,8 +243,9 @@ class ModuleEmitter {
   }
 
   /// Helper for emitting an unary formula's s-expressions.
-  FailureOr<pcl::Sexp> emitUnaryFormula(llvm::StringLiteral sym, Value v, pcl::Sexps &S) {
-    auto vs = emitFormula(v, S);
+  template <typename Op>
+  FailureOr<pcl::Sexp> emitUnaryFormula(llvm::StringLiteral sym, Op op, pcl::Sexps &S) {
+    auto vs = emitFormula(op.getValue(), S);
     if (failed(vs)) {
       return failure();
     }
@@ -214,27 +256,28 @@ class ModuleEmitter {
   ///
   /// The value must have a mapping in the environment to an existing name.
   FailureOr<pcl::Sexp> emitVar(Value v, pcl::Sexps &S) {
+    TRY_CACHE(v);
     auto name = ns.getOrFail(v);
     if (failed(name)) {
       return func->emitOpError() << ", value " << v << " could not be emitted";
     }
-    return S.atom(*name);
+    return C.map(v, S.atom(*name));
   }
 
   /// Emits the s-expressions for the given expression represented by the value.
   FailureOr<pcl::Sexp> emitExpr(Value v, pcl::Sexps &S) {
-
+    TRY_CACHE(v);
     LLVM_DEBUG({ llvm::dbgs() << "[ModuleEmitter] Emitting expression for value " << v << '\n'; });
     auto *defOp = v.getDefiningOp();
     if (!defOp) {
       return emitVar(v, S);
     }
-    return llvm::TypeSwitch<Operation *, FailureOr<pcl::Sexp>>(defOp)
+    return C.map(v, llvm::TypeSwitch<Operation *, FailureOr<pcl::Sexp>>(defOp)
         .Case<pcl::AddOp>([this, &S](auto op) { return emitBinaryExpr("+", op, S); })
         .Case<pcl::MulOp>([this, &S](auto op) { return emitBinaryExpr("*", op, S); })
         .Case<pcl::SubOp>([this, &S](auto op) { return emitBinaryExpr("-", op, S); })
         .Case<pcl::NegOp>([this, &S](auto op) { return emitUnaryExpr("-", op, S); })
-        .Case<pcl::AsFeltOp>([this, &S](auto op) { return emitFormula(op, S); })
+        .Case<pcl::AsFeltOp>([this, &S](auto op) { return emitFormula(op.getValue(), S); })
         .Case<pcl::VarOp>([this, &S](auto op) { return S.atom(ns.get(op)); })
         .Case<pcl::ConstOp>([&S](auto op) { return S.atom(op.getValueAPInt()); })
         .Case<func::CallOp>([this, &S, v](auto) {
@@ -243,17 +286,19 @@ class ModuleEmitter {
       return emitVar(v, S);
     }).Default([v](auto op) {
       return op->emitOpError() << ", value " << v << " could not be emitted";
-    });
+    }));
   }
 
   /// Emits the s-expressions for the given formula represented by the value.
   FailureOr<pcl::Sexp> emitFormula(Value v, pcl::Sexps &S) {
+    TRY_CACHE(v);
     LLVM_DEBUG({ llvm::dbgs() << "[ModuleEmitter] Emitting formula for value " << v << '\n'; });
+
     auto *defOp = v.getDefiningOp();
     if (!defOp) {
       return emitVar(v, S);
     }
-    return llvm::TypeSwitch<Operation *, FailureOr<pcl::Sexp>>(defOp)
+    return C.map(v, llvm::TypeSwitch<Operation *, FailureOr<pcl::Sexp>>(defOp)
         .Case<pcl::CmpEqOp>([this, &S](auto op) { return emitBinaryExpr("=", op, S); })
         .Case<pcl::CmpLtOp>([this, &S](auto op) { return emitBinaryExpr("<", op, S); })
         .Case<pcl::CmpLeOp>([this, &S](auto op) { return emitBinaryExpr("<=", op, S); })
@@ -268,7 +313,7 @@ class ModuleEmitter {
         .Case<pcl::TrueOp>([&S](auto) { return S.atom<unsigned>(1); })
         .Case<pcl::FalseOp>([&S](auto) {
       return S.atom<unsigned>(0);
-    }).Default([this, &S, v](auto) { return emitExpr(v, S); });
+    }).Default([this, &S, v](auto) { return emitExpr(v, S); }));
   }
 
   /// Emits the body of the module.

--- a/backends/pcl/lib/Target/PCL.cpp
+++ b/backends/pcl/lib/Target/PCL.cpp
@@ -273,21 +273,23 @@ class ModuleEmitter {
     if (!defOp) {
       return emitVar(v, S);
     }
-    return C.map(v, llvm::TypeSwitch<Operation *, FailureOr<pcl::Sexp>>(defOp)
-        .Case<pcl::AddOp>([this, &S](auto op) { return emitBinaryExpr("+", op, S); })
-        .Case<pcl::MulOp>([this, &S](auto op) { return emitBinaryExpr("*", op, S); })
-        .Case<pcl::SubOp>([this, &S](auto op) { return emitBinaryExpr("-", op, S); })
-        .Case<pcl::NegOp>([this, &S](auto op) { return emitUnaryExpr("-", op, S); })
-        .Case<pcl::AsFeltOp>([this, &S](auto op) { return emitFormula(op.getValue(), S); })
-        .Case<pcl::VarOp>([this, &S](auto op) { return S.atom(ns.get(op)); })
-        .Case<pcl::ConstOp>([&S](auto op) { return S.atom(op.getValueAPInt()); })
-        .Case<func::CallOp>([this, &S, v](auto) {
+    return C.map(
+        v, llvm::TypeSwitch<Operation *, FailureOr<pcl::Sexp>>(defOp)
+               .Case<pcl::AddOp>([this, &S](auto op) { return emitBinaryExpr("+", op, S); })
+               .Case<pcl::MulOp>([this, &S](auto op) { return emitBinaryExpr("*", op, S); })
+               .Case<pcl::SubOp>([this, &S](auto op) { return emitBinaryExpr("-", op, S); })
+               .Case<pcl::NegOp>([this, &S](auto op) { return emitUnaryExpr("-", op, S); })
+               .Case<pcl::AsFeltOp>([this, &S](auto op) { return emitFormula(op.getValue(), S); })
+               .Case<pcl::VarOp>([this, &S](auto op) { return S.atom(ns.get(op)); })
+               .Case<pcl::ConstOp>([&S](auto op) { return S.atom(op.getValueAPInt()); })
+               .Case<func::CallOp>([this, &S, v](auto) {
       // If we encounter a call we need to emit the value as a variable,
       // since we preload all the call outputs into the environment.
       return emitVar(v, S);
     }).Default([v](auto op) {
       return op->emitOpError() << ", value " << v << " could not be emitted";
-    }));
+    })
+    );
   }
 
   /// Emits the s-expressions for the given formula represented by the value.
@@ -299,22 +301,24 @@ class ModuleEmitter {
     if (!defOp) {
       return emitVar(v, S);
     }
-    return C.map(v, llvm::TypeSwitch<Operation *, FailureOr<pcl::Sexp>>(defOp)
-        .Case<pcl::CmpEqOp>([this, &S](auto op) { return emitBinaryExpr("=", op, S); })
-        .Case<pcl::CmpLtOp>([this, &S](auto op) { return emitBinaryExpr("<", op, S); })
-        .Case<pcl::CmpLeOp>([this, &S](auto op) { return emitBinaryExpr("<=", op, S); })
-        .Case<pcl::CmpGtOp>([this, &S](auto op) { return emitBinaryExpr(">", op, S); })
-        .Case<pcl::CmpGeOp>([this, &S](auto op) { return emitBinaryExpr(">=", op, S); })
-        .Case<pcl::AndOp>([this, &S](auto op) { return emitBinaryFormula("&&", op, S); })
-        .Case<pcl::OrOp>([this, &S](auto op) { return emitBinaryFormula("||", op, S); })
-        .Case<pcl::ImpliesOp>([this, &S](auto op) { return emitBinaryFormula("=>", op, S); })
-        .Case<pcl::IffOp>([this, &S](auto op) { return emitBinaryFormula("<=>", op, S); })
-        .Case<pcl::NotOp>([this, &S](auto op) { return emitUnaryFormula("!", op, S); })
-        .Case<pcl::DetOp>([this, &S](auto op) { return emitUnaryExpr("det", op, S); })
-        .Case<pcl::TrueOp>([&S](auto) { return S.atom<unsigned>(1); })
-        .Case<pcl::FalseOp>([&S](auto) {
+    return C.map(
+        v, llvm::TypeSwitch<Operation *, FailureOr<pcl::Sexp>>(defOp)
+               .Case<pcl::CmpEqOp>([this, &S](auto op) { return emitBinaryExpr("=", op, S); })
+               .Case<pcl::CmpLtOp>([this, &S](auto op) { return emitBinaryExpr("<", op, S); })
+               .Case<pcl::CmpLeOp>([this, &S](auto op) { return emitBinaryExpr("<=", op, S); })
+               .Case<pcl::CmpGtOp>([this, &S](auto op) { return emitBinaryExpr(">", op, S); })
+               .Case<pcl::CmpGeOp>([this, &S](auto op) { return emitBinaryExpr(">=", op, S); })
+               .Case<pcl::AndOp>([this, &S](auto op) { return emitBinaryFormula("&&", op, S); })
+               .Case<pcl::OrOp>([this, &S](auto op) { return emitBinaryFormula("||", op, S); })
+               .Case<pcl::ImpliesOp>([this, &S](auto op) { return emitBinaryFormula("=>", op, S); })
+               .Case<pcl::IffOp>([this, &S](auto op) { return emitBinaryFormula("<=>", op, S); })
+               .Case<pcl::NotOp>([this, &S](auto op) { return emitUnaryFormula("!", op, S); })
+               .Case<pcl::DetOp>([this, &S](auto op) { return emitUnaryExpr("det", op, S); })
+               .Case<pcl::TrueOp>([&S](auto) { return S.atom<unsigned>(1); })
+               .Case<pcl::FalseOp>([&S](auto) {
       return S.atom<unsigned>(0);
-    }).Default([this, &S, v](auto) { return emitExpr(v, S); }));
+    }).Default([this, &S, v](auto) { return emitExpr(v, S); })
+    );
   }
 
   /// Emits the body of the module.

--- a/backends/pcl/lib/Target/PCL.cpp
+++ b/backends/pcl/lib/Target/PCL.cpp
@@ -25,7 +25,10 @@
 #include <llvm/ADT/StringRef.h>
 #include <llvm/ADT/TypeSwitch.h>
 #include <llvm/Support/Allocator.h>
+#include <llvm/Support/Debug.h>
 #include <llvm/Support/raw_ostream.h>
+
+#define DEBUG_TYPE "pcl-to-lisp"
 
 using namespace mlir;
 namespace {
@@ -39,10 +42,13 @@ struct NameState {
   ///
   /// If the name is not already in the environment creates one using the given prefix.
   std::string get(Value v, const std::string &prefix = "v") {
+    LLVM_DEBUG({ llvm::dbgs() << "[NameState] querying value " << v << "... "; });
     if (auto it = names.find(v); it != names.end()) {
+      LLVM_DEBUG({ llvm::dbgs() << "Found: " << it->second << '\n'; });
       return it->second;
     }
     std::string s = prefix + std::to_string(nextId++);
+    LLVM_DEBUG({ llvm::dbgs() << "Created: " << s << '\n'; });
     names[v] = s;
     return s;
   }
@@ -59,7 +65,12 @@ struct NameState {
   /// Sets the name of the given value.
   ///
   /// If the value already had a mapping, it is overriden.
-  void set(Value v, std::string name) { names[v] = std::move(name); }
+  void set(Value v, std::string name) {
+    LLVM_DEBUG({
+      llvm::dbgs() << "[NameState] Mapping value " << v << " to name \"" << name << "\"\n";
+    });
+    names[v] = std::move(name);
+  }
 };
 
 /// Emits the s-expressions for the beginning of the PCL file.
@@ -94,6 +105,7 @@ class ModuleEmitter {
   /// The prologue comprises the `(begin-module ...)` declaration followed by
   /// the input declarations.
   void prologue(pcl::Sexps &S) {
+    LLVM_DEBUG({ llvm::dbgs() << "[ModuleEmitter] Emitting prologue\n"; });
     S.push({S.atom("begin-module"), S.atom(func.getSymName())});
     for (auto arg : inputs()) {
       S.push({S.atom("input"), S.atom(ns.get(arg, "in"))});
@@ -127,6 +139,7 @@ class ModuleEmitter {
   /// (end-module)                ; Close the module.
   /// ```
   LogicalResult epilogue(pcl::Sexps &S) {
+    LLVM_DEBUG({ llvm::dbgs() << "[ModuleEmitter] Emitting epilogue\n"; });
     if (auto ret = dyn_cast_or_null<func::ReturnOp>(func.getBody().front().getTerminator())) {
       for (Value v : ret.getOperands()) {
         // Map the output to either a previously assigned map (i.e. from a `pcl.var` op) or to
@@ -166,8 +179,8 @@ class ModuleEmitter {
   }
 
   /// Helper for emitting an unary expression's s-expressions.
-  FailureOr<pcl::Sexp> emitUnaryExpr(llvm::StringLiteral sym, Value v, pcl::Sexps &S) {
-    auto vs = emitExpr(v, S);
+  template<typename Op> FailureOr<pcl::Sexp> emitUnaryExpr(llvm::StringLiteral sym, Op op, pcl::Sexps &S) {
+    auto vs = emitExpr(op.getValue(), S);
     if (failed(vs)) {
       return failure();
     }
@@ -210,6 +223,8 @@ class ModuleEmitter {
 
   /// Emits the s-expressions for the given expression represented by the value.
   FailureOr<pcl::Sexp> emitExpr(Value v, pcl::Sexps &S) {
+
+    LLVM_DEBUG({ llvm::dbgs() << "[ModuleEmitter] Emitting expression for value " << v << '\n'; });
     auto *defOp = v.getDefiningOp();
     if (!defOp) {
       return emitVar(v, S);
@@ -233,6 +248,7 @@ class ModuleEmitter {
 
   /// Emits the s-expressions for the given formula represented by the value.
   FailureOr<pcl::Sexp> emitFormula(Value v, pcl::Sexps &S) {
+    LLVM_DEBUG({ llvm::dbgs() << "[ModuleEmitter] Emitting formula for value " << v << '\n'; });
     auto *defOp = v.getDefiningOp();
     if (!defOp) {
       return emitVar(v, S);
@@ -264,6 +280,9 @@ class ModuleEmitter {
       if (failed(
               llvm::TypeSwitch<Operation *, LogicalResult>(op)
                   .Case<pcl::AssertOp>([this, &S](auto assertOp) {
+        LLVM_DEBUG({
+          llvm::dbgs() << "[ModuleEmitter] Emitting assert statement " << assertOp << '\n';
+        });
         auto cond = emitFormula(assertOp.getCond(), S);
         if (failed(cond)) {
           return failure();
@@ -272,6 +291,9 @@ class ModuleEmitter {
         return success();
       })
                   .Case<pcl::PostOp>([this, &S](auto postOp) {
+        LLVM_DEBUG({
+          llvm::dbgs() << "[ModuleEmitter] Emitting post-condition statement " << postOp << '\n';
+        });
         auto cond = emitFormula(postOp.getCond(), S);
         if (failed(cond)) {
           return failure();
@@ -280,6 +302,10 @@ class ModuleEmitter {
         return success();
       })
                   .Case<pcl::AssumeDeterministicOp>([this, &S](auto assumeOp) {
+        LLVM_DEBUG({
+          llvm::dbgs() << "[ModuleEmitter] Emitting assume-deterministic statement " << assumeOp
+                       << '\n';
+        });
         auto expr = emitExpr(assumeOp.getV(), S);
         if (failed(expr)) {
           return failure();
@@ -288,6 +314,9 @@ class ModuleEmitter {
         return success();
       })
                   .Case<func::CallOp>([this, &S](auto callOp) {
+        LLVM_DEBUG({
+          llvm::dbgs() << "[ModuleEmitter] Emitting call statement " << callOp << '\n';
+        });
         SmallVector<pcl::Sexp> outputs, inputs;
         outputs.reserve(callOp.getResults().size());
         inputs.reserve(callOp.getOperands().size());
@@ -380,7 +409,10 @@ public:
 
 /// Locates all the `func.func` ops in the MLIR module that represent a PCL module.
 static SmallVector<ModuleEmitter> findModules(ModuleOp op) {
-  return llvm::map_to_vector(op.getOps<func::FuncOp>(), [](auto f) { return ModuleEmitter(f); });
+  return llvm::map_to_vector(op.getOps<func::FuncOp>(), [](auto f) {
+    LLVM_DEBUG({ llvm::dbgs() << "Emitting function " << f.getSymName() << '\n'; });
+    return ModuleEmitter(f);
+  });
 }
 
 static void nl(raw_ostream &os, const pcl::PCLTargetConfig &config) {

--- a/backends/pcl/lib/Target/Sexp.cpp
+++ b/backends/pcl/lib/Target/Sexp.cpp
@@ -9,6 +9,10 @@
 
 #include "Sexp.h"
 
+#include <llvm/ADT/STLExtras.h>
+
+#define DEBUG_TYPE "sexp"
+
 namespace pcl {
 
 namespace detail {
@@ -36,6 +40,12 @@ Sexp Sexp::withSquareBrackets() {
 }
 
 Sexp SexpCtx::sexp(llvm::ArrayRef<Sexp> elements) {
+  LLVM_DEBUG({
+    llvm::dbgs() << "[Sexp] Creating s-expression with elements: ";
+    llvm::interleaveComma(elements, llvm::dbgs());
+    llvm::dbgs() << '\n';
+  });
+
   static_assert(sizeof(Sexp) == sizeof(detail::SexpElt *));
   detail::SexpElt **buf = allocator.Allocate<detail::SexpElt *>(elements.size());
   memcpy(
@@ -49,7 +59,7 @@ Sexp SexpCtx::sexp(llvm::ArrayRef<Sexp> elements) {
 }
 } // namespace pcl
 
-llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const pcl::Sexp &sexp) {
+llvm::raw_ostream &llvm::operator<<(llvm::raw_ostream &os, const pcl::Sexp &sexp) {
   sexp.print(os);
   return os;
 }

--- a/backends/pcl/lib/Target/Sexp.h
+++ b/backends/pcl/lib/Target/Sexp.h
@@ -11,7 +11,10 @@
 
 #include <llvm/ADT/ArrayRef.h>
 #include <llvm/Support/Allocator.h>
+#include <llvm/Support/Debug.h>
 #include <llvm/Support/raw_ostream.h>
+
+#define DEBUG_TYPE "sexp"
 
 namespace pcl {
 class SexpCtx;
@@ -69,6 +72,7 @@ public:
 // This is a known GCC issue: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=109224
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmismatched-new-delete"
+    LLVM_DEBUG({ llvm::dbgs() << "[Sexp] Creating atom with value: " << val << '\n'; });
     return Sexp(new (allocator) detail::Atom<T>(std::move(val)));
 #pragma GCC diagnostic pop
   }
@@ -114,4 +118,7 @@ public:
 
 } // namespace pcl
 
-llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const pcl::Sexp &sexp);
+namespace llvm {
+raw_ostream &operator<<(raw_ostream &os, const pcl::Sexp &sexp);
+}
+#undef DEBUG_TYPE

--- a/changelogs/unreleased/dani__tweak-pcl-lowering-legalization.yaml
+++ b/changelogs/unreleased/dani__tweak-pcl-lowering-legalization.yaml
@@ -1,0 +1,2 @@
+fixed:
+  - Fixed crashes in the `--llzk-to-pcl` pass and in the `--pcl-to-lisp` translation.

--- a/include/llzk/Dialect/Polymorphic/IR/Ops.h
+++ b/include/llzk/Dialect/Polymorphic/IR/Ops.h
@@ -37,7 +37,7 @@ template <typename OpT>
 concept TemplateSymbolBindingOp =
     std::is_same_v<OpT, TemplateSymbolBindingOpInterface> ||
     std::is_base_of_v<TemplateSymbolBindingOpInterface::Trait<OpT>, OpT>;
-}
+} // namespace llzk::polymorphic
 
 // Include TableGen'd declarations
 #define GET_OP_CLASSES

--- a/test/Transforms/PCLLowering/pcl_lowering_fail.llzk
+++ b/test/Transforms/PCLLowering/pcl_lowering_fail.llzk
@@ -12,7 +12,7 @@ module attributes {llzk.lang} {
       function.return %self : !struct.type<@ComponentA2>
     }
 
-    // expected-error@+1 {{Constrain function's args are expected to be felts. Found '!struct.type<@ComponentA1>'for arg #: 1}}
+    // expected-error@+1 {{function's args are expected to be felts. Found '!struct.type<@ComponentA1>'for arg #: 1}}
     function.def @constrain(%self: !struct.type<@ComponentA2>, %p: !struct.type<@ComponentA1>) {
       function.return
     }

--- a/test/Transforms/PCLLowering/pcl_lowering_pass_small.llzk
+++ b/test/Transforms/PCLLowering/pcl_lowering_pass_small.llzk
@@ -82,3 +82,86 @@ module attributes {llzk.lang} {
 // CHECK-NEXT:      pcl.assert %[[VAL_3]]
 // CHECK-NEXT:      return 
 // CHECK-NEXT:    }
+
+// -----
+
+module attributes {llzk.lang} {
+  struct.def @Lt {
+    function.def @compute(%in: !felt.type<"koalabear">) -> !struct.type<@Lt> {
+      %self = struct.new : <@Lt>
+      function.return %self : !struct.type<@Lt>
+    }
+    function.def @constrain(%self: !struct.type<@Lt>, %in: !felt.type<"koalabear">) {
+      %felt_const_1 = felt.const 1 : !felt.type<"koalabear">
+      %felt_const_65536 = felt.const 65536 : !felt.type<"koalabear">
+      %0 = bool.cmp lt(%in, %felt_const_65536) : !felt.type<"koalabear">, !felt.type<"koalabear">
+      %1 = cast.tofelt %0 : i1, !felt.type<"koalabear">
+      constrain.eq %1, %felt_const_1 : !felt.type<"koalabear">, !felt.type<"koalabear">
+      function.return
+    }
+  }
+  function.def @foo(%arg0: !felt.type<"koalabear">) -> !felt.type<"koalabear"> {
+    %true = arith.constant  1 : i1
+    %0 = scf.if %true -> (!felt.type<"koalabear">) {
+      %1 = felt.mul %arg0, %arg0 : !felt.type<"koalabear">, !felt.type<"koalabear">
+      scf.yield %1 : !felt.type<"koalabear">
+    } else {
+      scf.yield %arg0 : !felt.type<"koalabear">
+    }
+    function.return %0 : !felt.type<"koalabear">
+  }
+}
+
+// CHECK-LABEL:   func.func @Lt(
+// CHECK-SAME:        %[[VAL_0:[0-9a-zA-Z_\.]+]]: !pcl.felt) {
+// CHECK-NEXT:      %[[CONST_1:[0-9a-zA-Z_\.]+]] = pcl.const 1
+// CHECK-NEXT:      %[[CONST_65536:[0-9a-zA-Z_\.]+]] = pcl.const 65536
+// CHECK-NEXT:      %[[VAL_1:[0-9a-zA-Z_\.]+]] = pcl.lt %[[VAL_0]], %[[CONST_65536]]
+// CHECK-NEXT:      %[[VAL_2:[0-9a-zA-Z_\.]+]] = pcl.asfelt %[[VAL_1]]
+// CHECK-NEXT:      %[[VAL_3:[0-9a-zA-Z_\.]+]] = pcl.eq %[[VAL_2]], %[[CONST_1]]
+// CHECK-NEXT:      pcl.assert %[[VAL_3]]
+// CHECK-NEXT:      return 
+// CHECK-NEXT:    }
+// COM: Check that @foo is not lowered.
+// CHECK-NOT:  @foo
+
+// -----
+
+module attributes {llzk.lang} {
+  struct.def @Lt {
+    function.def @compute(%in: !felt.type<"koalabear">) -> !struct.type<@Lt> {
+      %self = struct.new : <@Lt>
+      function.return %self : !struct.type<@Lt>
+    }
+    function.def @constrain(%self: !struct.type<@Lt>, %in: !felt.type<"koalabear">) {
+      %felt_const_1 = felt.const 1 : !felt.type<"koalabear">
+      %felt_const_65536 = felt.const 65536 : !felt.type<"koalabear">
+      %inx2 = function.call @bar(%in) : (!felt.type<"koalabear">) -> !felt.type<"koalabear">
+      %0 = bool.cmp lt(%inx2, %felt_const_65536) : !felt.type<"koalabear">, !felt.type<"koalabear">
+      %1 = cast.tofelt %0 : i1, !felt.type<"koalabear">
+      constrain.eq %1, %felt_const_1 : !felt.type<"koalabear">, !felt.type<"koalabear">
+      function.return
+    }
+  }
+  function.def @bar(%arg0: !felt.type<"koalabear">) -> !felt.type<"koalabear"> {
+      %0 = felt.mul %arg0, %arg0 : !felt.type<"koalabear">, !felt.type<"koalabear">
+    function.return %0 : !felt.type<"koalabear">
+  }
+}
+
+// CHECK-LABEL:   func.func @Lt(
+// CHECK-SAME:        %[[VAL_0:[0-9a-zA-Z_\.]+]]: !pcl.felt) {
+// CHECK-NEXT:      %[[CONST_1:[0-9a-zA-Z_\.]+]] = pcl.const 1
+// CHECK-NEXT:      %[[CONST_65536:[0-9a-zA-Z_\.]+]] = pcl.const 65536
+// CHECK-NEXT:      %[[VAL_0x2:[0-9a-zA-Z_\.]+]] = call @bar(%[[VAL_0]]) : (!pcl.felt) -> !pcl.felt
+// CHECK-NEXT:      %[[VAL_1:[0-9a-zA-Z_\.]+]] = pcl.lt %[[VAL_0x2]], %[[CONST_65536]]
+// CHECK-NEXT:      %[[VAL_2:[0-9a-zA-Z_\.]+]] = pcl.asfelt %[[VAL_1]]
+// CHECK-NEXT:      %[[VAL_3:[0-9a-zA-Z_\.]+]] = pcl.eq %[[VAL_2]], %[[CONST_1]]
+// CHECK-NEXT:      pcl.assert %[[VAL_3]]
+// CHECK-NEXT:      return 
+// CHECK-NEXT:    }
+// CHECK-LABEL:  func.func @bar(
+// CHECK-SAME:        %[[VAL_0:[0-9a-zA-Z_\.]+]]: !pcl.felt) -> !pcl.felt {
+// CHECK-NEXT:      %[[VAL_1:[0-9a-zA-Z_\.]+]] = pcl.mul %[[VAL_0]], %[[VAL_0]]
+// CHECK-NEXT:      return %[[VAL_1]] : !pcl.felt
+// CHECK-NEXT:    }


### PR DESCRIPTION
Fixes crashes that occurred in the LLZK->PCL conversion pass and in the PCL translation:

- Ops not supported by the LLZK->PCL pass that are located in functions not targetted by the lowering are now ignored.
- Handle support for calls to free functions from the constrain functions
- Fix an infinite loop while printing some unary operators.
- Improve performance of the translator by caching s-expressions already generated.
