### PR TITLE
Stubbed lowering mode for the LLZK->PCL pass

### DIFF
--- a/backends/pcl/include/pcl/Conversion/ConversionPasses.h
+++ b/backends/pcl/include/pcl/Conversion/ConversionPasses.h
@@ -15,6 +15,11 @@
 
 namespace pcl {
 
+enum class LlzkToPclMode : std::uint8_t {
+  Full,
+  Stubbed
+};
+
 #define GEN_PASS_DECL
 #define GEN_PASS_REGISTRATION
 #include "pcl/Conversion/ConversionPasses.h.inc"

--- a/backends/pcl/include/pcl/Conversion/ConversionPasses.h
+++ b/backends/pcl/include/pcl/Conversion/ConversionPasses.h
@@ -15,10 +15,7 @@
 
 namespace pcl {
 
-enum class LlzkToPclMode : std::uint8_t {
-  Full,
-  Stubbed
-};
+enum class LlzkToPclMode : std::uint8_t { Full, Stubbed };
 
 #define GEN_PASS_DECL
 #define GEN_PASS_REGISTRATION

--- a/backends/pcl/include/pcl/Conversion/ConversionPasses.td
+++ b/backends/pcl/include/pcl/Conversion/ConversionPasses.td
@@ -19,6 +19,15 @@ def PCLLoweringPass : LLZKPass<"llzk-to-pcl"> {
       Transforms LLZK constraints into an equivalent set of constraints expressed in the pcl-mlir dialect.
       This pass currently expects the flattening and inlining passes to be run prior to its use.
     }];
+
+  let options = [Option<
+      "mode", "mode", "LlzkToPclMode", "::pcl::LlzkToPclMode::Full",
+      "Lowering mode (full or stubbed)", [{::llvm::cl::values(
+               clEnumValN(::pcl::LlzkToPclMode::Full, "full",
+                "Lower the IR completely."),
+               clEnumValN(::pcl::LlzkToPclMode::Stubbed, "stubbed",
+                "Replace free functions with unsupported ops with stubs.")
+              )}]>];
 }
 
 #endif // PCL_CONV_CONVERSION_PASSES_TD

--- a/backends/pcl/include/pcl/Conversion/ConversionPasses.td
+++ b/backends/pcl/include/pcl/Conversion/ConversionPasses.td
@@ -26,7 +26,7 @@ def PCLLoweringPass : LLZKPass<"llzk-to-pcl"> {
                clEnumValN(::pcl::LlzkToPclMode::Full, "full",
                 "Lower the IR completely."),
                clEnumValN(::pcl::LlzkToPclMode::Stubbed, "stubbed",
-                "Replace free functions with unsupported ops with stubs.")
+                "Replace free functions containing unsupported ops with stubs.")
               )}]>];
 }
 

--- a/backends/pcl/lib/Conversion/PCLLoweringPass.cpp
+++ b/backends/pcl/lib/Conversion/PCLLoweringPass.cpp
@@ -39,6 +39,7 @@
 #include "llzk/Transforms/LLZKLoweringUtils.h"
 #include "llzk/Util/DynamicAPIntHelper.h"
 #include "llzk/Util/Field.h"
+#include "llzk/Util/SymbolLookup.h"
 
 #include <pcl/Dialect/IR/Dialect.h>
 #include <pcl/Dialect/IR/Ops.h>
@@ -67,19 +68,22 @@
 #include <llvm/ADT/DenseMapInfo.h>
 #include <llvm/ADT/DenseSet.h>
 #include <llvm/ADT/EquivalenceClasses.h>
+#include <llvm/ADT/STLExtras.h>
 #include <llvm/ADT/SmallVector.h>
 #include <llvm/ADT/SmallVectorExtras.h>
 #include <llvm/ADT/StringSet.h>
 #include <llvm/ADT/TypeSwitch.h>
 #include <llvm/Support/Debug.h>
+#include <llvm/Support/ErrorHandling.h>
 #include <llvm/Support/LogicalResult.h>
 
 #include <cstdint>
+#include <memory>
 #include <optional>
 
 // Include the generated base pass class definitions.
 namespace pcl {
-#define GEN_PASS_DECL_PCLLOWERINGPASS
+
 #define GEN_PASS_DEF_PCLLOWERINGPASS
 #include "pcl/Conversion/ConversionPasses.h.inc"
 } // namespace pcl
@@ -108,6 +112,116 @@ template <typename Op> static std::string flatFullyQualifiedName(Op op) {
   }
 
   return name;
+}
+
+/// Set of free functions that are used by the `@constrain` functions in the circuit.
+///
+/// Functions are matched by their FQN. This means that a function op with identical FQN
+/// to one already inserted in the set will be reported as being already in the set. This is done
+/// for handling the analysis step of the stubbed mode, where the IR is cloned to avoid destructive
+/// actions affecting the original IR.
+///
+/// For that reason, this mapping is missing the U in CRUD and we only insert during creation.
+class UsedFreeFunctions {
+  using M = llvm::DenseMap<Attribute, FuncDefOp>;
+
+  /// Maps the FQN to the operation representing it.
+  M funcs;
+
+  /// Inserts the function into the mapping.
+  void insert(FuncDefOp op) { funcs.insert({op.getFullyQualifiedName(), op}); }
+
+  /// Convenience method for the construction of the mapping.
+  void insertCallees(
+      llvm::SmallVectorImpl<FuncDefOp> &WL, mlir::SymbolTableCollection &tables, FuncDefOp f,
+      llvm::function_ref<bool(FuncDefOp)> P = nullptr
+  ) {
+    f.walk([&WL, this, &tables, P](CallOp callOp) {
+      auto calleeLookup = callOp.getCalleeTarget(tables);
+      if (failed(calleeLookup)) {
+        return;
+      }
+
+      auto callee = calleeLookup->get();
+      // If function already in set, or predicate is true (if available), skip the op.
+      if (contains(callee) || (P && P(callee))) {
+        return;
+      }
+
+      insert(callee);
+      WL.push_back(callee);
+    });
+  }
+
+public:
+  /// Collects the call-graph from the constrain functions (excluding the `@constrain` functions
+  /// themselves). Since we only care if a given `function.def` is part of the graph or not we
+  /// return the set of vertices.
+  UsedFreeFunctions(ModuleOp op) {
+    llvm::SmallVector<FuncDefOp> WL;
+    mlir::SymbolTableCollection tables;
+
+    // Fill the worklist with the initial set of functions.
+    op->walk([&WL, this, &tables](StructDefOp structOp) {
+      if (auto f = structOp.getConstrainFuncOp()) {
+        insertCallees(WL, tables, f, [](FuncDefOp callee) { return callee.isStructConstrain(); });
+      }
+    });
+
+    // Complete the graph using the worklist.
+    while (!WL.empty()) {
+      auto next = WL.back();
+      WL.pop_back();
+      insertCallees(WL, tables, next);
+    }
+  }
+
+  /// Returns whether the function is in the set or not.
+  bool contains(FuncDefOp op) const { return funcs.contains(op.getFullyQualifiedName()); }
+
+  /// Removes the function from the mapping.
+  ///
+  /// As a safety precaution, is only erased if the given function is equal to the
+  /// one mapped by the FQN.
+  void erase(FuncDefOp op) {
+    auto fqn = op.getFullyQualifiedName();
+    if (auto mappedOp = funcs[fqn]; mappedOp == op) {
+      funcs.erase(fqn);
+    }
+  }
+
+  class iterator {
+    using It = M::iterator;
+    It iter;
+
+  public:
+    using difference_type = It::difference_type;
+    using value_type = FuncDefOp;
+    using pointer = value_type *;
+    using reference = value_type &;
+    using iterator_category = It::iterator_category;
+
+    iterator() = default;
+    iterator(It I) : iter(I) {}
+
+    reference operator*() { return iter->getSecond(); }
+
+    iterator &operator++() {
+      ++iter;
+      return *this;
+    }
+
+    iterator operator++(int) { return iterator(iter++); }
+
+    friend bool operator!=(const iterator &LHS, const iterator &RHS);
+  };
+
+  iterator begin() { return iterator(funcs.begin()); }
+  iterator end() { return iterator(funcs.end()); }
+};
+
+bool operator!=(const UsedFreeFunctions::iterator &LHS, const UsedFreeFunctions::iterator &RHS) {
+  return LHS.iter != RHS.iter;
 }
 
 template <typename Op> class ConstantOpValue {};
@@ -554,17 +668,17 @@ public:
 
 class ConvertFreeFunction : public OpConversionPattern<FuncDefOp>,
                             public BodyCopier<FuncDefOp, ConvertFreeFunction> {
-  llvm::DenseSet<FuncDefOp> &funcs;
+  UsedFreeFunctions &funcs;
   ModuleOp root;
 
 public:
   ConvertFreeFunction(
-      MLIRContext *context, llvm::DenseSet<FuncDefOp> &usedFreeFunctions, ModuleOp rootOp,
+      MLIRContext *context, UsedFreeFunctions &usedFreeFunctions, ModuleOp rootOp,
       PatternBenefit patBenefit = 1
   )
       : OpConversionPattern(context, patBenefit), funcs(usedFreeFunctions), root(rootOp) {}
   ConvertFreeFunction(
-      const TypeConverter &tc, MLIRContext *context, llvm::DenseSet<FuncDefOp> &usedFreeFunctions,
+      const TypeConverter &tc, MLIRContext *context, UsedFreeFunctions &usedFreeFunctions,
       ModuleOp rootOp, PatternBenefit patBenefit = 1
   )
       : OpConversionPattern(tc, context, patBenefit), funcs(usedFreeFunctions), root(rootOp) {}
@@ -588,6 +702,74 @@ public:
       return failure();
     }
     return copyBody(op, rewriter);
+  }
+};
+
+class ConvertFreeFunctionIntoStub : public OpConversionPattern<FuncDefOp> {
+  llvm::DenseSet<FuncDefOp> &stubs;
+  ModuleOp root;
+
+public:
+  ConvertFreeFunctionIntoStub(
+      MLIRContext *context, llvm::DenseSet<FuncDefOp> &stubFunctions, ModuleOp rootOp,
+      PatternBenefit patBenefit = 1
+  )
+      : OpConversionPattern(context, patBenefit), stubs(stubFunctions), root(rootOp) {}
+  ConvertFreeFunctionIntoStub(
+      const TypeConverter &tc, MLIRContext *context, llvm::DenseSet<FuncDefOp> &stubFunctions,
+      ModuleOp rootOp, PatternBenefit patBenefit = 1
+  )
+      : OpConversionPattern(tc, context, patBenefit), stubs(stubFunctions), root(rootOp) {}
+
+  FailureOr<FuncDefOp> getFuncOp(FuncDefOp op) const { return op; }
+
+  unsigned int baseOffset() const { return 0; }
+
+  llvm::SmallVector<Type> outputTypes(FuncDefOp op) const {
+    return llvm::SmallVector<Type>(
+        op.getFunctionType().getNumResults(), pcl::FeltType::get(op.getContext())
+    );
+  }
+
+  ModuleOp getRoot() const { return root; }
+
+  LogicalResult
+  matchAndRewrite(FuncDefOp op, OpAdaptor, ConversionPatternRewriter &rewriter) const override {
+    // Don't convert functions outside the set.
+    if (!stubs.contains(op)) {
+      return failure();
+    }
+
+    SmallVector<Type> inputs(op.getNumArguments(), pcl::FeltType::get(rewriter.getContext()));
+    SmallVector<Type> outputs = llvm::SmallVector<Type>(
+        op.getFunctionType().getNumResults(), pcl::FeltType::get(op.getContext())
+    );
+
+    auto funcOp = func::FuncOp::create(
+        op.getLoc(), flatFullyQualifiedName(op), rewriter.getFunctionType(inputs, outputs)
+    );
+    auto *body = funcOp.addEntryBlock();
+    {
+      OpBuilder::InsertionGuard guard(rewriter);
+      rewriter.setInsertionPointToStart(body);
+      auto outputValues = llvm::map_to_vector(
+          llvm::enumerate(op.getFunctionType().getResults()),
+          [&rewriter, loc = op.getLoc()](auto p) -> Value {
+        auto [n, _] = p;
+        return rewriter.create<pcl::VarOp>(loc, ("out" + Twine(n)).str(), /*isOutput=*/true);
+      }
+      );
+      rewriter.create<func::ReturnOp>(op.getLoc(), outputValues);
+    }
+
+    rewriter.eraseOp(op);
+    {
+      OpBuilder::InsertionGuard guard(rewriter);
+      rewriter.setInsertionPointToEnd(&root->getRegion(0).front());
+      rewriter.insert(funcOp);
+    }
+
+    return success();
   }
 };
 
@@ -703,16 +885,15 @@ struct ConvertFreeFunctionCall : public OpConversionPattern<CallOp> {
 
 /// Removes any `function.def` operation that is not in the given set of used free functions.
 class RemoveFreeFunction : public OpConversionPattern<FuncDefOp> {
-  llvm::DenseSet<FuncDefOp> &funcs;
+  UsedFreeFunctions &funcs;
 
 public:
   RemoveFreeFunction(
-      MLIRContext *context, llvm::DenseSet<FuncDefOp> &usedFreeFunctions,
-      PatternBenefit patBenefit = 1
+      MLIRContext *context, UsedFreeFunctions &usedFreeFunctions, PatternBenefit patBenefit = 1
   )
       : OpConversionPattern(context, patBenefit), funcs(usedFreeFunctions) {}
   RemoveFreeFunction(
-      const TypeConverter &tc, MLIRContext *context, llvm::DenseSet<FuncDefOp> &usedFreeFunctions,
+      const TypeConverter &tc, MLIRContext *context, UsedFreeFunctions &usedFreeFunctions,
       PatternBenefit patBenefit = 1
   )
       : OpConversionPattern(tc, context, patBenefit), funcs(usedFreeFunctions) {}
@@ -728,121 +909,6 @@ public:
     return success();
   }
 };
-
-/// Populates the set with the patterns used in step 1 of the conversion.
-static void populateStep1ConversionPatterns(
-    const TypeConverter &tc, RewritePatternSet &patterns, MLIRContext *ctx, NonDetOpNames &names
-) {
-  patterns.add<
-      // clang-format off
-      ConvertConstantOp<FeltConstantOp>,
-      ConvertConstantOp<arith::ConstantOp>,
-      ConvertBinaryOp<AddFeltOp, pcl::AddOp>,
-      ConvertBinaryOp<SubFeltOp, pcl::SubOp>,
-      ConvertBinaryOp<MulFeltOp, pcl::MulOp>,
-      ConvertUnaryOp<NegFeltOp, pcl::NegOp>,
-      ConvertBinaryOp<AndBoolOp, pcl::AndOp>,
-      ConvertBinaryOp<OrBoolOp, pcl::OrOp>,
-      ConvertUnaryOp<NotBoolOp, pcl::NotOp>,
-      ConvertBoolXorOp,
-      RemoveIntToFeltOp,
-      ConvertCmpOp,
-      ConvertEmitEqualityOp,
-      // This pattern is currently disabled because asserts may represent predicates that are not actually part of the constraint system.
-      // ConvertAssertOp,
-      ConvertSelfMemberReadOpOfFelt,
-      ConvertSelfMemberReadOpOfSubcmp,
-      ConvertSubcmpMemberReadOp,
-      ConvertReturnOp,
-      ConvertFreeFuncReturnOp,
-      ConvertConstrainCall,
-      ConvertFreeFunctionCall
-      // clang-format on
-      >(tc, ctx);
-  patterns.add<ConvertNonDetOp>(tc, ctx, names);
-}
-
-/// Populates the set with the patterns used in step 2 of the conversion.
-static void populateStep2ConversionPatterns(
-    const TypeConverter &tc, RewritePatternSet &patterns, MLIRContext *ctx, ModuleOp root,
-    llvm::DenseSet<FuncDefOp> &usedFreeFunctions
-) {
-  patterns.add<ConvertStructDefOp>(tc, ctx, root);
-  patterns.add<RemoveFreeFunction>(tc, ctx, usedFreeFunctions);
-  patterns.add<ConvertFreeFunction>(tc, ctx, usedFreeFunctions, root);
-}
-
-/// Populates the set with the patterns used in step 3 of the conversion.
-static void populateStep3ConversionPatterns(
-    RewritePatternSet &patterns, MLIRContext *context, DupVarsReplacements &replacements
-) {
-  patterns.add<RemoveDuplicateVarOp>(context, replacements);
-  patterns.add<RemoveModuleOp>(context);
-}
-
-/// Returns true if the operation is legal wrt step 1.
-///
-/// An operation is legal in Step 1 if its located outside the
-/// `constrain` function of a struct.
-static bool isStep1LegalOp(Operation *op, llvm::DenseSet<FuncDefOp> &usedFreeFunctions) {
-  if (auto structDefOp = op->getParentOfType<StructDefOp>()) {
-    auto funcDefOp = op->getParentOfType<FuncDefOp>();
-    if (!funcDefOp) {
-      // Legal because is not within a function definition.
-      return true;
-    }
-    // Legal if the containing function definition is not the struct's constrain function.
-    return structDefOp.getConstrainFuncOp() != funcDefOp;
-  }
-
-  auto funcDefOp = op->getParentOfType<FuncDefOp>();
-  if (!funcDefOp) {
-    // Legal because is not within a struct nor a free function definition.
-    return true;
-  }
-
-  // If the op is inside a free function, check if the function is in the set.
-  // If the function is in the set, then the op is illegal.
-  return !usedFreeFunctions.contains(funcDefOp);
-}
-
-/// Populates the conversion target with the legallity expected of step 1 of the conversion.
-static void populateStep1ConversionTarget(
-    ConversionTarget &target, NonDetOpNames &names, llvm::DenseSet<FuncDefOp> &usedFreeFunctions
-) {
-  target.addLegalDialect<pcl::PCLDialect, func::FuncDialect>();
-  target.addLegalOp<ModuleOp, UnrealizedConversionCastOp>();
-  target.addDynamicallyLegalDialect<
-      BoolDialect, FeltDialect, CastDialect, arith::ArithDialect, ConstrainDialect,
-      array::ArrayDialect, global::GlobalDialect, include::IncludeDialect, pod::PODDialect,
-      polymorphic::PolymorphicDialect, ram::RAMDialect, smt::SMTDialect, string::StringDialect,
-      verif::VerifDialect, LLZKDialect, StructDialect, FunctionDialect, scf::SCFDialect>(
-      [&usedFreeFunctions](Operation *op) { return isStep1LegalOp(op, usedFreeFunctions); }
-  );
-  target.addLegalOp<FuncDefOp>();
-
-  target.addDynamicallyLegalOp<NonDetOp>([&names, &usedFreeFunctions](NonDetOp op) {
-    return isStep1LegalOp(op, usedFreeFunctions) && names.find(op) == names.end();
-  });
-}
-
-/// Populates the conversion target with the legallity expected of step 2 of the conversion.
-static void populateStep2ConversionTarget(ConversionTarget &target) {
-  target.addLegalDialect<pcl::PCLDialect>();
-  target.addLegalOp<ModuleOp, func::FuncOp, func::CallOp, func::ReturnOp>();
-  target.addIllegalOp<StructDefOp, FuncDefOp>();
-}
-
-/// Populates the conversion target with the legality expected of step 3 of the conversion.
-static void populateStep3ConversionTarget(
-    ConversionTarget &target, DupVarsReplacements &replacements, ModuleOp root
-) {
-  target.addLegalDialect<pcl::PCLDialect, func::FuncDialect>();
-  target.addDynamicallyLegalOp<pcl::VarOp>([&replacements](pcl::VarOp op) {
-    return replacements.find(op) == replacements.end();
-  });
-  target.addDynamicallyLegalOp<ModuleOp>([root](ModuleOp op) { return op == root; });
-}
 
 /// Type converter from LLZK types to PCL.
 struct PCLTypeConverter : public TypeConverter {
@@ -926,6 +992,307 @@ struct PCLTypeConverter : public TypeConverter {
   }
 };
 
+/// Base class for lowering modes.
+class BaseMode {
+  ModuleOp module;
+  NonDetOpNames names;
+  UsedFreeFunctions usedFreeFunctions;
+
+protected:
+  MLIRContext &getContext() { return *module.getContext(); }
+
+  ModuleOp getOperation() { return module; }
+
+  UsedFreeFunctions &getUsedFreeFunctions() { return usedFreeFunctions; }
+
+  /// Returns true if the operation is legal wrt step 1.
+  ///
+  /// An operation is legal in Step 1 if its located outside the
+  /// `constrain` function of a struct or a used free function.
+  bool isStep1LegalOp(Operation *op) {
+    if (auto structDefOp = op->getParentOfType<StructDefOp>()) {
+      auto funcDefOp = op->getParentOfType<FuncDefOp>();
+      // Legal if either:
+      //  - Not within a function definition.
+      //  - The containing function definition is not the struct's constrain function.
+      return !funcDefOp || structDefOp.getConstrainFuncOp() != funcDefOp;
+    }
+
+    auto funcDefOp = op->getParentOfType<FuncDefOp>();
+    // Legal if:
+    //  - Not within a free function definition.
+    //  - The free function is not in the set of used free functions.
+    return !funcDefOp || !usedFreeFunctions.contains(funcDefOp);
+  }
+
+  void populateStep1ConversionPatterns(const TypeConverter &tc, RewritePatternSet &patterns) {
+    patterns.add<
+        // clang-format off
+        ConvertConstantOp<FeltConstantOp>,
+        ConvertConstantOp<arith::ConstantOp>,
+        ConvertBinaryOp<AddFeltOp, pcl::AddOp>,
+        ConvertBinaryOp<SubFeltOp, pcl::SubOp>,
+        ConvertBinaryOp<MulFeltOp, pcl::MulOp>,
+        ConvertUnaryOp<NegFeltOp, pcl::NegOp>,
+        ConvertBinaryOp<AndBoolOp, pcl::AndOp>,
+        ConvertBinaryOp<OrBoolOp, pcl::OrOp>,
+        ConvertUnaryOp<NotBoolOp, pcl::NotOp>,
+        ConvertBoolXorOp,
+        RemoveIntToFeltOp,
+        ConvertCmpOp,
+        ConvertEmitEqualityOp,
+        // This pattern is currently disabled because asserts may represent predicates that are not actually part of the constraint system.
+        // ConvertAssertOp,
+        ConvertSelfMemberReadOpOfFelt,
+        ConvertSelfMemberReadOpOfSubcmp,
+        ConvertSubcmpMemberReadOp,
+        ConvertReturnOp,
+        ConvertFreeFuncReturnOp,
+        ConvertConstrainCall,
+        ConvertFreeFunctionCall
+        // clang-format on
+        >(tc, &getContext());
+    patterns.add<ConvertNonDetOp>(tc, &getContext(), names);
+  }
+
+  void populateStep1ConversionTarget(ConversionTarget &target) {
+    target.addLegalDialect<pcl::PCLDialect, func::FuncDialect>();
+    target.addLegalOp<ModuleOp, UnrealizedConversionCastOp>();
+    target.addDynamicallyLegalDialect<
+        BoolDialect, FeltDialect, CastDialect, arith::ArithDialect, ConstrainDialect,
+        array::ArrayDialect, global::GlobalDialect, include::IncludeDialect, pod::PODDialect,
+        polymorphic::PolymorphicDialect, ram::RAMDialect, smt::SMTDialect, string::StringDialect,
+        verif::VerifDialect, LLZKDialect, StructDialect, FunctionDialect, scf::SCFDialect>(
+        [this](Operation *op) { return isStep1LegalOp(op); }
+    );
+    target.addLegalOp<FuncDefOp>();
+
+    target.addDynamicallyLegalOp<NonDetOp>([this](NonDetOp op) {
+      return isStep1LegalOp(op) && names.find(op) == names.end();
+    });
+  }
+
+  virtual void
+  populateStep2ConversionPatterns(const TypeConverter &tc, RewritePatternSet &patterns) = 0;
+
+  void populateStep2ConversionTarget(ConversionTarget &target) {
+    target.addLegalDialect<pcl::PCLDialect>();
+    target.addLegalOp<ModuleOp, func::FuncOp, func::CallOp, func::ReturnOp>();
+    target.addIllegalOp<StructDefOp, FuncDefOp>();
+  }
+
+  /// Populates the set with the patterns used in step 3 of the conversion.
+  void
+  populateStep3ConversionPatterns(RewritePatternSet &patterns, DupVarsReplacements &replacements) {
+    patterns.add<RemoveDuplicateVarOp>(&getContext(), replacements);
+    patterns.add<RemoveModuleOp>(&getContext());
+  }
+
+  /// Populates the conversion target with the legality expected of step 3 of the conversion.
+  void populateStep3ConversionTarget(ConversionTarget &target, DupVarsReplacements &replacements) {
+    target.addLegalDialect<pcl::PCLDialect, func::FuncDialect>();
+    target.addDynamicallyLegalOp<pcl::VarOp>([&replacements](pcl::VarOp op) {
+      return replacements.find(op) == replacements.end();
+    });
+    target.addDynamicallyLegalOp<ModuleOp>([this](ModuleOp op) { return op == getOperation(); });
+  }
+
+  /// Collects all the `llzk.nondet` ops that need to be replaced.
+  ///
+  /// Only `llzk.nondet` ops of type `!felt.type` are considered.
+  void collectNonDetOpNames() {
+    uint64_t count = 0;
+    llvm::StringSet<> usedNames;
+
+    getOperation()->walk([&usedNames](MemberDefOp op) { usedNames.insert(op.getSymName()); });
+
+    getOperation()->walk([&count, this, &usedNames](NonDetOp op) {
+      if (!mlir::isa<FeltType>(op.getType())) {
+        return;
+      }
+      StringRef nameRef;
+      SmallVector<char, 25> nameSto;
+      do {
+        nameSto.clear();
+        Twine name = "_nondet_internal_var__" + Twine(count);
+        nameRef = name.toStringRef(nameSto);
+        count++;
+      } while (usedNames.contains(nameRef));
+      names.insert({op, StringAttr::get(&getContext(), nameRef)});
+    });
+  }
+
+  /// Step 1 converts the body of each struct to PCL operations.
+  ///
+  /// This conversion is performed before moving the body to a function because
+  /// that way the IR can access information about the members of the struct.
+  virtual LogicalResult runStep1() = 0;
+
+  /// Step 2 converts the struct to a function, moving the contents of the @constrain function
+  /// into the body of the new function.
+  LogicalResult runStep2() {
+    ConversionTarget target(getContext());
+    RewritePatternSet patterns(&getContext());
+    PCLTypeConverter tc;
+    populateStep2ConversionPatterns(tc, patterns);
+    populateStep2ConversionTarget(target);
+
+    return applyFullConversion(getOperation(), target, std::move(patterns));
+  }
+
+  /// Step 3 cleans up the IR removing unnecessary ops that may be left over by the previous steps.
+  ///
+  /// The cleanup operations are:
+  ///
+  /// - The conversion process may generate multiple copies of the same variable. This is fine since
+  /// `VarOp` implements `Pure`. However, for cleaniness we remove these duplicates now, replacing
+  /// all extra instances with the value that dominates everyone else.
+  ///
+  /// - Remove empty non-root module ops.
+  LogicalResult runStep3() {
+    DupVarsReplacements replacements = collectDupVarsReplacements();
+
+    ConversionTarget target(getContext());
+    RewritePatternSet patterns(&getContext());
+    populateStep3ConversionPatterns(patterns, replacements);
+    populateStep3ConversionTarget(target, replacements);
+
+    return applyFullConversion(getOperation(), target, std::move(patterns));
+  }
+
+  /// Collects all the vars that need to be replaced.
+  DupVarsReplacements collectDupVarsReplacements() {
+    DupVarsReplacements replacements;
+    getOperation()->walk([&replacements](func::FuncOp fn) {
+      DominanceInfo dom(fn);
+      llvm::StringMap<llvm::SmallVector<pcl::VarOp, 1>> varsByName;
+      fn->walk([&varsByName](pcl::VarOp var) { varsByName[var.getName()].push_back(var); });
+
+      for (auto &[_, vars] : varsByName) {
+        if (vars.empty()) {
+          continue;
+        }
+        std::stable_sort(vars.begin(), vars.end(), [&dom](pcl::VarOp lhs, pcl::VarOp rhs) {
+          return dom.dominates(lhs.getOperation(), rhs);
+        });
+        auto fst = vars[0];
+        for (auto other : ArrayRef(vars).drop_front()) {
+          replacements[other] = fst;
+        }
+      }
+    });
+    return replacements;
+  }
+
+public:
+  BaseMode(ModuleOp op) : module(op), usedFreeFunctions(op) { collectNonDetOpNames(); }
+
+  virtual ~BaseMode() = default;
+
+  LogicalResult lower() {
+    return failure(failed(runStep1()) || failed(runStep2()) || failed(runStep3()));
+  }
+};
+
+/// Full lowering mode.
+struct FullLoweringMode : public BaseMode {
+  using BaseMode::BaseMode;
+
+  /// Step 1 converts the body of each struct to PCL operations.
+  ///
+  /// This conversion is performed before moving the body to a function because
+  /// that way the IR can access information about the members of the struct.
+  LogicalResult runStep1() override {
+    ConversionTarget target(getContext());
+    RewritePatternSet patterns(&getContext());
+    PCLTypeConverter tc;
+    populateStep1ConversionPatterns(tc, patterns);
+    populateStep1ConversionTarget(target);
+
+    return applyFullConversion(getOperation(), target, std::move(patterns));
+  }
+
+  void
+  populateStep2ConversionPatterns(const TypeConverter &tc, RewritePatternSet &patterns) override {
+    patterns.add<ConvertStructDefOp>(tc, &getContext(), getOperation());
+    patterns.add<RemoveFreeFunction>(tc, &getContext(), getUsedFreeFunctions());
+    patterns.add<ConvertFreeFunction>(tc, &getContext(), getUsedFreeFunctions(), getOperation());
+  }
+};
+
+/// Stubbed lowering mode.
+struct StubbedLoweringMode : public BaseMode {
+  using BaseMode::BaseMode;
+
+private:
+  llvm::DenseSet<Operation *> legalizableOps;
+  llvm::DenseSet<FuncDefOp> stubs;
+
+  /// Run step 1 in analysis mode. Running the conversion this way will note
+  /// all the ops that will be converted if the conversion is actually applied.
+  LogicalResult analize() {
+    ConversionTarget target(getContext());
+    RewritePatternSet patterns(&getContext());
+    PCLTypeConverter tc;
+    populateStep1ConversionPatterns(tc, patterns);
+    populateStep1ConversionTarget(target);
+
+    return applyAnalysisConversion(
+        getOperation(), target, std::move(patterns), {.legalizableOps = &legalizableOps}
+    );
+  }
+
+  /// Checks what operations inside the used free functions are not in the legalizableOps set.
+  /// If any, the free function is removed from the set and marked as a stub.
+  /// Functions marked as stubs are lowered as such in step 2.
+  void checkAnalisysResult() {
+    for (auto funcOp : getUsedFreeFunctions()) {
+      funcOp->walk([&funcOp, this](Operation *op) {
+        // If the op is not in the set of ops that would get converted,
+        // mark the op as a stub and stop the search.
+        if (!legalizableOps.contains(op)) {
+          stubs.insert(funcOp);
+          return WalkResult::interrupt();
+        }
+        return WalkResult::advance();
+      });
+    }
+
+    // Remove all the stubs from the used functions set.
+    for (auto stub : stubs) {
+      getUsedFreeFunctions().erase(stub);
+    }
+  }
+
+  /// Step 1 converts the body of each struct to PCL operations.
+  ///
+  /// This conversion is performed before moving the body to a function because
+  /// that way the IR can access information about the members of the struct.
+  LogicalResult runStep1() override {
+    if (failed(analize())) {
+      return failure();
+    }
+    checkAnalisysResult();
+
+    // After the analysis, do the conversion as normal.
+    ConversionTarget target(getContext());
+    RewritePatternSet patterns(&getContext());
+    PCLTypeConverter tc;
+    populateStep1ConversionPatterns(tc, patterns);
+    populateStep1ConversionTarget(target);
+
+    return applyFullConversion(getOperation(), target, std::move(patterns));
+  }
+
+  void
+  populateStep2ConversionPatterns(const TypeConverter &tc, RewritePatternSet &patterns) override {
+    patterns.add<ConvertStructDefOp>(tc, &getContext(), getOperation());
+    patterns.add<RemoveFreeFunction>(tc, &getContext(), getUsedFreeFunctions());
+    patterns.add<ConvertFreeFunction>(tc, &getContext(), getUsedFreeFunctions(), getOperation());
+    patterns.add<ConvertFreeFunctionIntoStub>(tc, &getContext(), stubs, getOperation());
+  }
+};
+
 class PassImpl : public pcl::impl::PCLLoweringPassBase<PassImpl> {
   using Base = PCLLoweringPassBase<PassImpl>;
   using Base::Base;
@@ -989,183 +1356,27 @@ class PassImpl : public pcl::impl::PCLLoweringPassBase<PassImpl> {
     return toAPSInt(selectedField.get().prime());
   }
 
-  /// Collects all the member names that are already in use.
-  llvm::StringSet<> collectUsedNames() {
-    llvm::StringSet<> names;
-    getOperation()->walk([&names](MemberDefOp op) { names.insert(op.getSymName()); });
-    return names;
-  }
-
-  /// Collects all the `llzk.nondet` ops that need to be replaced.
-  ///
-  /// Only `llzk.nondet` ops of type `!felt.type` are considered.
-  NonDetOpNames collectNonDetOpNames() {
-    uint64_t count = 0;
-    auto usedNames = collectUsedNames();
-    NonDetOpNames names;
-    getOperation()->walk([&count, &names, &usedNames, this](NonDetOp op) {
-      if (!mlir::isa<FeltType>(op.getType())) {
-        return;
-      }
-      StringRef nameRef;
-      SmallVector<char, 25> nameSto;
-      do {
-        nameSto.clear();
-        Twine name = "_nondet_internal_var__" + Twine(count);
-        nameRef = name.toStringRef(nameSto);
-        count++;
-      } while (usedNames.contains(nameRef));
-      names.insert({op, StringAttr::get(&getContext(), nameRef)});
-    });
-    return names;
-  }
-
-  /// Collects all the vars that need to be replaced.
-  DupVarsReplacements collectDupVarsReplacements() {
-    DupVarsReplacements replacements;
-    getOperation()->walk([&replacements](func::FuncOp fn) {
-      DominanceInfo dom(fn);
-      llvm::StringMap<llvm::SmallVector<pcl::VarOp, 1>> varsByName;
-      fn->walk([&varsByName](pcl::VarOp var) { varsByName[var.getName()].push_back(var); });
-
-      for (auto &[_, vars] : varsByName) {
-        if (vars.empty()) {
-          continue;
-        }
-        std::stable_sort(vars.begin(), vars.end(), [&dom](pcl::VarOp lhs, pcl::VarOp rhs) {
-          return dom.dominates(lhs.getOperation(), rhs);
-        });
-        auto fst = vars[0];
-        for (auto other : ArrayRef(vars).drop_front()) {
-          replacements[other] = fst;
-        }
-      }
-    });
-    return replacements;
-  }
-
-  /// Collects the call-graph from the constrain functions (excluding the `@constrain` functions
-  /// themselves). Since we only care if a given `function.def` is part of the graph or not we
-  /// return the set of vertices.
-  llvm::DenseSet<FuncDefOp> collectConstrainCallGraph() {
-    llvm::SmallVector<FuncDefOp> WL;
-    llvm::DenseSet<FuncDefOp> funcs;
-    mlir::SymbolTableCollection tables;
-
-    // Fill the worklist with the initial set of functions.
-    getOperation()->walk([&WL, &funcs, &tables](StructDefOp structOp) {
-      auto f = structOp.getConstrainFuncOp();
-      if (!f) {
-        return;
-      }
-
-      f.walk([&WL, &funcs, &tables](CallOp callOp) {
-        auto callee = callOp.getCalleeTarget(tables);
-        // Ignore it if the lookup failed, is a @constrain function, or is already in the set.
-        if (failed(callee) || callee->get().isStructConstrain() || funcs.contains(callee->get())) {
-          return;
-        }
-        funcs.insert(callee->get());
-        WL.push_back(callee->get());
-      });
-    });
-
-    // Complete the graph using the worklist.
-    while (!WL.empty()) {
-      auto next = WL.back();
-      WL.pop_back();
-
-      next.walk([&WL, &funcs, &tables](CallOp op) {
-        auto callee = op.getCalleeTarget(tables);
-        if (failed(callee) || funcs.contains(callee->get())) {
-          return;
-        }
-        funcs.insert(callee->get());
-        WL.push_back(callee->get());
-      });
+  std::unique_ptr<BaseMode> createMode() {
+    switch (mode.getValue()) {
+    case pcl::LlzkToPclMode::Full:
+      return std::make_unique<FullLoweringMode>(getOperation());
+    case pcl::LlzkToPclMode::Stubbed:
+      return std::make_unique<StubbedLoweringMode>(getOperation());
     }
-
-    return funcs;
-  }
-
-  /// Step 1 converts the body of each struct to PCL operations.
-  ///
-  /// This conversion is performed before moving the body to a function because
-  /// that way the IR can access information about the members of the struct.
-  LogicalResult runStep1(llvm::DenseSet<FuncDefOp> &usedFreeFunctions) {
-    auto nonDetNames = collectNonDetOpNames();
-    ConversionTarget target(getContext());
-    RewritePatternSet patterns(&getContext());
-    PCLTypeConverter tc;
-    populateStep1ConversionPatterns(tc, patterns, &getContext(), nonDetNames);
-    populateStep1ConversionTarget(target, nonDetNames, usedFreeFunctions);
-
-    return applyFullConversion(getOperation(), target, std::move(patterns));
-  }
-
-  /// Step 2 converts the struct to a function, moving the contents of the @constrain function
-  /// into the body of the new function.
-  LogicalResult runStep2(llvm::DenseSet<FuncDefOp> &usedFreeFunctions) {
-    ConversionTarget target(getContext());
-    RewritePatternSet patterns(&getContext());
-    PCLTypeConverter tc;
-    populateStep2ConversionPatterns(tc, patterns, &getContext(), getOperation(), usedFreeFunctions);
-    populateStep2ConversionTarget(target);
-
-    return applyFullConversion(getOperation(), target, std::move(patterns));
-  }
-
-  /// Step 3 cleans up the IR removing unnecessary ops that may be left over by the previous steps.
-  ///
-  /// The cleanup operations are:
-  ///
-  /// - The conversion process may generate multiple copies of the same variable. This is fine since
-  /// `VarOp` implements `Pure`. However, for cleaniness we remove these duplicates now, replacing
-  /// all extra instances with the value that dominates everyone else.
-  ///
-  /// - Remove empty non-root module ops.
-  LogicalResult runStep3() {
-    DupVarsReplacements replacements = collectDupVarsReplacements();
-
-    ConversionTarget target(getContext());
-    RewritePatternSet patterns(&getContext());
-    populateStep3ConversionPatterns(patterns, &getContext(), replacements);
-    populateStep3ConversionTarget(target, replacements, getOperation());
-
-    return applyFullConversion(getOperation(), target, std::move(patterns));
+    llvm_unreachable("only two lowering modes");
   }
 
   void runOnOperation() override {
     // check PCLDialect is loaded.
     assert(getContext().getLoadedDialect<pcl::PCLDialect>() && "PCL dialect not loaded");
     auto prime = selectPrime();
-    if (failed(prime)) {
+    if (failed(prime) || failed(validateStructs())) {
       signalPassFailure();
       return;
     }
+    auto modeInstance = createMode();
 
-    if (failed(validateStructs())) {
-      signalPassFailure();
-      return;
-    }
-    auto usedFreeFunctions = collectConstrainCallGraph();
-
-    if (failed(runStep1(usedFreeFunctions))) {
-      signalPassFailure();
-      return;
-    }
-
-    if (failed(runStep2(usedFreeFunctions))) {
-      signalPassFailure();
-      return;
-    }
-
-    if (failed(runStep3())) {
-      signalPassFailure();
-      return;
-    }
-
-    if (failed(setPrime(*prime))) {
+    if (failed(modeInstance->lower()) || failed(setPrime(*prime))) {
       signalPassFailure();
       return;
     }

--- a/backends/pcl/lib/Conversion/PCLLoweringPass.cpp
+++ b/backends/pcl/lib/Conversion/PCLLoweringPass.cpp
@@ -108,7 +108,7 @@ template <typename Op> static std::string flatFullyQualifiedName(Op op) {
   o << fqn.getRootReference().getValue();
   if (!fqn.getNestedReferences().empty()) {
     o << sep;
-    llvm::interleave(fqn.getNestedReferences(), o, [&o](auto ref) { o << ref.getValue(); }, sep);
+    interleave(fqn.getNestedReferences(), o, [&o](auto ref) { o << ref.getValue(); }, sep);
   }
 
   return name;
@@ -123,7 +123,7 @@ template <typename Op> static std::string flatFullyQualifiedName(Op op) {
 ///
 /// For that reason, this mapping is missing the U in CRUD and we only insert during creation.
 class UsedFreeFunctions {
-  using M = llvm::DenseMap<Attribute, FuncDefOp>;
+  using M = DenseMap<Attribute, FuncDefOp>;
 
   /// Maps the FQN to the operation representing it.
   M funcs;
@@ -133,8 +133,8 @@ class UsedFreeFunctions {
 
   /// Convenience method for the construction of the mapping.
   void insertCallees(
-      llvm::SmallVectorImpl<FuncDefOp> &WL, mlir::SymbolTableCollection &tables, FuncDefOp f,
-      llvm::function_ref<bool(FuncDefOp)> P = nullptr
+      SmallVectorImpl<FuncDefOp> &WL, SymbolTableCollection &tables, FuncDefOp f,
+      function_ref<bool(FuncDefOp)> P = nullptr
   ) {
     f.walk([&WL, this, &tables, P](CallOp callOp) {
       auto calleeLookup = callOp.getCalleeTarget(tables);
@@ -158,8 +158,8 @@ public:
   /// themselves). Since we only care if a given `function.def` is part of the graph or not we
   /// return the set of vertices.
   UsedFreeFunctions(ModuleOp op) {
-    llvm::SmallVector<FuncDefOp> WL;
-    mlir::SymbolTableCollection tables;
+    SmallVector<FuncDefOp> WL;
+    SymbolTableCollection tables;
 
     // Fill the worklist with the initial set of functions.
     op->walk([&WL, this, &tables](StructDefOp structOp) {
@@ -228,12 +228,12 @@ template <typename Op> class ConstantOpValue {};
 
 template <> class ConstantOpValue<FeltConstantOp> {
 protected:
-  llvm::APInt getValue(FeltConstantOp op) const { return op.getValue().getValue(); }
+  APInt getValue(FeltConstantOp op) const { return op.getValue().getValue(); }
 };
 
 template <> class ConstantOpValue<arith::ConstantOp> {
 protected:
-  llvm::APInt getValue(arith::ConstantOp op) const {
+  APInt getValue(arith::ConstantOp op) const {
     // Extend width by 1 bit to avoid sign issues.
     auto value = mlir::cast<IntegerAttr>(op.getValue()).getValue();
     return value.zext(value.getBitWidth() + 1);
@@ -355,7 +355,7 @@ struct ConvertCmpOp : public OpConversionPattern<CmpOp> {
 class ConvertEmitEqualityOp : public OpConversionPattern<EmitEqualityOp> {
   bool isBool(Value v) const { return llvm::isa<pcl::BoolType>(v.getType()); }
 
-  std::optional<llvm::APInt> getConstAPInt(Value v) const {
+  std::optional<APInt> getConstAPInt(Value v) const {
     if (auto c = llvm::dyn_cast_if_present<pcl::ConstOp>(v.getDefiningOp())) {
       return c.getValueAPInt();
     }
@@ -545,7 +545,7 @@ struct ConvertFreeFuncReturnOp : public OpConversionPattern<ReturnOp> {
   }
 };
 
-using NonDetOpNames = llvm::DenseMap<NonDetOp, StringAttr>;
+using NonDetOpNames = DenseMap<NonDetOp, StringAttr>;
 
 /// Converts `llzk.nondet` ops into fresh pcl variables.
 class ConvertNonDetOp : public OpConversionPattern<NonDetOp> {
@@ -652,7 +652,7 @@ public:
 
   unsigned int baseOffset() const { return 1; }
 
-  llvm::SmallVector<Type> outputTypes(StructDefOp op) const {
+  SmallVector<Type> outputTypes(StructDefOp op) const {
     return mapOutputMembers<Type>(op, [ctx = op.getContext()](MemberDefOp) {
       return pcl::FeltType::get(ctx);
     });
@@ -687,8 +687,8 @@ public:
 
   unsigned int baseOffset() const { return 0; }
 
-  llvm::SmallVector<Type> outputTypes(FuncDefOp op) const {
-    return llvm::SmallVector<Type>(
+  SmallVector<Type> outputTypes(FuncDefOp op) const {
+    return SmallVector<Type>(
         op.getFunctionType().getNumResults(), pcl::FeltType::get(op.getContext())
     );
   }
@@ -706,17 +706,17 @@ public:
 };
 
 class ConvertFreeFunctionIntoStub : public OpConversionPattern<FuncDefOp> {
-  llvm::DenseSet<FuncDefOp> &stubs;
+  DenseSet<FuncDefOp> &stubs;
   ModuleOp root;
 
 public:
   ConvertFreeFunctionIntoStub(
-      MLIRContext *context, llvm::DenseSet<FuncDefOp> &stubFunctions, ModuleOp rootOp,
+      MLIRContext *context, DenseSet<FuncDefOp> &stubFunctions, ModuleOp rootOp,
       PatternBenefit patBenefit = 1
   )
       : OpConversionPattern(context, patBenefit), stubs(stubFunctions), root(rootOp) {}
   ConvertFreeFunctionIntoStub(
-      const TypeConverter &tc, MLIRContext *context, llvm::DenseSet<FuncDefOp> &stubFunctions,
+      const TypeConverter &tc, MLIRContext *context, DenseSet<FuncDefOp> &stubFunctions,
       ModuleOp rootOp, PatternBenefit patBenefit = 1
   )
       : OpConversionPattern(tc, context, patBenefit), stubs(stubFunctions), root(rootOp) {}
@@ -725,8 +725,8 @@ public:
 
   unsigned int baseOffset() const { return 0; }
 
-  llvm::SmallVector<Type> outputTypes(FuncDefOp op) const {
-    return llvm::SmallVector<Type>(
+  SmallVector<Type> outputTypes(FuncDefOp op) const {
+    return SmallVector<Type>(
         op.getFunctionType().getNumResults(), pcl::FeltType::get(op.getContext())
     );
   }
@@ -741,7 +741,7 @@ public:
     }
 
     SmallVector<Type> inputs(op.getNumArguments(), pcl::FeltType::get(rewriter.getContext()));
-    SmallVector<Type> outputs = llvm::SmallVector<Type>(
+    SmallVector<Type> outputs(
         op.getFunctionType().getNumResults(), pcl::FeltType::get(op.getContext())
     );
 
@@ -1102,7 +1102,7 @@ protected:
   /// Only `llzk.nondet` ops of type `!felt.type` are considered.
   void collectNonDetOpNames() {
     uint64_t count = 0;
-    llvm::StringSet<> usedNames;
+    StringSet<> usedNames;
 
     getOperation()->walk([&usedNames](MemberDefOp op) { usedNames.insert(op.getSymName()); });
 
@@ -1165,7 +1165,7 @@ protected:
     DupVarsReplacements replacements;
     getOperation()->walk([&replacements](func::FuncOp fn) {
       DominanceInfo dom(fn);
-      llvm::StringMap<llvm::SmallVector<pcl::VarOp, 1>> varsByName;
+      llvm::StringMap<SmallVector<pcl::VarOp, 1>> varsByName;
       fn->walk([&varsByName](pcl::VarOp var) { varsByName[var.getName()].push_back(var); });
 
       for (auto &[_, vars] : varsByName) {
@@ -1225,8 +1225,8 @@ struct StubbedLoweringMode : public BaseMode {
   using BaseMode::BaseMode;
 
 private:
-  llvm::DenseSet<Operation *> legalizableOps;
-  llvm::DenseSet<FuncDefOp> stubs;
+  DenseSet<Operation *> legalizableOps;
+  DenseSet<FuncDefOp> stubs;
 
   /// Run step 1 in analysis mode. Running the conversion this way will note
   /// all the ops that will be converted if the conversion is actually applied.
@@ -1316,24 +1316,21 @@ class PassImpl : public pcl::impl::PCLLoweringPassBase<PassImpl> {
   LogicalResult validateStructs() {
     return failure(
         getOperation()
-            ->walk([this](StructDefOp op) {
-      if (failed(validateStruct(op))) {
-        return WalkResult::interrupt();
-      }
-      return WalkResult::advance();
+            ->walk([this](StructDefOp op) -> WalkResult {
+      return validateStruct(op);
     }).wasInterrupted()
     );
   }
 
   // PCL programs require a module-level attribute specifying the prime.
-  LogicalResult setPrime(llvm::APInt &prime) {
+  LogicalResult setPrime(APInt &prime) {
     getOperation()->setAttrs(DictionaryAttr::get(&getContext()));
     getOperation()->setAttr("pcl.prime", pcl::PrimeAttr::get(&getContext(), prime));
 
     return success();
   }
 
-  FailureOr<llvm::APSInt> selectPrime() {
+  FailureOr<APSInt> selectPrime() {
     FieldSet fields;
     // If the collection reports that at least one FeltType did not declare the field and
     // the fields set is empty, then we raise an error.

--- a/backends/pcl/lib/Conversion/PCLLoweringPass.cpp
+++ b/backends/pcl/lib/Conversion/PCLLoweringPass.cpp
@@ -746,21 +746,9 @@ public:
     );
 
     auto funcOp = func::FuncOp::create(
-        op.getLoc(), flatFullyQualifiedName(op), rewriter.getFunctionType(inputs, outputs)
+        op.getLoc(), flatFullyQualifiedName(op), rewriter.getFunctionType(inputs, outputs),
+        {NamedAttribute("sym_visibility", rewriter.getStringAttr("private"))}
     );
-    auto *body = funcOp.addEntryBlock();
-    {
-      OpBuilder::InsertionGuard guard(rewriter);
-      rewriter.setInsertionPointToStart(body);
-      auto outputValues = llvm::map_to_vector(
-          llvm::enumerate(op.getFunctionType().getResults()),
-          [&rewriter, loc = op.getLoc()](auto p) -> Value {
-        auto [n, _] = p;
-        return rewriter.create<pcl::VarOp>(loc, ("out" + Twine(n)).str(), /*isOutput=*/true);
-      }
-      );
-      rewriter.create<func::ReturnOp>(op.getLoc(), outputValues);
-    }
 
     rewriter.eraseOp(op);
     {
@@ -1315,8 +1303,7 @@ class PassImpl : public pcl::impl::PCLLoweringPassBase<PassImpl> {
 
   LogicalResult validateStructs() {
     return failure(
-        getOperation()
-            ->walk([this](StructDefOp op) -> WalkResult {
+        getOperation()->walk([this](StructDefOp op) -> WalkResult {
       return validateStruct(op);
     }).wasInterrupted()
     );

--- a/backends/pcl/lib/Target/PCL.cpp
+++ b/backends/pcl/lib/Target/PCL.cpp
@@ -130,6 +130,9 @@ class ModuleEmitter {
   func::FuncOp func;
   SexpCache C;
 
+  /// Returns true if the function has no body.
+  bool isEmpty() { return func.isDeclaration(); }
+
   /// Helper for getting the inputs of the module.
   ArrayRef<BlockArgument> inputs() { return func.getBody().front().getArguments(); }
 
@@ -141,15 +144,33 @@ class ModuleEmitter {
     return {};
   }
 
+  /// Emits the s-expression that opens a module: `(begin-module <name>)`.
+  void emitModuleHeader(pcl::Sexps &S) {
+    S.push({S.atom("begin-module"), S.atom(func.getSymName())});
+  }
+
+  /// Emits the s-expression that closes a module: `(end-module)`.
+  void emitModuleFooter(pcl::Sexps &S) { S.push(S.sexp({S.atom("end-module")})); }
+
+  /// Emits an input declaration.
+  template <typename T> void emitInput(pcl::Sexps &S, T name) {
+    S.push({S.atom("input"), S.atom(std::move(name))});
+  }
+
+  /// Emits an output declaration.
+  template <typename T> void emitOutput(pcl::Sexps &S, T name) {
+    S.push({S.atom("output"), S.atom(std::move(name))});
+  }
+
   /// Emits the s-expressions in the prologue of the module.
   ///
   /// The prologue comprises the `(begin-module ...)` declaration followed by
   /// the input declarations.
   void prologue(pcl::Sexps &S) {
     LLVM_DEBUG({ llvm::dbgs() << "[ModuleEmitter] Emitting prologue\n"; });
-    S.push({S.atom("begin-module"), S.atom(func.getSymName())});
+    emitModuleHeader(S);
     for (auto arg : inputs()) {
-      S.push({S.atom("input"), S.atom(ns.get(arg, "in"))});
+      emitInput(S, ns.get(arg, "in"));
     }
   }
 
@@ -198,10 +219,10 @@ class ModuleEmitter {
           }
           S.push({S.atom("assert"), S.sexp({S.atom("="), S.atom(name), *vSexp})});
         }
-        S.push({S.atom("output"), S.atom(name)});
+        emitOutput(S, name);
       }
     }
-    S.push(S.sexp({S.atom("end-module")}));
+    emitModuleFooter(S);
     return success();
   }
 
@@ -397,6 +418,23 @@ class ModuleEmitter {
     }).wasInterrupted());
   }
 
+  /// Emits an empty body for a module representing a stubbed function.
+  LogicalResult emptyBody(pcl::Sexps &S) {
+    auto nInputs = func.getFunctionType().getNumInputs();
+    auto nOutputs = func.getFunctionType().getNumResults();
+
+    emitModuleHeader(S);
+    for (unsigned i = 0; i < nInputs; i++) {
+      emitInput(S, ("in" + Twine(i)).str());
+    }
+    for (unsigned i = 0; i < nOutputs; i++) {
+      emitOutput(S, ("out" + Twine(i)).str());
+    }
+    emitModuleFooter(S);
+
+    return success();
+  }
+
   /// Fills the environment with values that declare a name.
   ///
   /// Values that can declare names are the inputs and outputs of the module, `pcl.var` ops, and
@@ -444,6 +482,10 @@ public:
 
   /// Emits the complete sequence of s-expressions representing the module.
   LogicalResult emit(pcl::Sexps &S) {
+    if (isEmpty()) {
+      return emptyBody(S);
+    }
+
     fillNames();
     prologue(S);
     if (failed(body(S))) {

--- a/changelogs/unreleased/dani__pcl-stubbed-lowering-mode.yaml
+++ b/changelogs/unreleased/dani__pcl-stubbed-lowering-mode.yaml
@@ -1,0 +1,2 @@
+added:
+  - A mode to `-llzk-to-pcl` that lowers unsupported functions as stubs.

--- a/test/PCL/pcl_to_lisp.llzk
+++ b/test/PCL/pcl_to_lisp.llzk
@@ -89,3 +89,29 @@ module attributes {pcl.prime = #pcl.prime<7>} {
 // CHECK-NEXT: (assert (= out1 (+ 5 x)))
 // CHECK-NEXT: (output out1)
 // CHECK-NEXT: (end-module)
+
+// -----
+
+!F = !pcl.felt
+module attributes {pcl.prime = #pcl.prime<7>} {
+  func.func private @the_stub(!F) -> !F 
+  func.func @calls_stub(%arg0: !F) -> !F {
+    %0 = pcl.var "y" true 
+    %1 = call @the_stub(%arg0) : (!F) -> !F 
+    %2 = pcl.eq %0, %1 
+    pcl.assert %2
+    return %0 : !F
+  }
+}
+
+// CHECK-LABEL: (prime-number 7)
+// CHECK-NEXT: (begin-module the_stub)
+// CHECK-NEXT: (input in0)
+// CHECK-NEXT: (output out0)
+// CHECK-NEXT: (end-module)
+// CHECK-NEXT: (begin-module calls_stub)
+// CHECK-NEXT: (input in0)
+// CHECK-NEXT: (call [the_stub_call0_out0] the_stub [in0])
+// CHECK-NEXT: (assert (= y the_stub_call0_out0))
+// CHECK-NEXT: (output y)
+// CHECK-NEXT: (end-module)

--- a/test/Transforms/PCLLowering/pcl_lowering_pass_stubbed.llzk
+++ b/test/Transforms/PCLLowering/pcl_lowering_pass_stubbed.llzk
@@ -1,0 +1,208 @@
+// REQUIRES: with-pcl
+// RUN: llzk-opt -I %S -split-input-file -llzk-to-pcl=mode=stubbed -verify-diagnostics %s | FileCheck --enable-var-scope %s
+
+module attributes {llzk.lang} {
+  struct.def @ArithConst {
+    struct.member @out : !felt.type<"koalabear"> {llzk.pub}
+    function.def @compute() -> !struct.type<@ArithConst> {
+      %self = struct.new : <@ArithConst>
+      function.return %self : !struct.type<@ArithConst>
+    }
+    function.def @constrain(%self: !struct.type<@ArithConst>) {
+      %true = arith.constant true
+      %0 = struct.readm %self[@out] : !struct.type<@ArithConst>, !felt.type<"koalabear">
+      %1 = cast.tofelt %true : i1, !felt.type<"koalabear">
+      constrain.eq %0, %1 : !felt.type<"koalabear">, !felt.type<"koalabear">
+      function.return
+    }
+  }
+}
+
+// CHECK-LABEL:   func.func @ArithConst() -> !pcl.felt {
+// CHECK-NEXT:      %[[VAL_0:[0-9a-zA-Z_\.]+]] = pcl.const 1
+// CHECK-NEXT:      %[[VAL_1:[0-9a-zA-Z_\.]+]] = pcl.var "out" true
+// CHECK-NEXT:      %[[VAL_2:[0-9a-zA-Z_\.]+]] = pcl.eq %[[VAL_1]], %[[VAL_0]]
+// CHECK-NEXT:      pcl.assert %[[VAL_2]]
+// CHECK-NEXT:      return %[[VAL_1]] : !pcl.felt
+// CHECK-NEXT:    }
+
+// -----
+
+module attributes {llzk.lang} {
+  struct.def @Neg {
+    struct.member @out : !felt.type<"koalabear"> {llzk.pub}
+    function.def @compute(%in: !felt.type<"koalabear">) -> !struct.type<@Neg> {
+      %self = struct.new : <@Neg>
+      function.return %self : !struct.type<@Neg>
+    }
+    function.def @constrain(%self: !struct.type<@Neg>, %in: !felt.type<"koalabear">) {
+      %0 = felt.neg %in : !felt.type<"koalabear">
+      %1 = struct.readm %self[@out]: !struct.type<@Neg>, !felt.type<"koalabear">
+      constrain.eq %0, %1 : !felt.type<"koalabear">, !felt.type<"koalabear">
+      function.return
+    }
+  }
+}
+
+// CHECK-LABEL:   func.func @Neg(
+// CHECK-SAME:        %[[VAL_0:[0-9a-zA-Z_\.]+]]: !pcl.felt) -> !pcl.felt {
+// CHECK-NEXT:      %[[VAL_1:[0-9a-zA-Z_\.]+]] = pcl.neg %[[VAL_0]]
+// CHECK-NEXT:      %[[VAL_2:[0-9a-zA-Z_\.]+]] = pcl.var "out" true
+// CHECK-NEXT:      %[[VAL_3:[0-9a-zA-Z_\.]+]] = pcl.eq %[[VAL_1]], %[[VAL_2]]
+// CHECK-NEXT:      pcl.assert %[[VAL_3]]
+// CHECK-NEXT:      return %[[VAL_2]] : !pcl.felt
+// CHECK-NEXT:    }
+
+// -----
+
+module attributes {llzk.lang} {
+  struct.def @Lt {
+    function.def @compute(%in: !felt.type<"koalabear">) -> !struct.type<@Lt> {
+      %self = struct.new : <@Lt>
+      function.return %self : !struct.type<@Lt>
+    }
+    function.def @constrain(%self: !struct.type<@Lt>, %in: !felt.type<"koalabear">) {
+      %felt_const_1 = felt.const 1 : !felt.type<"koalabear">
+      %felt_const_65536 = felt.const 65536 : !felt.type<"koalabear">
+      %0 = bool.cmp lt(%in, %felt_const_65536) : !felt.type<"koalabear">, !felt.type<"koalabear">
+      %1 = cast.tofelt %0 : i1, !felt.type<"koalabear">
+      constrain.eq %1, %felt_const_1 : !felt.type<"koalabear">, !felt.type<"koalabear">
+      function.return
+    }
+  }
+}
+
+// CHECK-LABEL:   func.func @Lt(
+// CHECK-SAME:        %[[VAL_0:[0-9a-zA-Z_\.]+]]: !pcl.felt) {
+// CHECK-NEXT:      %[[CONST_1:[0-9a-zA-Z_\.]+]] = pcl.const 1
+// CHECK-NEXT:      %[[CONST_65536:[0-9a-zA-Z_\.]+]] = pcl.const 65536
+// CHECK-NEXT:      %[[VAL_1:[0-9a-zA-Z_\.]+]] = pcl.lt %[[VAL_0]], %[[CONST_65536]]
+// CHECK-NEXT:      %[[VAL_2:[0-9a-zA-Z_\.]+]] = pcl.asfelt %[[VAL_1]]
+// CHECK-NEXT:      %[[VAL_3:[0-9a-zA-Z_\.]+]] = pcl.eq %[[VAL_2]], %[[CONST_1]]
+// CHECK-NEXT:      pcl.assert %[[VAL_3]]
+// CHECK-NEXT:      return 
+// CHECK-NEXT:    }
+
+// -----
+
+module attributes {llzk.lang} {
+  struct.def @Lt {
+    function.def @compute(%in: !felt.type<"koalabear">) -> !struct.type<@Lt> {
+      %self = struct.new : <@Lt>
+      function.return %self : !struct.type<@Lt>
+    }
+    function.def @constrain(%self: !struct.type<@Lt>, %in: !felt.type<"koalabear">) {
+      %felt_const_1 = felt.const 1 : !felt.type<"koalabear">
+      %felt_const_65536 = felt.const 65536 : !felt.type<"koalabear">
+      %0 = bool.cmp lt(%in, %felt_const_65536) : !felt.type<"koalabear">, !felt.type<"koalabear">
+      %1 = cast.tofelt %0 : i1, !felt.type<"koalabear">
+      constrain.eq %1, %felt_const_1 : !felt.type<"koalabear">, !felt.type<"koalabear">
+      function.return
+    }
+  }
+  function.def @foo(%arg0: !felt.type<"koalabear">) -> !felt.type<"koalabear"> {
+    %true = arith.constant  1 : i1
+    %0 = scf.if %true -> (!felt.type<"koalabear">) {
+      %1 = felt.mul %arg0, %arg0 : !felt.type<"koalabear">, !felt.type<"koalabear">
+      scf.yield %1 : !felt.type<"koalabear">
+    } else {
+      scf.yield %arg0 : !felt.type<"koalabear">
+    }
+    function.return %0 : !felt.type<"koalabear">
+  }
+}
+
+// CHECK-LABEL:   func.func @Lt(
+// CHECK-SAME:        %[[VAL_0:[0-9a-zA-Z_\.]+]]: !pcl.felt) {
+// CHECK-NEXT:      %[[CONST_1:[0-9a-zA-Z_\.]+]] = pcl.const 1
+// CHECK-NEXT:      %[[CONST_65536:[0-9a-zA-Z_\.]+]] = pcl.const 65536
+// CHECK-NEXT:      %[[VAL_1:[0-9a-zA-Z_\.]+]] = pcl.lt %[[VAL_0]], %[[CONST_65536]]
+// CHECK-NEXT:      %[[VAL_2:[0-9a-zA-Z_\.]+]] = pcl.asfelt %[[VAL_1]]
+// CHECK-NEXT:      %[[VAL_3:[0-9a-zA-Z_\.]+]] = pcl.eq %[[VAL_2]], %[[CONST_1]]
+// CHECK-NEXT:      pcl.assert %[[VAL_3]]
+// CHECK-NEXT:      return 
+// CHECK-NEXT:    }
+// COM: Check that @foo is not lowered.
+// CHECK-NOT:  @foo
+
+// -----
+
+module attributes {llzk.lang} {
+  struct.def @Lt {
+    function.def @compute(%in: !felt.type<"koalabear">) -> !struct.type<@Lt> {
+      %self = struct.new : <@Lt>
+      function.return %self : !struct.type<@Lt>
+    }
+    function.def @constrain(%self: !struct.type<@Lt>, %in: !felt.type<"koalabear">) {
+      %felt_const_1 = felt.const 1 : !felt.type<"koalabear">
+      %felt_const_65536 = felt.const 65536 : !felt.type<"koalabear">
+      %inx2 = function.call @bar(%in) : (!felt.type<"koalabear">) -> !felt.type<"koalabear">
+      %0 = bool.cmp lt(%inx2, %felt_const_65536) : !felt.type<"koalabear">, !felt.type<"koalabear">
+      %1 = cast.tofelt %0 : i1, !felt.type<"koalabear">
+      constrain.eq %1, %felt_const_1 : !felt.type<"koalabear">, !felt.type<"koalabear">
+      function.return
+    }
+  }
+  function.def @bar(%arg0: !felt.type<"koalabear">) -> !felt.type<"koalabear"> {
+      %0 = felt.mul %arg0, %arg0 : !felt.type<"koalabear">, !felt.type<"koalabear">
+    function.return %0 : !felt.type<"koalabear">
+  }
+}
+
+// CHECK-LABEL:   func.func @Lt(
+// CHECK-SAME:        %[[VAL_0:[0-9a-zA-Z_\.]+]]: !pcl.felt) {
+// CHECK-NEXT:      %[[CONST_1:[0-9a-zA-Z_\.]+]] = pcl.const 1
+// CHECK-NEXT:      %[[CONST_65536:[0-9a-zA-Z_\.]+]] = pcl.const 65536
+// CHECK-NEXT:      %[[VAL_0x2:[0-9a-zA-Z_\.]+]] = call @bar(%[[VAL_0]]) : (!pcl.felt) -> !pcl.felt
+// CHECK-NEXT:      %[[VAL_1:[0-9a-zA-Z_\.]+]] = pcl.lt %[[VAL_0x2]], %[[CONST_65536]]
+// CHECK-NEXT:      %[[VAL_2:[0-9a-zA-Z_\.]+]] = pcl.asfelt %[[VAL_1]]
+// CHECK-NEXT:      %[[VAL_3:[0-9a-zA-Z_\.]+]] = pcl.eq %[[VAL_2]], %[[CONST_1]]
+// CHECK-NEXT:      pcl.assert %[[VAL_3]]
+// CHECK-NEXT:      return 
+// CHECK-NEXT:    }
+// CHECK-LABEL:  func.func @bar(
+// CHECK-SAME:        %[[VAL_0:[0-9a-zA-Z_\.]+]]: !pcl.felt) -> !pcl.felt {
+// CHECK-NEXT:      %[[VAL_1:[0-9a-zA-Z_\.]+]] = pcl.mul %[[VAL_0]], %[[VAL_0]]
+// CHECK-NEXT:      return %[[VAL_1]] : !pcl.felt
+// CHECK-NEXT:    }
+
+// -----
+
+module attributes {llzk.lang} {
+  struct.def @Lt {
+    function.def @compute(%in: !felt.type<"koalabear">) -> !struct.type<@Lt> {
+      %self = struct.new : <@Lt>
+      function.return %self : !struct.type<@Lt>
+    }
+    function.def @constrain(%self: !struct.type<@Lt>, %in: !felt.type<"koalabear">) attributes {function.allow_non_native_field_ops} {
+      %felt_const_1 = felt.const 1 : !felt.type<"koalabear">
+      %felt_const_65536 = felt.const 65536 : !felt.type<"koalabear">
+      %inx2 = function.call @bar(%in) : (!felt.type<"koalabear">) -> !felt.type<"koalabear">
+      %0 = bool.cmp lt(%inx2, %felt_const_65536) : !felt.type<"koalabear">, !felt.type<"koalabear">
+      %1 = cast.tofelt %0 : i1, !felt.type<"koalabear">
+      constrain.eq %1, %felt_const_1 : !felt.type<"koalabear">, !felt.type<"koalabear">
+      function.return
+    }
+  }
+  function.def @bar(%arg0: !felt.type<"koalabear">) -> !felt.type<"koalabear"> attributes {function.allow_non_native_field_ops} {
+      %0 = felt.bit_and %arg0, %arg0 : !felt.type<"koalabear">, !felt.type<"koalabear">
+    function.return %0 : !felt.type<"koalabear">
+  }
+}
+
+// CHECK-LABEL:   func.func @Lt(
+// CHECK-SAME:        %[[VAL_0:[0-9a-zA-Z_\.]+]]: !pcl.felt) {
+// CHECK-NEXT:      %[[CONST_1:[0-9a-zA-Z_\.]+]] = pcl.const 1
+// CHECK-NEXT:      %[[CONST_65536:[0-9a-zA-Z_\.]+]] = pcl.const 65536
+// CHECK-NEXT:      %[[VAL_0x2:[0-9a-zA-Z_\.]+]] = call @bar(%[[VAL_0]]) : (!pcl.felt) -> !pcl.felt
+// CHECK-NEXT:      %[[VAL_1:[0-9a-zA-Z_\.]+]] = pcl.lt %[[VAL_0x2]], %[[CONST_65536]]
+// CHECK-NEXT:      %[[VAL_2:[0-9a-zA-Z_\.]+]] = pcl.asfelt %[[VAL_1]]
+// CHECK-NEXT:      %[[VAL_3:[0-9a-zA-Z_\.]+]] = pcl.eq %[[VAL_2]], %[[CONST_1]]
+// CHECK-NEXT:      pcl.assert %[[VAL_3]]
+// CHECK-NEXT:      return 
+// CHECK-NEXT:    }
+// CHECK-LABEL:  func.func @bar(
+// CHECK-SAME:        %[[VAL_0:[0-9a-zA-Z_\.]+]]: !pcl.felt) -> !pcl.felt {
+// CHECK-NEXT:      %[[VAL_1:[0-9a-zA-Z_\.]+]] = pcl.var "out0" true
+// CHECK-NEXT:      return %[[VAL_1]] : !pcl.felt
+// CHECK-NEXT:    }

--- a/test/Transforms/PCLLowering/pcl_lowering_pass_stubbed.llzk
+++ b/test/Transforms/PCLLowering/pcl_lowering_pass_stubbed.llzk
@@ -122,7 +122,7 @@ module attributes {llzk.lang} {
 // CHECK-NEXT:      pcl.assert %[[VAL_3]]
 // CHECK-NEXT:      return 
 // CHECK-NEXT:    }
-// COM: Check that @foo is not lowered.
+// COM: Check that @foo is not lowered since it's dead wrt the constrain function.
 // CHECK-NOT:  @foo
 
 // -----
@@ -185,7 +185,7 @@ module attributes {llzk.lang} {
     }
   }
   function.def @bar(%arg0: !felt.type<"koalabear">) -> !felt.type<"koalabear"> attributes {function.allow_non_native_field_ops} {
-      %0 = felt.bit_and %arg0, %arg0 : !felt.type<"koalabear">, !felt.type<"koalabear">
+    %0 = felt.bit_and %arg0, %arg0 : !felt.type<"koalabear">, !felt.type<"koalabear">
     function.return %0 : !felt.type<"koalabear">
   }
 }
@@ -201,8 +201,4 @@ module attributes {llzk.lang} {
 // CHECK-NEXT:      pcl.assert %[[VAL_3]]
 // CHECK-NEXT:      return 
 // CHECK-NEXT:    }
-// CHECK-LABEL:  func.func @bar(
-// CHECK-SAME:        %[[VAL_0:[0-9a-zA-Z_\.]+]]: !pcl.felt) -> !pcl.felt {
-// CHECK-NEXT:      %[[VAL_1:[0-9a-zA-Z_\.]+]] = pcl.var "out0" true
-// CHECK-NEXT:      return %[[VAL_1]] : !pcl.felt
-// CHECK-NEXT:    }
+// CHECK-NEXT:    func.func private @bar(!pcl.felt) -> !pcl.felt 


### PR DESCRIPTION
Refactors the `-llzk-to-pcl` pass to add a stubbed mode. This mode will lower free functions with unsupported ops as stubs. This way we can still get the PCL representation of the supported parts of the circuit.

The default mode is still the full lowering and the stubbed mode needs to be manually enabled.
