### PR TITLE
Add trim pass

### DIFF
--- a/backends/pcl/include/CMakeLists.txt
+++ b/backends/pcl/include/CMakeLists.txt
@@ -23,4 +23,5 @@ install(
   PATTERN CMakeFiles EXCLUDE)
 
 add_subdirectory(pcl/Conversion/)
+add_subdirectory(pcl/Transforms/)
 add_subdirectory(pcl/Dialect/IR/)

--- a/backends/pcl/include/pcl/Transforms/CMakeLists.txt
+++ b/backends/pcl/include/pcl/Transforms/CMakeLists.txt
@@ -1,0 +1,10 @@
+include_directories(${MLIR_INCLUDE_DIRS} ${LLZK_INCLUDE_DIR})
+
+set(LLVM_TARGET_DEFINITIONS "TransformationPasses.td")
+mlir_tablegen(TransformationPasses.h.inc -gen-pass-decls -name=Transformation)
+mlir_tablegen(TransformationPasses.capi.h.inc -gen-pass-capi-header --prefix PCLTransformation)
+mlir_tablegen(TransformationPasses.capi.cpp.inc -gen-pass-capi-impl --prefix PCLTransformation)
+llzk_add_mlir_doc(PCLTransformationPassesDocGen passes/pcl/TransformationPasses.md -gen-pass-doc)
+
+add_public_tablegen_target(PCLTransformationIncGen)
+add_dependencies(PCLDialectHeaders PCLTransformationIncGen)

--- a/backends/pcl/include/pcl/Transforms/TransformationPasses.h
+++ b/backends/pcl/include/pcl/Transforms/TransformationPasses.h
@@ -2,7 +2,7 @@
 //
 // Part of the LLZK Project, under the Apache License v2.0.
 // See LICENSE.txt for license information.
-// Copyright 2025 Veridise Inc.
+// Copyright 2026 Project LLZK
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//

--- a/backends/pcl/include/pcl/Transforms/TransformationPasses.h
+++ b/backends/pcl/include/pcl/Transforms/TransformationPasses.h
@@ -1,0 +1,20 @@
+//===-- TransformationPasses.h ----------------------------------*- C++ -*-===//
+//
+// Part of the LLZK Project, under the Apache License v2.0.
+// See LICENSE.txt for license information.
+// Copyright 2025 Veridise Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "llzk/Pass/PassBase.h"
+
+namespace pcl {
+
+#define GEN_PASS_DECL
+#define GEN_PASS_REGISTRATION
+#include "pcl/Transforms/TransformationPasses.h.inc"
+
+} // namespace pcl

--- a/backends/pcl/include/pcl/Transforms/TransformationPasses.td
+++ b/backends/pcl/include/pcl/Transforms/TransformationPasses.td
@@ -2,7 +2,7 @@
 //
 // Part of the LLZK Project, under the Apache License v2.0.
 // See LICENSE.txt for license information.
-// Copyright 2025 Veridise Inc.
+// Copyright 2026 Project LLZK
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//

--- a/backends/pcl/include/pcl/Transforms/TransformationPasses.td
+++ b/backends/pcl/include/pcl/Transforms/TransformationPasses.td
@@ -10,7 +10,6 @@
 #ifndef PCL_TRANSFORMATION_PASSES_TD
 #define PCL_TRANSFORMATION_PASSES_TD
 
-
 include "mlir/Pass/PassBase.td"
 
 class PCLPass<string passArg, string operation = "::mlir::ModuleOp">
@@ -23,7 +22,8 @@ class PCLPass<string passArg, string operation = "::mlir::ModuleOp">
   ];
 }
 
-def TrimExprSizePass : PCLPass<"pcl-trim-expression-size", "::mlir::func::FuncOp"> {
+def TrimExprSizePass
+    : PCLPass<"pcl-trim-expression-size", "::mlir::func::FuncOp"> {
   let summary = "Trims the size of expressions by introducing intermediates";
   let description = [{
     Trims the size of expressions by introducing intermediate bindings. This transformation 
@@ -92,9 +92,8 @@ def TrimExprSizePass : PCLPass<"pcl-trim-expression-size", "::mlir::func::FuncOp
     ```
   }];
 
-  let options = [
-    Option<"maxSize", "max-size", "unsigned", /*default=*/"10",
-           "The maximum size expressions are allowed to have">,
+  let options = [Option<"maxSize", "max-size", "unsigned", /*default=*/"10",
+                        "The maximum size expressions are allowed to have">,
   ];
 }
 

--- a/backends/pcl/include/pcl/Transforms/TransformationPasses.td
+++ b/backends/pcl/include/pcl/Transforms/TransformationPasses.td
@@ -1,0 +1,101 @@
+//===-- TransformationPasses.td ----------------------------*- tablegen -*-===//
+//
+// Part of the LLZK Project, under the Apache License v2.0.
+// See LICENSE.txt for license information.
+// Copyright 2025 Veridise Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef PCL_TRANSFORMATION_PASSES_TD
+#define PCL_TRANSFORMATION_PASSES_TD
+
+
+include "mlir/Pass/PassBase.td"
+
+class PCLPass<string passArg, string operation = "::mlir::ModuleOp">
+    : Pass<passArg, operation> {
+  let dependentDialects = [
+      // clang-format off
+      "pcl::PCLDialect",
+      "mlir::func::FuncDialect"
+      // clang-format on
+  ];
+}
+
+def TrimExprSizePass : PCLPass<"pcl-trim-expression-size", "::mlir::func::FuncOp"> {
+  let summary = "Trims the size of expressions by introducing intermediates";
+  let description = [{
+    Trims the size of expressions by introducing intermediate bindings. This transformation 
+    is recommended before translating to PCL s-expressions if the circuit is large or 
+    it was converted from a circuit with many free functions.
+
+    When translating the MLIR representation of the PCL circuit to the s-expressions representation,
+    each expression is expanded at each use point. This could lead to an explosion of the IR 
+    size. For example, consider the following IR:
+
+    ```
+    %0 = pcl.var "a" false
+    %1 = pcl.var "b" false
+    %2 = pcl.add %0, %1
+    %3 = pcl.mul %2, %2
+    %4 = pcl.add %2, %3
+    %5 = pcl.var "c" false
+    %6 = pcl.eq %5, %4
+    pcl.assert %6
+    %7 = pcl.var "d" false
+    %8 = pcl.eq %7, %4
+    pcl.assert %8
+    %9 = pcl.var "e" false
+    %10 = pcl.eq %9, %4
+    pcl.assert %10
+    ```
+    
+    Its s-expressions representation will expand to something roughtly 3 times the size:
+
+    ```
+    (assert (= c (+ (+ a b) (* (+ a b) (+ a b)))))
+    (assert (= d (+ (+ a b) (* (+ a b) (+ a b)))))
+    (assert (= e (+ (+ a b) (* (+ a b) (+ a b)))))
+    ```
+
+    This pass will introduce an intermediate binding in the middle of large expressions, resulting in smaller 
+    s-expressions in the final representation. The example above would be trimmed as follows.
+
+    ```
+    %0 = pcl.var "a" false
+    %1 = pcl.var "b" false
+    %2 = pcl.add %0, %1
+    %3 = pcl.mul %2, %2
+    %4 = pcl.add %2, %3
+    %5 = pcl.var "t0" false 
+    %6 = pcl.eq %5, %4
+    pcl.assert %6
+    %7 = pcl.var "c" false
+    %8 = pcl.eq %7, %5
+    pcl.assert %8
+    %9 = pcl.var "d" false
+    %10 = pcl.eq %9, %5
+    pcl.assert %10
+    %11 = pcl.var "e" false
+    %12 = pcl.eq %11, %5
+    pcl.assert %12
+    ```
+
+    Which results in the following s-expressions:
+
+    ```
+    (assert (= t0 (+ (+ a b) (* (+ a b) (+ a b)))))
+    (assert (= c t0))
+    (assert (= d t0))
+    (assert (= e t0))
+    ```
+  }];
+
+  let options = [
+    Option<"maxSize", "max-size", "unsigned", /*default=*/"10",
+           "The maximum size expressions are allowed to have">,
+  ];
+}
+
+#endif // PCL_TRANSFORMATION_PASSES_TD

--- a/backends/pcl/lib/CMakeLists.txt
+++ b/backends/pcl/lib/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory(Dialect)
 add_subdirectory(Conversion)
+add_subdirectory(Transforms)
 add_subdirectory(Target)

--- a/backends/pcl/lib/Transforms/CMakeLists.txt
+++ b/backends/pcl/lib/Transforms/CMakeLists.txt
@@ -1,0 +1,23 @@
+add_library(PCLTransforms)
+add_library(LLZK::PCLTransforms ALIAS PCLTransforms)
+
+target_sources(PCLTransforms PRIVATE TrimExprSizePass.cpp)
+target_link_libraries(
+  PCLTransforms
+  PUBLIC
+    PCLDialect
+    LLZKDialectHeaders
+    ${LLZK_DEP_DIALECT_LIBS}
+    MLIRIR
+    MLIRPass
+    MLIRParser
+    MLIRTransformUtils
+    MLIRSCFTransforms
+    LLVMHeaders
+    MLIRHeaders
+    LLZKDialect
+    LLZKDialectShared
+)
+llzk_target_add_mlir_link_settings(PCLTransforms)
+
+install(TARGETS PCLTransforms EXPORT LLZKTargets)

--- a/backends/pcl/lib/Transforms/TrimExprSizePass.cpp
+++ b/backends/pcl/lib/Transforms/TrimExprSizePass.cpp
@@ -7,12 +7,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "pcl/Dialect/IR/Dialect.h"
 #include "pcl/Dialect/IR/Ops.h"
 #include "pcl/Transforms/TransformationPasses.h"
 
 #include <mlir/IR/Builders.h>
+#include <mlir/Dialect/Func/IR/FuncOps.h>
 
 #include <llvm/ADT/APInt.h>
 #include <llvm/ADT/DenseMap.h>
@@ -109,11 +109,9 @@ class PassImpl : public pcl::impl::TrimExprSizePassBase<PassImpl> {
         auto cmpEqOp = builder.create<pcl::CmpEqOp>(loc, varOp, zeroOp);
         auto notOp = builder.create<pcl::NotOp>(loc, cmpEqOp);
         cut->replaceAllUsesWith(notOp);
+        cutOpResult = builder.create<pcl::AsFeltOp>(loc, cutOpResult);
       } else {
         cut->replaceAllUsesWith(varOp);
-      }
-      if (isa<pcl::BoolType>(cutOpResult.getType())) {
-        cutOpResult = builder.create<pcl::AsFeltOp>(loc, cutOpResult);
       }
       auto cmpEqOp = builder.create<pcl::CmpEqOp>(loc, varOp, cutOpResult);
       builder.create<pcl::AssertOp>(loc, cmpEqOp);

--- a/backends/pcl/lib/Transforms/TrimExprSizePass.cpp
+++ b/backends/pcl/lib/Transforms/TrimExprSizePass.cpp
@@ -11,8 +11,8 @@
 #include "pcl/Dialect/IR/Ops.h"
 #include "pcl/Transforms/TransformationPasses.h"
 
-#include <mlir/IR/Builders.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
+#include <mlir/IR/Builders.h>
 
 #include <llvm/ADT/APInt.h>
 #include <llvm/ADT/DenseMap.h>

--- a/backends/pcl/lib/Transforms/TrimExprSizePass.cpp
+++ b/backends/pcl/lib/Transforms/TrimExprSizePass.cpp
@@ -1,0 +1,157 @@
+//===-- TrimExprSizePass.cpp -----------------------------------*- C++ -*-===//
+//
+// Part of the LLZK Project, under the Apache License v2.0.
+// See LICENSE.txt for license information.
+// Copyright 2026 Project LLZK
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "pcl/Dialect/IR/Dialect.h"
+#include "pcl/Dialect/IR/Ops.h"
+#include "pcl/Transforms/TransformationPasses.h"
+
+#include <mlir/IR/Builders.h>
+
+#include <llvm/ADT/APInt.h>
+#include <llvm/ADT/DenseMap.h>
+#include <llvm/ADT/DenseSet.h>
+#include <llvm/ADT/StringSet.h>
+#include <llvm/ADT/TypeSwitch.h>
+#include <llvm/Support/Debug.h>
+#include <llvm/Support/LogicalResult.h>
+
+#include <algorithm>
+
+using namespace mlir;
+
+// Include the generated base pass class definitions.
+namespace pcl {
+#define GEN_PASS_DEF_TRIMEXPRSIZEPASS
+#include "pcl/Transforms/TransformationPasses.h.inc"
+} // namespace pcl
+
+namespace {
+
+/// Maps the expresion sizes of Values in the IR.
+class ExprSizes {
+  llvm::DenseMap<Value, unsigned> sizes;
+  unsigned maxSize;
+  llvm::DenseSet<Operation *> &cuts;
+
+public:
+  ExprSizes(unsigned MAX, llvm::DenseSet<Operation *> &C) : maxSize(MAX), cuts(C) {}
+
+  unsigned operator[](Value v) { return get(v); }
+
+  unsigned get(Value v) {
+    auto *defOp = v.getDefiningOp();
+    if (!defOp || isa<pcl::VarOp, func::CallOp>(defOp) || cuts.contains(defOp)) {
+      return 1;
+    }
+    if (sizes.contains(v)) {
+      return sizes.at(v);
+    }
+
+    unsigned size = 1;
+    for (auto operand : defOp->getOperands()) {
+      size += get(operand);
+      if (size > maxSize) {
+        break;
+      }
+    }
+    sizes[v] = size;
+    return size;
+  }
+};
+
+class PassImpl : public pcl::impl::TrimExprSizePassBase<PassImpl> {
+  using pcl::impl::TrimExprSizePassBase<PassImpl>::TrimExprSizePassBase;
+
+  struct Plan {
+    llvm::DenseSet<Operation *> cuts;
+    llvm::StringSet<> names;
+    unsigned bindingsCount = 0;
+
+    std::string nextBinding() {
+      auto name = ("t" + Twine(bindingsCount)).str();
+      while (names.contains(name)) {
+        bindingsCount++;
+        name = ("t" + Twine(bindingsCount)).str();
+      }
+      bindingsCount++;
+      return name;
+    }
+  };
+
+  void runOnOperation() override {
+    auto plan = collectPlan();
+    OpBuilder builder(getOperation());
+
+    for (auto *cut : plan.cuts) {
+      auto loc = cut->getLoc();
+      if (cut->getNumResults() != 1) {
+        cut->emitOpError() << "cannot trim op with " << cut->getNumResults() << " results";
+        signalPassFailure();
+        return;
+      }
+      Value cutOpResult = cut->getResult(0);
+
+      auto name = plan.nextBinding();
+      OpBuilder::InsertionGuard guard(builder);
+      builder.setInsertionPointAfter(cut);
+      auto varOp = builder.create<pcl::VarOp>(loc, name, false);
+
+      if (isa<pcl::BoolType>(cutOpResult.getType())) {
+        auto value = pcl::FeltAttr::get(&getContext(), llvm::APInt::getZero(2));
+        auto zeroOp = builder.create<pcl::ConstOp>(loc, value);
+        auto cmpEqOp = builder.create<pcl::CmpEqOp>(loc, varOp, zeroOp);
+        auto notOp = builder.create<pcl::NotOp>(loc, cmpEqOp);
+        cut->replaceAllUsesWith(notOp);
+      } else {
+        cut->replaceAllUsesWith(varOp);
+      }
+      if (isa<pcl::BoolType>(cutOpResult.getType())) {
+        cutOpResult = builder.create<pcl::AsFeltOp>(loc, cutOpResult);
+      }
+      auto cmpEqOp = builder.create<pcl::CmpEqOp>(loc, varOp, cutOpResult);
+      builder.create<pcl::AssertOp>(loc, cmpEqOp);
+    }
+  }
+
+  Plan collectPlan() {
+    auto max = safeMaxSize();
+    llvm::DenseSet<Operation *> cuts;
+    llvm::StringSet<> names;
+    ExprSizes sizes(max, cuts);
+
+    getOperation()->walk([&sizes, &cuts, &names, max](Operation *op) {
+      if (auto varOp = mlir::dyn_cast_if_present<pcl::VarOp>(op)) {
+        names.insert(varOp.getName());
+      }
+      if (op->getNumResults() == 0) {
+        return;
+      }
+
+      for (auto result : op->getResults()) {
+        auto size = sizes[result];
+        if (size > max) {
+          cuts.insert(op);
+        }
+      }
+    });
+    return {.cuts = cuts, .names = names};
+  }
+
+  /// Returns the maximum size, capping to a minimum value of 2 if the user passed a smaller size.
+  unsigned safeMaxSize() {
+    auto size = maxSize.getValue();
+    if (size < 2) {
+      getOperation()->emitWarning("maximum sizes smaller than 2 are capped to that value");
+    }
+    return std::max({size, static_cast<unsigned>(2)});
+  }
+};
+
+} // namespace

--- a/changelogs/unreleased/dani__expr-size-limit-pass.yaml
+++ b/changelogs/unreleased/dani__expr-size-limit-pass.yaml
@@ -1,0 +1,2 @@
+added:
+  - Added the `--pcl-trim-expression-size` to the PCL backend.

--- a/test/PCL/trim-expr-size.llzk
+++ b/test/PCL/trim-expr-size.llzk
@@ -1,0 +1,62 @@
+// REQUIRES: with-pcl
+// RUN: llzk-opt -split-input-file -pcl-trim-expression-size -verify-diagnostics %s | FileCheck --enable-var-scope %s
+
+module attributes {pcl.prime = #pcl.prime<7>} {
+  func.func @trim_large_felt_expr() -> !pcl.felt {
+    %0 = pcl.const 5
+    %1 = pcl.const 1 
+    %2 = pcl.add %0, %1
+    %3 = pcl.add %2, %2
+    %4 = pcl.mul %3, %3
+    %5 = pcl.mul %4, %4
+    return %5 : !pcl.felt
+  }
+}
+
+// CHECK-LABEL: module attributes {pcl.prime = #pcl.prime<7>} {
+// CHECK-NEXT:    func.func @trim_large_felt_expr() -> !pcl.felt {
+// CHECK-NEXT:      %[[VAL_0:[0-9a-zA-Z_\.]+]] = pcl.const 5
+// CHECK-NEXT:      %[[VAL_1:[0-9a-zA-Z_\.]+]] = pcl.const 1
+// CHECK-NEXT:      %[[VAL_2:[0-9a-zA-Z_\.]+]] = pcl.add %[[VAL_0]], %[[VAL_1]]
+// CHECK-NEXT:      %[[VAL_3:[0-9a-zA-Z_\.]+]] = pcl.add %[[VAL_2]], %[[VAL_2]]
+// CHECK-NEXT:      %[[VAL_4:[0-9a-zA-Z_\.]+]] = pcl.mul %[[VAL_3]], %[[VAL_3]]
+// CHECK-NEXT:      %[[VAL_5:[0-9a-zA-Z_\.]+]] = pcl.var "t0" false
+// CHECK-NEXT:      %[[VAL_6:[0-9a-zA-Z_\.]+]] = pcl.eq %[[VAL_5]], %[[VAL_4]]
+// CHECK-NEXT:      pcl.assert %[[VAL_6]]
+// CHECK-NEXT:      %[[VAL_7:[0-9a-zA-Z_\.]+]] = pcl.mul %[[VAL_5]], %[[VAL_5]]
+// CHECK-NEXT:      return %[[VAL_7]] : !pcl.felt
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }
+
+// -----
+
+module attributes {pcl.prime = #pcl.prime<7>} {
+  func.func @trim_large_bool_expr(%0: !pcl.felt, %1: !pcl.felt) -> !pcl.bool {
+    %2 = pcl.add %0, %1
+    %3 = pcl.mul %0, %1
+    %4 = pcl.eq %2, %3
+    %5 = pcl.and %4, %4
+    %6 = pcl.and %5, %5
+    return %6 : !pcl.bool
+  }
+}
+
+// CHECK-LABEL: module attributes {pcl.prime = #pcl.prime<7>} {
+// CHECK-NEXT:    func.func @trim_large_bool_expr(
+// CHECK-SAME:      %[[ARG_0:[0-9a-zA-Z_\.]+]]: !pcl.felt, %[[ARG_1:[0-9a-zA-Z_\.]+]]: !pcl.felt
+// CHECK-SAME:    ) -> !pcl.bool {
+// CHECK-NEXT:      %[[VAL_0:[0-9a-zA-Z_\.]+]] = pcl.add %[[ARG_0]], %[[ARG_1]]
+// CHECK-NEXT:      %[[VAL_1:[0-9a-zA-Z_\.]+]] = pcl.mul %[[ARG_0]], %[[ARG_1]]
+// CHECK-NEXT:      %[[VAL_2:[0-9a-zA-Z_\.]+]] = pcl.eq %[[VAL_0]], %[[VAL_1]]
+// CHECK-NEXT:      %[[VAL_3:[0-9a-zA-Z_\.]+]] = pcl.and %[[VAL_2]], %[[VAL_2]]
+// CHECK-NEXT:      %[[VAL_4:[0-9a-zA-Z_\.]+]] = pcl.var "t0" false
+// CHECK-NEXT:      %[[VAL_5:[0-9a-zA-Z_\.]+]] = pcl.const 0
+// CHECK-NEXT:      %[[VAL_6:[0-9a-zA-Z_\.]+]] = pcl.eq %[[VAL_4]], %[[VAL_5]]
+// CHECK-NEXT:      %[[VAL_7:[0-9a-zA-Z_\.]+]] = pcl.not %[[VAL_6]]
+// CHECK-NEXT:      %[[VAL_8:[0-9a-zA-Z_\.]+]] = pcl.asfelt %[[VAL_3]]
+// CHECK-NEXT:      %[[VAL_9:[0-9a-zA-Z_\.]+]] = pcl.eq %[[VAL_4]], %[[VAL_8]]
+// CHECK-NEXT:      pcl.assert %[[VAL_9]]
+// CHECK-NEXT:      %[[VAL_10:[0-9a-zA-Z_\.]+]] = pcl.and %[[VAL_7]], %[[VAL_7]]
+// CHECK-NEXT:      return %[[VAL_10]] : !pcl.bool
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/tools/llzk-opt/CMakeLists.txt
+++ b/tools/llzk-opt/CMakeLists.txt
@@ -9,7 +9,8 @@ target_link_libraries(llzk-opt PRIVATE ${LLZK_DEP_DIALECT_LIBS} MLIROptLib
                       MLIRFuncDialect MLIRFuncInlinerExtension
                       $<$<BOOL:${LLZK_WITH_PCL_BOOL}>:PCLDialectHeaders>
                       $<$<BOOL:${LLZK_WITH_PCL_BOOL}>:PCLDialect>
-                      $<$<BOOL:${LLZK_WITH_PCL_BOOL}>:PCLConversion>
+                      $<$<BOOL:${LLZK_WITH_PCL_BOOL}>:PCLConversion> 
+                      $<$<BOOL:${LLZK_WITH_PCL_BOOL}>:PCLTransforms>
                       )
 llzk_target_add_mlir_link_settings(llzk-opt)
 include_directories(${MLIR_INCLUDE_DIRS} ${LLVM_INCLUDE_DIRS} ${R1CS_INCLUDE_DIR}

--- a/tools/llzk-opt/llzk-opt.cpp
+++ b/tools/llzk-opt/llzk-opt.cpp
@@ -53,9 +53,9 @@
 
 #if LLZK_WITH_PCL
 #include "pcl/Conversion/ConversionPasses.h"
-#include "pcl/Transforms/TransformationPasses.h"
 #include "pcl/Dialect/IR/Dialect.h"
 #include "pcl/DialectRegistration.h"
+#include "pcl/Transforms/TransformationPasses.h"
 #endif // LLZK_WITH_PCL
 
 static llvm::cl::list<std::string> IncludeDirs(

--- a/tools/llzk-opt/llzk-opt.cpp
+++ b/tools/llzk-opt/llzk-opt.cpp
@@ -53,6 +53,7 @@
 
 #if LLZK_WITH_PCL
 #include "pcl/Conversion/ConversionPasses.h"
+#include "pcl/Transforms/TransformationPasses.h"
 #include "pcl/Dialect/IR/Dialect.h"
 #include "pcl/DialectRegistration.h"
 #endif // LLZK_WITH_PCL
@@ -131,6 +132,7 @@ int main(int argc, char **argv) {
   zklean::registerConversionPasses();
 #if LLZK_WITH_PCL
   pcl::registerPCLConversionPasses();
+  pcl::registerTransformationPasses();
 #endif // LLZK_WITH_PCL
   llzk::smt::registerConversionPasses();
 


### PR DESCRIPTION
A pass for reducing the size of PCL expressions to avoid size explosions when printing the IR in lisp.
