### PR TITLE
Rename product fusion pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -274,7 +274,7 @@
     - "`llzk-poly-lowering-pass` - Lowers the degree of all polynomial equations to a specified maximum"
     - "`llzk-inline-structs` - Inline nested structs (i.e., subcomponents)"
     - "`llzk-compute-constrain-to-product` - Replace @compute/@constrain with @product function"
-    - "`llzk-fuse-product-loops` - Fuse matching witness/constraint loops in a @product function"
+    - "`llzk-fuse-product-control-flow` - Fuse matching compute/constrain control flow in a @product function"
   - Conversion:
     - "`llzk-to-pcl` - Rewrite constraints to be compatible with PCL constraints"
     - "`llzk-r1cs-lowering` - Rewrite constraints to be compatible with R1CS constraints"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -274,7 +274,7 @@
     - "`llzk-poly-lowering-pass` - Lowers the degree of all polynomial equations to a specified maximum"
     - "`llzk-inline-structs` - Inline nested structs (i.e., subcomponents)"
     - "`llzk-compute-constrain-to-product` - Replace @compute/@constrain with @product function"
-    - "`llzk-fuse-product-control-flow` - Fuse matching compute/constrain control flow in a @product function"
+    - "`llzk-fuse-product-loops` - Fuse matching witness/constraint loops in a @product function"
   - Conversion:
     - "`llzk-to-pcl` - Rewrite constraints to be compatible with PCL constraints"
     - "`llzk-r1cs-lowering` - Rewrite constraints to be compatible with R1CS constraints"

--- a/changelogs/unreleased/refactor__fuse-product-control-flow-name.yaml
+++ b/changelogs/unreleased/refactor__fuse-product-control-flow-name.yaml
@@ -1,0 +1,2 @@
+changed:
+  - Rename the product fusion pass and CLI to reflect control-flow fusion.

--- a/include/llzk/Transforms/LLZKTransformationPasses.td
+++ b/include/llzk/Transforms/LLZKTransformationPasses.td
@@ -112,8 +112,10 @@ def ComputeConstrainToProductPass
 }
 
 def FuseProductControlFlowPass : LLZKPass<"llzk-fuse-product-control-flow"> {
-  let summary = "Fuse matching compute/constrain control flow in a @product function";
-  let description = "Fuse matching witness/constraint loops in a @product function";
+  let summary =
+      "Fuse matching compute/constrain control flow in a @product function";
+  let description =
+      "Fuse matching witness/constraint loops in a @product function";
 }
 
 def EnforceNoMemberOverwritePass : LLZKPass<"llzk-enforce-no-overwrite"> {

--- a/include/llzk/Transforms/LLZKTransformationPasses.td
+++ b/include/llzk/Transforms/LLZKTransformationPasses.td
@@ -111,9 +111,9 @@ def ComputeConstrainToProductPass
                         "(default to `@Main`)">];
 }
 
-def FuseProductLoopsPass : LLZKPass<"llzk-fuse-product-loops"> {
-  let summary = "Fuse matching witness/constraint loops in a @product function";
-  let description = summary;
+def FuseProductControlFlowPass : LLZKPass<"llzk-fuse-product-control-flow"> {
+  let summary = "Fuse matching compute/constrain control flow in a @product function";
+  let description = "Fuse matching witness/constraint loops in a @product function";
 }
 
 def EnforceNoMemberOverwritePass : LLZKPass<"llzk-enforce-no-overwrite"> {

--- a/lib/Transforms/LLZKFuseProductControlFlowPass.cpp
+++ b/lib/Transforms/LLZKFuseProductControlFlowPass.cpp
@@ -1,4 +1,4 @@
-//===-- LLZKFuseProductLoopsPass.cpp ----------------------------*- C++ -*-===//
+//===-- LLZKFuseProductControlFlowPass.cpp ----------------------*- C++ -*-===//
 //
 // Part of the LLZK Project, under the Apache License v2.0.
 // See LICENSE.txt for license information.
@@ -8,7 +8,7 @@
 //===----------------------------------------------------------------------===//
 ///
 /// \file
-/// This file implements the `-llzk-fuse-product-loops` pass.
+/// This file implements the `-llzk-fuse-product-control-flow` pass.
 ///
 //===----------------------------------------------------------------------===//
 
@@ -205,8 +205,8 @@ static LogicalResult fuseMatchingLoopPairs(Region &body, MLIRContext *context) {
   return success();
 }
 
-class PassImpl : public llzk::impl::FuseProductLoopsPassBase<PassImpl> {
-  using Base = FuseProductLoopsPassBase<PassImpl>;
+class PassImpl : public llzk::impl::FuseProductControlFlowPassBase<PassImpl> {
+  using Base = FuseProductControlFlowPassBase<PassImpl>;
   using Base::Base;
 
   void runOnOperation() override {

--- a/lib/Transforms/LLZKFuseProductControlFlowPass.cpp
+++ b/lib/Transforms/LLZKFuseProductControlFlowPass.cpp
@@ -30,7 +30,7 @@
 
 // Include the generated base pass class definitions.
 namespace llzk {
-#define GEN_PASS_DEF_FUSEPRODUCTLOOPSPASS
+#define GEN_PASS_DEF_FUSEPRODUCTCONTROLFLOWPASS
 #include "llzk/Transforms/LLZKTransformationPasses.h.inc"
 } // namespace llzk
 

--- a/lib/Transforms/LLZKTransformationPassPipelines.cpp
+++ b/lib/Transforms/LLZKTransformationPassPipelines.cpp
@@ -96,7 +96,7 @@ void buildRemoveUnnecessaryOpsAndDefsPipeline(mlir::OpPassManager &pm) {
 
 void buildProductProgramPipeline(OpPassManager &pm) {
   pm.addPass(createComputeConstrainToProductPass());
-  pm.addPass(createFuseProductLoopsPass());
+  pm.addPass(createFuseProductControlFlowPass());
 }
 
 void buildFullStructInliningPipeline(OpPassManager &pm, const FullStructInliningConfig &cfg) {

--- a/test/Transforms/FuseProductControlFlow/fuse_outer.llzk
+++ b/test/Transforms/FuseProductControlFlow/fuse_outer.llzk
@@ -1,4 +1,4 @@
-// RUN: llzk-opt --llzk-compute-constrain-to-product="root-struct=A" --llzk-fuse-product-loops %s | FileCheck --enable-var-scope %s
+// RUN: llzk-opt --llzk-compute-constrain-to-product="root-struct=A" --llzk-fuse-product-control-flow %s | FileCheck --enable-var-scope %s
 
 module attributes {llzk.lang = "llzk"} {
     poly.template @TA {

--- a/test/Transforms/FuseProductControlFlow/fuse_outer_inner.llzk
+++ b/test/Transforms/FuseProductControlFlow/fuse_outer_inner.llzk
@@ -1,4 +1,4 @@
-// RUN: llzk-opt --llzk-compute-constrain-to-product="root-struct=A" --llzk-fuse-product-loops %s | FileCheck --enable-var-scope %s
+// RUN: llzk-opt --llzk-compute-constrain-to-product="root-struct=A" --llzk-fuse-product-control-flow %s | FileCheck --enable-var-scope %s
 // REQUIRES: raghav-cf-fusion
 
 module attributes {llzk.lang = "llzk"} {

--- a/test/Transforms/FuseProductControlFlow/fuse_single.llzk
+++ b/test/Transforms/FuseProductControlFlow/fuse_single.llzk
@@ -1,4 +1,4 @@
-// RUN: llzk-opt --llzk-compute-constrain-to-product="root-struct=A" --llzk-fuse-product-loops %s | FileCheck --enable-var-scope %s
+// RUN: llzk-opt --llzk-compute-constrain-to-product="root-struct=A" --llzk-fuse-product-control-flow %s | FileCheck --enable-var-scope %s
 
 module attributes {llzk.lang = "llzk"} {
     poly.template @TA {

--- a/test/Transforms/FuseProductControlFlow/fuse_with_compute_suffix.llzk
+++ b/test/Transforms/FuseProductControlFlow/fuse_with_compute_suffix.llzk
@@ -1,4 +1,4 @@
-// RUN: llzk-opt --llzk-compute-constrain-to-product="root-struct=A" --llzk-fuse-product-loops %s | FileCheck --enable-var-scope %s
+// RUN: llzk-opt --llzk-compute-constrain-to-product="root-struct=A" --llzk-fuse-product-control-flow %s | FileCheck --enable-var-scope %s
 
 module attributes {llzk.lang = "llzk"} {
     poly.template @TA {

--- a/test/Transforms/FuseProductControlFlow/no_fuse_inner.llzk
+++ b/test/Transforms/FuseProductControlFlow/no_fuse_inner.llzk
@@ -1,4 +1,4 @@
-// RUN: llzk-opt --llzk-compute-constrain-to-product="root-struct=A" --llzk-fuse-product-loops %s | FileCheck --enable-var-scope %s
+// RUN: llzk-opt --llzk-compute-constrain-to-product="root-struct=A" --llzk-fuse-product-control-flow %s | FileCheck --enable-var-scope %s
 // REQUIRES: raghav-cf-fusion
 
 module attributes {llzk.lang = "llzk"} {

--- a/test/Transforms/FuseProductControlFlow/no_fuse_region_mismatch.llzk
+++ b/test/Transforms/FuseProductControlFlow/no_fuse_region_mismatch.llzk
@@ -1,4 +1,4 @@
-// RUN: llzk-opt --llzk-compute-constrain-to-product="root-struct=A" --llzk-fuse-product-loops %s | FileCheck --enable-var-scope %s
+// RUN: llzk-opt --llzk-compute-constrain-to-product="root-struct=A" --llzk-fuse-product-control-flow %s | FileCheck --enable-var-scope %s
 // REQUIRES: raghav-cf-fusion
 
 module attributes {llzk.lang = "llzk"} {

--- a/test/Transforms/FuseProductControlFlow/no_fuse_region_mismatch.llzk
+++ b/test/Transforms/FuseProductControlFlow/no_fuse_region_mismatch.llzk
@@ -79,7 +79,6 @@ module attributes {llzk.lang = "llzk"} {
 // CHECK-NEXT:      array.write %[[VAL_10:[0-9a-zA-Z_\.]+]]{{\[}}%[[VAL_0]]] = %[[VAL_8]] : <@N x !felt.type>, !felt.type {product_source = "compute"}
 // CHECK-NEXT:    } {product_source = "compute"}
 // CHECK-NEXT:  } {product_source = "compute"}
-
 // CHECK: scf.if
 // CHECK-SAME:         %[[VAL_0:[0-9a-zA-Z_\.]+]] {
 // CHECK-NEXT:    scf.for %[[VAL_1:[0-9a-zA-Z_\.]+]] = %[[VAL_2:[0-9a-zA-Z_\.]+]] to %[[VAL_3:[0-9a-zA-Z_\.]+]] step %[[VAL_4:[0-9a-zA-Z_\.]+]] {

--- a/test/Transforms/FuseProductControlFlow/no_fuse_single.llzk
+++ b/test/Transforms/FuseProductControlFlow/no_fuse_single.llzk
@@ -1,4 +1,4 @@
-// RUN: llzk-opt --llzk-compute-constrain-to-product="root-struct=A" --llzk-fuse-product-loops %s | FileCheck --enable-var-scope %s
+// RUN: llzk-opt --llzk-compute-constrain-to-product="root-struct=A" --llzk-fuse-product-control-flow %s | FileCheck --enable-var-scope %s
 // REQUIRES: raghav-cf-fusion
 
 module attributes {llzk.lang = "llzk"} {

--- a/test/Transforms/FuseProductControlFlow/no_fuse_sink.llzk
+++ b/test/Transforms/FuseProductControlFlow/no_fuse_sink.llzk
@@ -1,4 +1,4 @@
-// RUN: llzk-opt --llzk-fuse-product-loops %s | FileCheck --enable-var-scope %s
+// RUN: llzk-opt --llzk-fuse-product-control-flow %s | FileCheck --enable-var-scope %s
 
 !F = !felt.type
 !A = !array.type<8 x !F>


### PR DESCRIPTION
## Summary

Rename the existing product loop-fusion pass, CLI option, implementation file, and test directory to `FuseProductControlFlowPass` / `llzk-fuse-product-control-flow`. This prerequisite PR handles the naming and registration portion of #484; the feature-specific control-flow implementation and full pass description remain in #484.

## Related work

Partially addresses #484, following the [maintainer-requested split](https://github.com/project-llzk/llzk-lib/pull/484#issuecomment-5272597271).

## Changes

- Rename the pass, CLI option, implementation file, and product-fusion test directory.
- Update generated pass declarations, registration, and existing fixture invocations.
- Update the TableGen summary to describe control-flow fusion while leaving the full pass `description` change in #484, as requested.
- Preserve existing fusion behavior and generated FileCheck output; this PR changes names and paths only.

## Testing

All required hosted CI checks pass for head `c81db5b7d30367db9eaeea65b20eb798dafd1d4d` on the [checks](https://github.com/project-llzk/llzk-lib/pull/684/checks). The existing product-fusion FileCheck fixtures pass with the renamed pass option, and their generated check blocks are unchanged.

## Submission checklist

- [ ] If I am an external contributor, this PR has a linked issue marked `approved`; otherwise, this does not apply.
- [x] I added or updated tests for all relevant behavior, or explained above why tests are not needed.
- [x] I updated the relevant TableGen or other documentation, or explained above why documentation is not needed.
- [x] I added a changelog entry describing user-visible changes.
- [x] I enabled **Allow edits from maintainers**.

## AI assistance

- [ ] No AI tools contributed to this PR.
- [x] AI tools contributed to this PR.

**Tools used:** Codex

**How the tools contributed:** Implementation and code review.

**How I verified the contribution:** Final changes reviewed.