### PR TITLE
Workaround for bug in upstream `remove-dead-values` pass

### DIFF
--- a/lib/Dialect/POD/Transforms/PodToScalarPass.cpp
+++ b/lib/Dialect/POD/Transforms/PodToScalarPass.cpp
@@ -6439,6 +6439,76 @@ static LogicalResult rejectRemainingRaggedNestedLeafUses(ModuleOp modOp) {
   return rejectRaggedNestedLeafBoundaryCrossings(modOp);
 }
 
+// In MLIR 20.1.8, the `RemoveDeadValues` pass did not handle branching regions as aggressively
+// as the `RunLivenessAnalysis` that it depends on. The liveness analysis can conclude an `scf.if`
+// branch is dead and thus its `scf.yield` operand is also dead. However, RDV does not end up
+// removing that branch but does remove the definition of the `scf.yield` operand, leaving a NULL
+// operand in the `scf.yield` op.
+//
+// The bug is fixed in MLIR 22.1.0 but there is a temporary solution: before running the RDV pass,
+// run "Sparse Conditional Constant Propagation" (SCCP) plus a custom pass that folds `scf.if` with
+// static conditions.
+//
+// Portions adapted from mlir/lib/Dialect/SCF/IR/SCF.cpp
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+namespace temp_fix_pre_mlir_22 {
+
+static void replaceOpWithRegion(
+    PatternRewriter &rewriter, Operation *op, Region &region, ValueRange blockArgs = {}
+) {
+  assert(llvm::hasSingleElement(region) && "expected single-region block");
+  Block *block = &region.front();
+  Operation *terminator = block->getTerminator();
+  ValueRange results = terminator->getOperands();
+  rewriter.inlineBlockBefore(block, op, blockArgs);
+  rewriter.replaceOp(op, results);
+  rewriter.eraseOp(terminator);
+}
+
+struct RemoveStaticCondition : public OpRewritePattern<scf::IfOp> {
+  using OpRewritePattern<scf::IfOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(scf::IfOp op, PatternRewriter &rewriter) const override {
+    BoolAttr condition;
+    if (!matchPattern(op.getCondition(), m_Constant(&condition))) {
+      return failure();
+    }
+    if (condition.getValue()) {
+      replaceOpWithRegion(rewriter, op, op.getThenRegion());
+    } else if (!op.getElseRegion().empty()) {
+      replaceOpWithRegion(rewriter, op, op.getElseRegion());
+    } else {
+      rewriter.eraseOp(op);
+    }
+    return success();
+  }
+};
+
+struct FlattenStaticIfPass : PassWrapper<FlattenStaticIfPass, OperationPass<ModuleOp>> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(FlattenStaticIfPass)
+
+  void runOnOperation() override {
+    RewritePatternSet patterns(&getContext());
+    patterns.add<RemoveStaticCondition>(&getContext());
+
+    if (failed(applyPatternsGreedily(
+            getOperation(), std::move(patterns),
+            GreedyRewriteConfig {.fold = false, .cseConstants = false}
+        ))) {
+      signalPassFailure();
+    }
+  }
+};
+
+void add(OpPassManager &pm) {
+  pm.addPass(createSCCPPass());
+  pm.addPass(std::make_unique<FlattenStaticIfPass>());
+}
+
+} // namespace temp_fix_pre_mlir_22
+
 /// Pass driver for the full POD-to-scalar lowering pipeline described above.
 class PassImpl : public llzk::pod::impl::PodToScalarPassBase<PassImpl> {
   using Base = PodToScalarPassBase<PassImpl>;
@@ -6465,6 +6535,7 @@ class PassImpl : public llzk::pod::impl::PodToScalarPassBase<PassImpl> {
             .allocatorOpName = NewPodOp::getOperationName().str()
         }
     ));
+    temp_fix_pre_mlir_22::add(cleanupPM);
     cleanupPM.addPass(createRemoveDeadValuesWorkaroundPass());
 
     size_t podAllocWeight = podAllocScalarizationWeight(module);

--- a/test/Transforms/PodToScalar/array_of_pod_creation.llzk
+++ b/test/Transforms/PodToScalar/array_of_pod_creation.llzk
@@ -46,12 +46,12 @@ module attributes {llzk.lang} {
 // CHECK: #[[$M:[0-9a-zA-Z_\.]+]] = affine_map<()[s0] -> (s0 + 1)>
 // CHECK-LABEL: module attributes {llzk.lang} {
 // CHECK-NEXT:    function.def @materialized(%[[VAL_0:[0-9a-zA-Z_\.]+]]: index) -> !array.type<2,#[[$M]] x index> {
+// CHECK-NEXT:      %[[VAL_5:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:      %[[VAL_4:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
 // CHECK-NEXT:      %[[VAL_1:[0-9a-zA-Z_\.]+]] = array.new{(){{\[}}%[[VAL_0]]]} : <#[[$M]] x index>
 // CHECK-NEXT:      %[[VAL_2:[0-9a-zA-Z_\.]+]] = array.new{(){{\[}}%[[VAL_0]]]} : <#[[$M]] x index>
 // CHECK-NEXT:      %[[VAL_3:[0-9a-zA-Z_\.]+]] = array.new{(){{\[}}%[[VAL_0]]]} : <2,#[[$M]] x index>
-// CHECK-NEXT:      %[[VAL_4:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
 // CHECK-NEXT:      array.insert %[[VAL_3]]{{\[}}%[[VAL_4]]] = %[[VAL_1]] : <2,#[[$M]] x index>, <#[[$M]] x index>
-// CHECK-NEXT:      %[[VAL_5:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
 // CHECK-NEXT:      array.insert %[[VAL_3]]{{\[}}%[[VAL_5]]] = %[[VAL_2]] : <2,#[[$M]] x index>, <#[[$M]] x index>
 // CHECK-NEXT:      function.return %[[VAL_3]] : !array.type<2,#[[$M]] x index>
 // CHECK-NEXT:    }

--- a/test/Transforms/PodToScalar/array_of_pod_reads_writes.llzk
+++ b/test/Transforms/PodToScalar/array_of_pod_reads_writes.llzk
@@ -39,12 +39,12 @@ module attributes {llzk.lang} {
 // CHECK-SAME:    %[[VAL_2:[0-9a-zA-Z_\.]+]]: index, %[[VAL_3:[0-9a-zA-Z_\.]+]]: index,
 // CHECK-SAME:    %[[VAL_4:[0-9a-zA-Z_\.]+]]: index, %[[VAL_5:[0-9a-zA-Z_\.]+]]: index
 // CHECK-SAME:    ) -> !array.type<2,3 x index> {
+// CHECK-NEXT:      %[[VAL_10:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:      %[[VAL_9:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
 // CHECK-NEXT:      %[[VAL_6:[0-9a-zA-Z_\.]+]] = array.new %[[VAL_0]], %[[VAL_1]], %[[VAL_2]] : <3 x index>
 // CHECK-NEXT:      %[[VAL_7:[0-9a-zA-Z_\.]+]] = array.new %[[VAL_3]], %[[VAL_4]], %[[VAL_5]] : <3 x index>
 // CHECK-NEXT:      %[[VAL_8:[0-9a-zA-Z_\.]+]] = array.new  : <2,3 x index>
-// CHECK-NEXT:      %[[VAL_9:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
 // CHECK-NEXT:      array.insert %[[VAL_8]]{{\[}}%[[VAL_9]]] = %[[VAL_6]] : <2,3 x index>, <3 x index>
-// CHECK-NEXT:      %[[VAL_10:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
 // CHECK-NEXT:      array.insert %[[VAL_8]]{{\[}}%[[VAL_10]]] = %[[VAL_7]] : <2,3 x index>, <3 x index>
 // CHECK-NEXT:      function.return %[[VAL_8]] : !array.type<2,3 x index>
 // CHECK-NEXT:    }
@@ -90,9 +90,9 @@ module attributes {llzk.lang} {
 }
 // CHECK-LABEL: module attributes {llzk.lang} {
 // CHECK-NEXT:    function.def @read_item(%[[ARR:[0-9a-zA-Z_\.]+]]: !array.type<2 x index>, %[[IDX:[0-9a-zA-Z_\.]+]]: index) -> index {
+// CHECK-NEXT:      %[[C1:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
 // CHECK-NEXT:      %[[C0:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
 // CHECK-NEXT:      %[[UNUSED0:[0-9a-zA-Z_\.]+]] = array.read %[[ARR]]{{\[}}%[[C0]]] : <2 x index>, index
-// CHECK-NEXT:      %[[C1:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
 // CHECK-NEXT:      %[[UNUSED1:[0-9a-zA-Z_\.]+]] = array.read %[[ARR]]{{\[}}%[[C1]]] : <2 x index>, index
 // CHECK-NEXT:      %[[SEL:[0-9a-zA-Z_\.]+]] = array.read %[[ARR]]{{\[}}%[[IDX]]] : <2 x index>, index
 // CHECK-NEXT:      function.return %[[SEL]] : index
@@ -303,48 +303,40 @@ module attributes {llzk.lang} {
 }
 // CHECK-LABEL: module attributes {llzk.lang} {
 // CHECK-NEXT:    function.def @for_external_pod_array(%[[VAL_0:[0-9a-zA-Z_\.]+]]: !array.type<2 x index>, %[[VAL_1:[0-9a-zA-Z_\.]+]]: index) -> index {
-// CHECK-NEXT:      %[[VAL_2:[0-9a-zA-Z_\.]+]] = array.new  : <2 x index>
-// CHECK-NEXT:      %[[VAL_3:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:      %[[VAL_4:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_0]]{{\[}}%[[VAL_3]]] : <2 x index>, index
-// CHECK-NEXT:      %[[VAL_5:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:      array.write %[[VAL_2]]{{\[}}%[[VAL_5]]] = %[[VAL_4]] : <2 x index>, index
-// CHECK-NEXT:      %[[VAL_6:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:      %[[VAL_7:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_0]]{{\[}}%[[VAL_6]]] : <2 x index>, index
-// CHECK-NEXT:      %[[VAL_8:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:      array.write %[[VAL_2]]{{\[}}%[[VAL_8]]] = %[[VAL_7]] : <2 x index>, index
-// CHECK-NEXT:      %[[VAL_9:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:      %[[VAL_10:[0-9a-zA-Z_\.]+]] = arith.constant 2 : index
-// CHECK-NEXT:      %[[VAL_11:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:      %[[VAL_12:[0-9a-zA-Z_\.]+]] = scf.for %[[VAL_13:[0-9a-zA-Z_\.]+]] = %[[VAL_11]] to %[[VAL_10]] step %[[VAL_9]] iter_args(%[[VAL_14:[0-9a-zA-Z_\.]+]] = %[[VAL_2]]) -> (!array.type<2 x index>) {
-// CHECK-NEXT:        %[[VAL_15:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_14]]{{\[}}%[[VAL_1]]] : <2 x index>, index
-// CHECK-NEXT:        scf.yield %[[VAL_14]] : !array.type<2 x index>
+// CHECK-NEXT:      %[[VAL_2:[0-9a-zA-Z_\.]+]] = arith.constant 2 : index
+// CHECK-NEXT:      %[[VAL_3:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:      %[[VAL_4:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:      %[[VAL_5:[0-9a-zA-Z_\.]+]] = array.new  : <2 x index>
+// CHECK-NEXT:      %[[VAL_6:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_0]]{{\[}}%[[VAL_4]]] : <2 x index>, index
+// CHECK-NEXT:      array.write %[[VAL_5]]{{\[}}%[[VAL_4]]] = %[[VAL_6]] : <2 x index>, index
+// CHECK-NEXT:      %[[VAL_7:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_0]]{{\[}}%[[VAL_3]]] : <2 x index>, index
+// CHECK-NEXT:      array.write %[[VAL_5]]{{\[}}%[[VAL_3]]] = %[[VAL_7]] : <2 x index>, index
+// CHECK-NEXT:      %[[VAL_8:[0-9a-zA-Z_\.]+]] = scf.for %[[VAL_9:[0-9a-zA-Z_\.]+]] = %[[VAL_4]] to %[[VAL_2]] step %[[VAL_3]] iter_args(%[[VAL_10:[0-9a-zA-Z_\.]+]] = %[[VAL_5]]) -> (!array.type<2 x index>) {
+// CHECK-NEXT:        %[[VAL_11:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_10]]{{\[}}%[[VAL_1]]] : <2 x index>, index
+// CHECK-NEXT:        scf.yield %[[VAL_10]] : !array.type<2 x index>
 // CHECK-NEXT:      }
-// CHECK-NEXT:      %[[VAL_16:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_12]]{{\[}}%[[VAL_1]]] : <2 x index>, index
-// CHECK-NEXT:      function.return %[[VAL_16]] : index
+// CHECK-NEXT:      %[[VAL_12:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_8]]{{\[}}%[[VAL_1]]] : <2 x index>, index
+// CHECK-NEXT:      function.return %[[VAL_12]] : index
 // CHECK-NEXT:    }
-// CHECK-NEXT:    function.def @while_external_pod_array(%[[VAL_17:[0-9a-zA-Z_\.]+]]: !array.type<2 x index>, %[[VAL_18:[0-9a-zA-Z_\.]+]]: index, %[[VAL_19:[0-9a-zA-Z_\.]+]]: index) -> index {
-// CHECK-NEXT:      %[[VAL_20:[0-9a-zA-Z_\.]+]] = array.new  : <2 x index>
-// CHECK-NEXT:      %[[VAL_21:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:      %[[VAL_22:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_17]]{{\[}}%[[VAL_21]]] : <2 x index>, index
-// CHECK-NEXT:      %[[VAL_23:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:      array.write %[[VAL_20]]{{\[}}%[[VAL_23]]] = %[[VAL_22]] : <2 x index>, index
-// CHECK-NEXT:      %[[VAL_24:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:      %[[VAL_25:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_17]]{{\[}}%[[VAL_24]]] : <2 x index>, index
-// CHECK-NEXT:      %[[VAL_26:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:      array.write %[[VAL_20]]{{\[}}%[[VAL_26]]] = %[[VAL_25]] : <2 x index>, index
-// CHECK-NEXT:      %[[VAL_27:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:      %[[VAL_28:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:      %[[VAL_29:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_30:[0-9a-zA-Z_\.]+]] = %[[VAL_18]], %[[VAL_31:[0-9a-zA-Z_\.]+]] = %[[VAL_20]]) : (index, !array.type<2 x index>) -> (index, !array.type<2 x index>) {
-// CHECK-NEXT:        %[[VAL_32:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_31]]{{\[}}%[[VAL_19]]] : <2 x index>, index
-// CHECK-NEXT:        %[[VAL_33:[0-9a-zA-Z_\.]+]] = arith.cmpi sgt, %[[VAL_30]], %[[VAL_28]] : index
-// CHECK-NEXT:        scf.condition(%[[VAL_33]]) %[[VAL_30]], %[[VAL_31]] : index, !array.type<2 x index>
+// CHECK-NEXT:    function.def @while_external_pod_array(%[[VAL_13:[0-9a-zA-Z_\.]+]]: !array.type<2 x index>, %[[VAL_14:[0-9a-zA-Z_\.]+]]: index, %[[VAL_15:[0-9a-zA-Z_\.]+]]: index) -> index {
+// CHECK-NEXT:      %[[VAL_16:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:      %[[VAL_17:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:      %[[VAL_18:[0-9a-zA-Z_\.]+]] = array.new  : <2 x index>
+// CHECK-NEXT:      %[[VAL_19:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_13]]{{\[}}%[[VAL_17]]] : <2 x index>, index
+// CHECK-NEXT:      array.write %[[VAL_18]]{{\[}}%[[VAL_17]]] = %[[VAL_19]] : <2 x index>, index
+// CHECK-NEXT:      %[[VAL_20:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_13]]{{\[}}%[[VAL_16]]] : <2 x index>, index
+// CHECK-NEXT:      array.write %[[VAL_18]]{{\[}}%[[VAL_16]]] = %[[VAL_20]] : <2 x index>, index
+// CHECK-NEXT:      %[[VAL_21:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_22:[0-9a-zA-Z_\.]+]] = %[[VAL_14]], %[[VAL_23:[0-9a-zA-Z_\.]+]] = %[[VAL_18]]) : (index, !array.type<2 x index>) -> (index, !array.type<2 x index>) {
+// CHECK-NEXT:        %[[VAL_24:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_23]]{{\[}}%[[VAL_15]]] : <2 x index>, index
+// CHECK-NEXT:        %[[VAL_25:[0-9a-zA-Z_\.]+]] = arith.cmpi sgt, %[[VAL_22]], %[[VAL_17]] : index
+// CHECK-NEXT:        scf.condition(%[[VAL_25]]) %[[VAL_22]], %[[VAL_23]] : index, !array.type<2 x index>
 // CHECK-NEXT:      } do {
-// CHECK-NEXT:      ^bb0(%[[VAL_34:[0-9a-zA-Z_\.]+]]: index, %[[VAL_35:[0-9a-zA-Z_\.]+]]: !array.type<2 x index>):
-// CHECK-NEXT:        %[[VAL_36:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_35]]{{\[}}%[[VAL_19]]] : <2 x index>, index
-// CHECK-NEXT:        %[[VAL_37:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_34]], %[[VAL_27]] : index
-// CHECK-NEXT:        scf.yield %[[VAL_37]], %[[VAL_35]] : index, !array.type<2 x index>
+// CHECK-NEXT:      ^bb0(%[[VAL_26:[0-9a-zA-Z_\.]+]]: index, %[[VAL_27:[0-9a-zA-Z_\.]+]]: !array.type<2 x index>):
+// CHECK-NEXT:        %[[VAL_28:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_27]]{{\[}}%[[VAL_15]]] : <2 x index>, index
+// CHECK-NEXT:        %[[VAL_29:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_26]], %[[VAL_16]] : index
+// CHECK-NEXT:        scf.yield %[[VAL_29]], %[[VAL_27]] : index, !array.type<2 x index>
 // CHECK-NEXT:      }
-// CHECK-NEXT:      %[[VAL_38:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_29]]#1{{\[}}%[[VAL_19]]] : <2 x index>, index
-// CHECK-NEXT:      function.return %[[VAL_38]] : index
+// CHECK-NEXT:      %[[VAL_30:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_21]]#1{{\[}}%[[VAL_15]]] : <2 x index>, index
+// CHECK-NEXT:      function.return %[[VAL_30]] : index
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }

--- a/test/Transforms/PodToScalar/bool_quantifiers.llzk
+++ b/test/Transforms/PodToScalar/bool_quantifiers.llzk
@@ -17,9 +17,9 @@ module attributes {llzk.lang} {
 // CHECK-SAME:    %[[VAL_1:[0-9a-zA-Z_\.]+]]: !array.type<2 x index>,
 // CHECK-SAME:    %[[VAL_2:[0-9a-zA-Z_\.]+]]: index
 // CHECK-SAME:    ) -> i1 attributes {function.allow_non_native_field_ops} {
-// CHECK-NEXT:      %[[VAL_3:[0-9a-zA-Z_\.]+]] = arith.constant true
-// CHECK-NEXT:      %[[VAL_4:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
 // CHECK-NEXT:      %[[VAL_5:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:      %[[VAL_4:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:      %[[VAL_3:[0-9a-zA-Z_\.]+]] = arith.constant true
 // CHECK-NEXT:      %[[VAL_6:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_0]], %[[VAL_5]] : <2 x index>
 // CHECK-NEXT:      %[[VAL_7:[0-9a-zA-Z_\.]+]] = scf.for %[[VAL_8:[0-9a-zA-Z_\.]+]] = %[[VAL_5]] to %[[VAL_6]] step %[[VAL_4]] iter_args(%[[VAL_9:[0-9a-zA-Z_\.]+]] = %[[VAL_3]]) -> (i1) {
 // CHECK-NEXT:        %[[VAL_10:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_0]]{{\[}}%[[VAL_8]]] : <2 x index>, index
@@ -54,28 +54,24 @@ module attributes {llzk.lang} {
 // CHECK-SAME:    %[[VAL_2:[0-9a-zA-Z_\.]+]]: index,
 // CHECK-SAME:    %[[VAL_3:[0-9a-zA-Z_\.]+]]: index
 // CHECK-SAME:    ) -> i1 attributes {function.allow_non_native_field_ops} {
-// CHECK-NEXT:      %[[VAL_4:[0-9a-zA-Z_\.]+]] = arith.constant false
+// CHECK-NEXT:      %[[VAL_4:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
 // CHECK-NEXT:      %[[VAL_5:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:      %[[VAL_6:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:      %[[VAL_6:[0-9a-zA-Z_\.]+]] = arith.constant false
 // CHECK-NEXT:      %[[VAL_7:[0-9a-zA-Z_\.]+]] = array.new  : <2 x index>
-// CHECK-NEXT:      %[[VAL_8:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:      array.write %[[VAL_7]]{{\[}}%[[VAL_8]]] = %[[VAL_0]] : <2 x index>, index
-// CHECK-NEXT:      %[[VAL_9:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:      array.write %[[VAL_7]]{{\[}}%[[VAL_9]]] = %[[VAL_2]] : <2 x index>, index
-// CHECK-NEXT:      %[[VAL_10:[0-9a-zA-Z_\.]+]] = array.new  : <2 x index>
-// CHECK-NEXT:      %[[VAL_11:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:      array.write %[[VAL_10]]{{\[}}%[[VAL_11]]] = %[[VAL_1]] : <2 x index>, index
-// CHECK-NEXT:      %[[VAL_12:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:      array.write %[[VAL_10]]{{\[}}%[[VAL_12]]] = %[[VAL_3]] : <2 x index>, index
-// CHECK-NEXT:      %[[VAL_13:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_7]], %[[VAL_6]] : <2 x index>
-// CHECK-NEXT:      %[[VAL_14:[0-9a-zA-Z_\.]+]] = scf.for %[[VAL_15:[0-9a-zA-Z_\.]+]] = %[[VAL_6]] to %[[VAL_13]] step %[[VAL_5]] iter_args(%[[VAL_16:[0-9a-zA-Z_\.]+]] = %[[VAL_4]]) -> (i1) {
-// CHECK-NEXT:        %[[VAL_17:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_7]]{{\[}}%[[VAL_15]]] : <2 x index>, index
-// CHECK-NEXT:        %[[VAL_18:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_10]]{{\[}}%[[VAL_15]]] : <2 x index>, index
-// CHECK-NEXT:        %[[VAL_19:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_18]], %[[VAL_3]] : index
-// CHECK-NEXT:        %[[VAL_20:[0-9a-zA-Z_\.]+]] = bool.or %[[VAL_16]], %[[VAL_19]] : i1, i1
-// CHECK-NEXT:        scf.yield %[[VAL_20]] : i1
+// CHECK-NEXT:      array.write %[[VAL_7]]{{\[}}%[[VAL_4]]] = %[[VAL_0]] : <2 x index>, index
+// CHECK-NEXT:      array.write %[[VAL_7]]{{\[}}%[[VAL_5]]] = %[[VAL_2]] : <2 x index>, index
+// CHECK-NEXT:      %[[VAL_8:[0-9a-zA-Z_\.]+]] = array.new  : <2 x index>
+// CHECK-NEXT:      array.write %[[VAL_8]]{{\[}}%[[VAL_4]]] = %[[VAL_1]] : <2 x index>, index
+// CHECK-NEXT:      array.write %[[VAL_8]]{{\[}}%[[VAL_5]]] = %[[VAL_3]] : <2 x index>, index
+// CHECK-NEXT:      %[[VAL_9:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_7]], %[[VAL_4]] : <2 x index>
+// CHECK-NEXT:      %[[VAL_10:[0-9a-zA-Z_\.]+]] = scf.for %[[VAL_11:[0-9a-zA-Z_\.]+]] = %[[VAL_4]] to %[[VAL_9]] step %[[VAL_5]] iter_args(%[[VAL_12:[0-9a-zA-Z_\.]+]] = %[[VAL_6]]) -> (i1) {
+// CHECK-NEXT:        %[[VAL_13:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_7]]{{\[}}%[[VAL_11]]] : <2 x index>, index
+// CHECK-NEXT:        %[[VAL_14:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_8]]{{\[}}%[[VAL_11]]] : <2 x index>, index
+// CHECK-NEXT:        %[[VAL_15:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_14]], %[[VAL_3]] : index
+// CHECK-NEXT:        %[[VAL_16:[0-9a-zA-Z_\.]+]] = bool.or %[[VAL_12]], %[[VAL_15]] : i1, i1
+// CHECK-NEXT:        scf.yield %[[VAL_16]] : i1
 // CHECK-NEXT:      }
-// CHECK-NEXT:      function.return %[[VAL_14]] : i1
+// CHECK-NEXT:      function.return %[[VAL_10]] : i1
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
 // -----
@@ -160,10 +156,10 @@ module attributes {llzk.lang} {
 }
 // CHECK-LABEL: module attributes {llzk.lang} {
 // CHECK-NEXT:    function.def @forall_exists_dynamic_row_with_payload(%[[VAL_0:[0-9a-zA-Z_\.]+]]: !array.type<?,? x index>, %[[VAL_1:[0-9a-zA-Z_\.]+]]: !array.type<?,? x index>, %[[VAL_2:[0-9a-zA-Z_\.]+]]: !array.type<?,? x none>, %[[VAL_3:[0-9a-zA-Z_\.]+]]: index) -> i1 attributes {function.allow_non_native_field_ops} {
-// CHECK-NEXT:      %[[VAL_4:[0-9a-zA-Z_\.]+]] = arith.constant false
-// CHECK-NEXT:      %[[VAL_5:[0-9a-zA-Z_\.]+]] = arith.constant true
-// CHECK-NEXT:      %[[VAL_6:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
 // CHECK-NEXT:      %[[VAL_7:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:      %[[VAL_6:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:      %[[VAL_5:[0-9a-zA-Z_\.]+]] = arith.constant true
+// CHECK-NEXT:      %[[VAL_4:[0-9a-zA-Z_\.]+]] = arith.constant false
 // CHECK-NEXT:      %[[VAL_8:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_2]], %[[VAL_7]] : <?,? x none>
 // CHECK-NEXT:      %[[VAL_9:[0-9a-zA-Z_\.]+]] = scf.for %[[VAL_10:[0-9a-zA-Z_\.]+]] = %[[VAL_7]] to %[[VAL_8]] step %[[VAL_6]] iter_args(%[[VAL_11:[0-9a-zA-Z_\.]+]] = %[[VAL_5]]) -> (i1) {
 // CHECK-NEXT:        %[[VAL_12:[0-9a-zA-Z_\.]+]] = array.extract %[[VAL_0]]{{\[}}%[[VAL_10]]] : <?,? x index>

--- a/test/Transforms/PodToScalar/circom_decomp_prod.llzk
+++ b/test/Transforms/PodToScalar/circom_decomp_prod.llzk
@@ -285,35 +285,35 @@ module attributes {llzk.lang = "circom", llzk.main = !struct.type<@DecomposeProd
 // CHECK-NEXT:    struct.def @Num2Bits_0 {
 // CHECK-NEXT:      struct.member @out : !array.type<8 x !felt.type<"bn128">> {llzk.pub}
 // CHECK-NEXT:      function.def @compute(%[[VAL_0:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) -> !struct.type<@Num2Bits_0> attributes {function.allow_non_native_field_ops, function.allow_witness} {
-// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = felt.const  8 : <"bn128">
 // CHECK-NEXT:        %[[VAL_2:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
-// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = felt.const  8 : <"bn128">
+// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
 // CHECK-NEXT:        %[[VAL_4:[0-9a-zA-Z_\.]+]] = struct.new : <@Num2Bits_0>
 // CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = llzk.nondet : !array.type<8 x !felt.type<"bn128">>
 // CHECK-NEXT:        %[[VAL_6:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_7:[0-9a-zA-Z_\.]+]] = %[[VAL_2]]) : (!felt.type<"bn128">) -> !felt.type<"bn128"> {
-// CHECK-NEXT:          %[[VAL_8:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_7]], %[[VAL_3]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_8:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_7]], %[[VAL_1]]) : !felt.type<"bn128">, !felt.type<"bn128">
 // CHECK-NEXT:          scf.condition(%[[VAL_8]]) %[[VAL_7]] : !felt.type<"bn128">
 // CHECK-NEXT:        } do {
 // CHECK-NEXT:        ^bb0(%[[VAL_9:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
 // CHECK-NEXT:          %[[VAL_10:[0-9a-zA-Z_\.]+]] = felt.shr %[[VAL_0]], %[[VAL_9]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_11:[0-9a-zA-Z_\.]+]] = felt.bit_and %[[VAL_10]], %[[VAL_1]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_11:[0-9a-zA-Z_\.]+]] = felt.bit_and %[[VAL_10]], %[[VAL_3]] : !felt.type<"bn128">, !felt.type<"bn128">
 // CHECK-NEXT:          %[[VAL_12:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_9]] : !felt.type<"bn128">
 // CHECK-NEXT:          array.write %[[VAL_5]]{{\[}}%[[VAL_12]]] = %[[VAL_11]] : <8 x !felt.type<"bn128">>, !felt.type<"bn128">
 // CHECK-NEXT:          %[[VAL_13:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_9]] : !felt.type<"bn128">
 // CHECK-NEXT:          %[[VAL_14:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_5]]{{\[}}%[[VAL_13]]] : <8 x !felt.type<"bn128">>, !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_15:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_9]], %[[VAL_1]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_15:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_9]], %[[VAL_3]] : !felt.type<"bn128">, !felt.type<"bn128">
 // CHECK-NEXT:          scf.yield %[[VAL_15]] : !felt.type<"bn128">
 // CHECK-NEXT:        }
 // CHECK-NEXT:        struct.writem %[[VAL_4]][@out] = %[[VAL_5]] : <@Num2Bits_0>, !array.type<8 x !felt.type<"bn128">>
 // CHECK-NEXT:        function.return %[[VAL_4]] : !struct.type<@Num2Bits_0>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_16:[0-9a-zA-Z_\.]+]]: !struct.type<@Num2Bits_0>, %[[VAL_17:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
-// CHECK-NEXT:        %[[VAL_18:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
+// CHECK-NEXT:        %[[VAL_18:[0-9a-zA-Z_\.]+]] = felt.const  8 : <"bn128">
 // CHECK-NEXT:        %[[VAL_19:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
-// CHECK-NEXT:        %[[VAL_20:[0-9a-zA-Z_\.]+]] = felt.const  8 : <"bn128">
+// CHECK-NEXT:        %[[VAL_20:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
 // CHECK-NEXT:        %[[VAL_21:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_16]][@out] : <@Num2Bits_0>, !array.type<8 x !felt.type<"bn128">>
 // CHECK-NEXT:        %[[VAL_22:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_23:[0-9a-zA-Z_\.]+]] = %[[VAL_19]], %[[VAL_24:[0-9a-zA-Z_\.]+]] = %[[VAL_19]]) : (!felt.type<"bn128">, !felt.type<"bn128">) -> (!felt.type<"bn128">, !felt.type<"bn128">) {
-// CHECK-NEXT:          %[[VAL_25:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_24]], %[[VAL_20]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_25:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_24]], %[[VAL_18]]) : !felt.type<"bn128">, !felt.type<"bn128">
 // CHECK-NEXT:          scf.condition(%[[VAL_25]]) %[[VAL_23]], %[[VAL_24]] : !felt.type<"bn128">, !felt.type<"bn128">
 // CHECK-NEXT:        } do {
 // CHECK-NEXT:        ^bb0(%[[VAL_26:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">, %[[VAL_27:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
@@ -321,14 +321,14 @@ module attributes {llzk.lang = "circom", llzk.main = !struct.type<@DecomposeProd
 // CHECK-NEXT:          %[[VAL_29:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_21]]{{\[}}%[[VAL_28]]] : <8 x !felt.type<"bn128">>, !felt.type<"bn128">
 // CHECK-NEXT:          %[[VAL_30:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_27]] : !felt.type<"bn128">
 // CHECK-NEXT:          %[[VAL_31:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_21]]{{\[}}%[[VAL_30]]] : <8 x !felt.type<"bn128">>, !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_32:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_31]], %[[VAL_18]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_32:[0-9a-zA-Z_\.]+]] = felt.sub %[[VAL_31]], %[[VAL_20]] : !felt.type<"bn128">, !felt.type<"bn128">
 // CHECK-NEXT:          %[[VAL_33:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_29]], %[[VAL_32]] : !felt.type<"bn128">, !felt.type<"bn128">
 // CHECK-NEXT:          constrain.eq %[[VAL_33]], %[[VAL_19]] : !felt.type<"bn128">, !felt.type<"bn128">
 // CHECK-NEXT:          %[[VAL_34:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_27]] : !felt.type<"bn128">
 // CHECK-NEXT:          %[[VAL_35:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_21]]{{\[}}%[[VAL_34]]] : <8 x !felt.type<"bn128">>, !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_36:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_35]], %[[VAL_18]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_36:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_35]], %[[VAL_20]] : !felt.type<"bn128">, !felt.type<"bn128">
 // CHECK-NEXT:          %[[VAL_37:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_26]], %[[VAL_36]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_38:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_27]], %[[VAL_18]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_38:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_27]], %[[VAL_20]] : !felt.type<"bn128">, !felt.type<"bn128">
 // CHECK-NEXT:          scf.yield %[[VAL_37]], %[[VAL_38]] : !felt.type<"bn128">, !felt.type<"bn128">
 // CHECK-NEXT:        }
 // CHECK-NEXT:        constrain.eq %[[VAL_22]]#0, %[[VAL_17]] : !felt.type<"bn128">, !felt.type<"bn128">
@@ -344,36 +344,36 @@ module attributes {llzk.lang = "circom", llzk.main = !struct.type<@DecomposeProd
 // CHECK-NEXT:      struct.member @bits_high : !array.type<8 x !struct.type<@Num2Bits_0>>
 // CHECK-NEXT:      struct.member @bits_high$inputs_in : !array.type<8 x !felt.type<"bn128">>
 // CHECK-NEXT:      function.def @compute(%[[VAL_39:[0-9a-zA-Z_\.]+]]: !array.type<8 x !felt.type<"bn128">>, %[[VAL_40:[0-9a-zA-Z_\.]+]]: !array.type<8 x !felt.type<"bn128">>) -> !struct.type<@DecomposeProduct_1> attributes {function.allow_non_native_field_ops, function.allow_witness} {
-// CHECK-NEXT:        %[[VAL_41:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:        %[[VAL_42:[0-9a-zA-Z_\.]+]] = felt.const  256 : <"bn128">
-// CHECK-NEXT:        %[[VAL_43:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:        %[[VAL_41:[0-9a-zA-Z_\.]+]] = arith.constant 8 : index
+// CHECK-NEXT:        %[[VAL_42:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_43:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
 // CHECK-NEXT:        %[[VAL_44:[0-9a-zA-Z_\.]+]] = felt.const  8 : <"bn128">
-// CHECK-NEXT:        %[[VAL_45:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:        %[[VAL_46:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[VAL_47:[0-9a-zA-Z_\.]+]] = arith.constant 8 : index
+// CHECK-NEXT:        %[[VAL_45:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:        %[[VAL_46:[0-9a-zA-Z_\.]+]] = felt.const  256 : <"bn128">
+// CHECK-NEXT:        %[[VAL_47:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
 // CHECK-NEXT:        %[[VAL_48:[0-9a-zA-Z_\.]+]] = struct.new : <@DecomposeProduct_1>
 // CHECK-NEXT:        %[[VAL_49:[0-9a-zA-Z_\.]+]] = llzk.nondet : !array.type<8 x !felt.type<"bn128">>
 // CHECK-NEXT:        %[[VAL_50:[0-9a-zA-Z_\.]+]] = llzk.nondet : !array.type<8 x !felt.type<"bn128">>
 // CHECK-NEXT:        %[[VAL_51:[0-9a-zA-Z_\.]+]] = llzk.nondet : !array.type<8 x !felt.type<"bn128">>
 // CHECK-NEXT:        %[[VAL_52:[0-9a-zA-Z_\.]+]] = array.new  : <8 x index>
 // CHECK-NEXT:        %[[VAL_53:[0-9a-zA-Z_\.]+]] = array.new  : <8 x !struct.type<@Num2Bits_0>>
-// CHECK-NEXT:        scf.for %[[VAL_54:[0-9a-zA-Z_\.]+]] = %[[VAL_46]] to %[[VAL_47]] step %[[VAL_45]] {
+// CHECK-NEXT:        scf.for %[[VAL_54:[0-9a-zA-Z_\.]+]] = %[[VAL_42]] to %[[VAL_41]] step %[[VAL_43]] {
 // CHECK-NEXT:          %[[VAL_55:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_52]]{{\[}}%[[VAL_54]]] : <8 x index>, index
 // CHECK-NEXT:          %[[VAL_56:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_53]]{{\[}}%[[VAL_54]]] : <8 x !struct.type<@Num2Bits_0>>, !struct.type<@Num2Bits_0>
-// CHECK-NEXT:          array.write %[[VAL_52]]{{\[}}%[[VAL_54]]] = %[[VAL_45]] : <8 x index>, index
+// CHECK-NEXT:          array.write %[[VAL_52]]{{\[}}%[[VAL_54]]] = %[[VAL_43]] : <8 x index>, index
 // CHECK-NEXT:          array.write %[[VAL_53]]{{\[}}%[[VAL_54]]] = %[[VAL_56]] : <8 x !struct.type<@Num2Bits_0>>, !struct.type<@Num2Bits_0>
 // CHECK-NEXT:        }
 // CHECK-NEXT:        %[[VAL_57:[0-9a-zA-Z_\.]+]] = array.new  : <8 x !felt.type<"bn128">>
 // CHECK-NEXT:        %[[VAL_58:[0-9a-zA-Z_\.]+]] = array.new  : <8 x index>
 // CHECK-NEXT:        %[[VAL_59:[0-9a-zA-Z_\.]+]] = array.new  : <8 x !struct.type<@Num2Bits_0>>
-// CHECK-NEXT:        scf.for %[[VAL_60:[0-9a-zA-Z_\.]+]] = %[[VAL_46]] to %[[VAL_47]] step %[[VAL_45]] {
+// CHECK-NEXT:        scf.for %[[VAL_60:[0-9a-zA-Z_\.]+]] = %[[VAL_42]] to %[[VAL_41]] step %[[VAL_43]] {
 // CHECK-NEXT:          %[[VAL_61:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_58]]{{\[}}%[[VAL_60]]] : <8 x index>, index
 // CHECK-NEXT:          %[[VAL_62:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_59]]{{\[}}%[[VAL_60]]] : <8 x !struct.type<@Num2Bits_0>>, !struct.type<@Num2Bits_0>
-// CHECK-NEXT:          array.write %[[VAL_58]]{{\[}}%[[VAL_60]]] = %[[VAL_45]] : <8 x index>, index
+// CHECK-NEXT:          array.write %[[VAL_58]]{{\[}}%[[VAL_60]]] = %[[VAL_43]] : <8 x index>, index
 // CHECK-NEXT:          array.write %[[VAL_59]]{{\[}}%[[VAL_60]]] = %[[VAL_62]] : <8 x !struct.type<@Num2Bits_0>>, !struct.type<@Num2Bits_0>
 // CHECK-NEXT:        }
 // CHECK-NEXT:        %[[VAL_63:[0-9a-zA-Z_\.]+]] = array.new  : <8 x !felt.type<"bn128">>
-// CHECK-NEXT:        %[[VAL_64:[0-9a-zA-Z_\.]+]]:3 = scf.while (%[[VAL_65:[0-9a-zA-Z_\.]+]] = %[[VAL_63]], %[[VAL_66:[0-9a-zA-Z_\.]+]] = %[[VAL_57]], %[[VAL_67:[0-9a-zA-Z_\.]+]] = %[[VAL_43]]) : (!array.type<8 x !felt.type<"bn128">>, !array.type<8 x !felt.type<"bn128">>, !felt.type<"bn128">) -> (!array.type<8 x !felt.type<"bn128">>, !array.type<8 x !felt.type<"bn128">>, !felt.type<"bn128">) {
+// CHECK-NEXT:        %[[VAL_64:[0-9a-zA-Z_\.]+]]:3 = scf.while (%[[VAL_65:[0-9a-zA-Z_\.]+]] = %[[VAL_63]], %[[VAL_66:[0-9a-zA-Z_\.]+]] = %[[VAL_57]], %[[VAL_67:[0-9a-zA-Z_\.]+]] = %[[VAL_45]]) : (!array.type<8 x !felt.type<"bn128">>, !array.type<8 x !felt.type<"bn128">>, !felt.type<"bn128">) -> (!array.type<8 x !felt.type<"bn128">>, !array.type<8 x !felt.type<"bn128">>, !felt.type<"bn128">) {
 // CHECK-NEXT:          %[[VAL_68:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_67]], %[[VAL_44]]) : !felt.type<"bn128">, !felt.type<"bn128">
 // CHECK-NEXT:          scf.condition(%[[VAL_68]]) %[[VAL_65]], %[[VAL_66]], %[[VAL_67]] : !array.type<8 x !felt.type<"bn128">>, !array.type<8 x !felt.type<"bn128">>, !felt.type<"bn128">
 // CHECK-NEXT:        } do {
@@ -387,7 +387,7 @@ module attributes {llzk.lang = "circom", llzk.main = !struct.type<@DecomposeProd
 // CHECK-NEXT:          array.write %[[VAL_49]]{{\[}}%[[VAL_77]]] = %[[VAL_76]] : <8 x !felt.type<"bn128">>, !felt.type<"bn128">
 // CHECK-NEXT:          %[[VAL_78:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_71]] : !felt.type<"bn128">
 // CHECK-NEXT:          %[[VAL_79:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_49]]{{\[}}%[[VAL_78]]] : <8 x !felt.type<"bn128">>, !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_80:[0-9a-zA-Z_\.]+]] = felt.umod %[[VAL_79]], %[[VAL_42]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_80:[0-9a-zA-Z_\.]+]] = felt.umod %[[VAL_79]], %[[VAL_46]] : !felt.type<"bn128">, !felt.type<"bn128">
 // CHECK-NEXT:          %[[VAL_81:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_71]] : !felt.type<"bn128">
 // CHECK-NEXT:          array.write %[[VAL_50]]{{\[}}%[[VAL_81]]] = %[[VAL_80]] : <8 x !felt.type<"bn128">>, !felt.type<"bn128">
 // CHECK-NEXT:          %[[VAL_82:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_71]] : !felt.type<"bn128">
@@ -399,8 +399,8 @@ module attributes {llzk.lang = "circom", llzk.main = !struct.type<@DecomposeProd
 // CHECK-NEXT:          %[[VAL_87:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_71]] : !felt.type<"bn128">
 // CHECK-NEXT:          %[[VAL_88:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_52]]{{\[}}%[[VAL_87]]] : <8 x index>, index
 // CHECK-NEXT:          %[[VAL_89:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_53]]{{\[}}%[[VAL_87]]] : <8 x !struct.type<@Num2Bits_0>>, !struct.type<@Num2Bits_0>
-// CHECK-NEXT:          %[[VAL_90:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_88]], %[[VAL_45]] : index
-// CHECK-NEXT:          %[[VAL_91:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_90]], %[[VAL_46]] : index
+// CHECK-NEXT:          %[[VAL_90:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_88]], %[[VAL_43]] : index
+// CHECK-NEXT:          %[[VAL_91:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_90]], %[[VAL_42]] : index
 // CHECK-NEXT:          scf.if %[[VAL_91]] {
 // CHECK-NEXT:            %[[VAL_92:[0-9a-zA-Z_\.]+]] = function.call @Num2Bits_0::@compute(%[[VAL_83]]) : (!felt.type<"bn128">) -> !struct.type<@Num2Bits_0>
 // CHECK-NEXT:            %[[VAL_93:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_71]] : !felt.type<"bn128">
@@ -409,8 +409,8 @@ module attributes {llzk.lang = "circom", llzk.main = !struct.type<@DecomposeProd
 // CHECK-NEXT:          }
 // CHECK-NEXT:          %[[VAL_94:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_71]] : !felt.type<"bn128">
 // CHECK-NEXT:          %[[VAL_95:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_49]]{{\[}}%[[VAL_94]]] : <8 x !felt.type<"bn128">>, !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_96:[0-9a-zA-Z_\.]+]] = felt.uintdiv %[[VAL_95]], %[[VAL_42]] : !felt.type<"bn128">, !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_97:[0-9a-zA-Z_\.]+]] = felt.umod %[[VAL_96]], %[[VAL_42]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_96:[0-9a-zA-Z_\.]+]] = felt.uintdiv %[[VAL_95]], %[[VAL_46]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_97:[0-9a-zA-Z_\.]+]] = felt.umod %[[VAL_96]], %[[VAL_46]] : !felt.type<"bn128">, !felt.type<"bn128">
 // CHECK-NEXT:          %[[VAL_98:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_71]] : !felt.type<"bn128">
 // CHECK-NEXT:          array.write %[[VAL_51]]{{\[}}%[[VAL_98]]] = %[[VAL_97]] : <8 x !felt.type<"bn128">>, !felt.type<"bn128">
 // CHECK-NEXT:          %[[VAL_99:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_71]] : !felt.type<"bn128">
@@ -422,20 +422,20 @@ module attributes {llzk.lang = "circom", llzk.main = !struct.type<@DecomposeProd
 // CHECK-NEXT:          %[[VAL_104:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_71]] : !felt.type<"bn128">
 // CHECK-NEXT:          %[[VAL_105:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_58]]{{\[}}%[[VAL_104]]] : <8 x index>, index
 // CHECK-NEXT:          %[[VAL_106:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_59]]{{\[}}%[[VAL_104]]] : <8 x !struct.type<@Num2Bits_0>>, !struct.type<@Num2Bits_0>
-// CHECK-NEXT:          %[[VAL_107:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_105]], %[[VAL_45]] : index
-// CHECK-NEXT:          %[[VAL_108:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_107]], %[[VAL_46]] : index
+// CHECK-NEXT:          %[[VAL_107:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_105]], %[[VAL_43]] : index
+// CHECK-NEXT:          %[[VAL_108:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_107]], %[[VAL_42]] : index
 // CHECK-NEXT:          scf.if %[[VAL_108]] {
 // CHECK-NEXT:            %[[VAL_109:[0-9a-zA-Z_\.]+]] = function.call @Num2Bits_0::@compute(%[[VAL_100]]) : (!felt.type<"bn128">) -> !struct.type<@Num2Bits_0>
 // CHECK-NEXT:            %[[VAL_110:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_71]] : !felt.type<"bn128">
 // CHECK-NEXT:            array.write %[[VAL_58]]{{\[}}%[[VAL_110]]] = %[[VAL_107]] : <8 x index>, index
 // CHECK-NEXT:            array.write %[[VAL_59]]{{\[}}%[[VAL_110]]] = %[[VAL_109]] : <8 x !struct.type<@Num2Bits_0>>, !struct.type<@Num2Bits_0>
 // CHECK-NEXT:          }
-// CHECK-NEXT:          %[[VAL_111:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_71]], %[[VAL_41]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_111:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_71]], %[[VAL_47]] : !felt.type<"bn128">, !felt.type<"bn128">
 // CHECK-NEXT:          scf.yield %[[VAL_69]], %[[VAL_70]], %[[VAL_111]] : !array.type<8 x !felt.type<"bn128">>, !array.type<8 x !felt.type<"bn128">>, !felt.type<"bn128">
 // CHECK-NEXT:        }
 // CHECK-NEXT:        struct.writem %[[VAL_48]][@bits_high$inputs_in] = %[[VAL_64]]#0 : <@DecomposeProduct_1>, !array.type<8 x !felt.type<"bn128">>
 // CHECK-NEXT:        %[[VAL_112:[0-9a-zA-Z_\.]+]] = array.new  : <8 x !struct.type<@Num2Bits_0>>
-// CHECK-NEXT:        scf.for %[[VAL_113:[0-9a-zA-Z_\.]+]] = %[[VAL_46]] to %[[VAL_47]] step %[[VAL_45]] {
+// CHECK-NEXT:        scf.for %[[VAL_113:[0-9a-zA-Z_\.]+]] = %[[VAL_42]] to %[[VAL_41]] step %[[VAL_43]] {
 // CHECK-NEXT:          %[[VAL_114:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_58]]{{\[}}%[[VAL_113]]] : <8 x index>, index
 // CHECK-NEXT:          %[[VAL_115:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_59]]{{\[}}%[[VAL_113]]] : <8 x !struct.type<@Num2Bits_0>>, !struct.type<@Num2Bits_0>
 // CHECK-NEXT:          array.write %[[VAL_112]]{{\[}}%[[VAL_113]]] = %[[VAL_115]] : <8 x !struct.type<@Num2Bits_0>>, !struct.type<@Num2Bits_0>
@@ -443,7 +443,7 @@ module attributes {llzk.lang = "circom", llzk.main = !struct.type<@DecomposeProd
 // CHECK-NEXT:        struct.writem %[[VAL_48]][@bits_high] = %[[VAL_112]] : <@DecomposeProduct_1>, !array.type<8 x !struct.type<@Num2Bits_0>>
 // CHECK-NEXT:        struct.writem %[[VAL_48]][@bits_low$inputs_in] = %[[VAL_64]]#1 : <@DecomposeProduct_1>, !array.type<8 x !felt.type<"bn128">>
 // CHECK-NEXT:        %[[VAL_116:[0-9a-zA-Z_\.]+]] = array.new  : <8 x !struct.type<@Num2Bits_0>>
-// CHECK-NEXT:        scf.for %[[VAL_117:[0-9a-zA-Z_\.]+]] = %[[VAL_46]] to %[[VAL_47]] step %[[VAL_45]] {
+// CHECK-NEXT:        scf.for %[[VAL_117:[0-9a-zA-Z_\.]+]] = %[[VAL_42]] to %[[VAL_41]] step %[[VAL_43]] {
 // CHECK-NEXT:          %[[VAL_118:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_52]]{{\[}}%[[VAL_117]]] : <8 x index>, index
 // CHECK-NEXT:          %[[VAL_119:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_53]]{{\[}}%[[VAL_117]]] : <8 x !struct.type<@Num2Bits_0>>, !struct.type<@Num2Bits_0>
 // CHECK-NEXT:          array.write %[[VAL_116]]{{\[}}%[[VAL_117]]] = %[[VAL_119]] : <8 x !struct.type<@Num2Bits_0>>, !struct.type<@Num2Bits_0>
@@ -455,13 +455,13 @@ module attributes {llzk.lang = "circom", llzk.main = !struct.type<@DecomposeProd
 // CHECK-NEXT:        function.return %[[VAL_48]] : !struct.type<@DecomposeProduct_1>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_120:[0-9a-zA-Z_\.]+]]: !struct.type<@DecomposeProduct_1>, %[[VAL_121:[0-9a-zA-Z_\.]+]]: !array.type<8 x !felt.type<"bn128">>, %[[VAL_122:[0-9a-zA-Z_\.]+]]: !array.type<8 x !felt.type<"bn128">>) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
-// CHECK-NEXT:        %[[VAL_123:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:        %[[VAL_124:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[VAL_125:[0-9a-zA-Z_\.]+]] = arith.constant 8 : index
+// CHECK-NEXT:        %[[VAL_123:[0-9a-zA-Z_\.]+]] = felt.const  8 : <"bn128">
+// CHECK-NEXT:        %[[VAL_124:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
+// CHECK-NEXT:        %[[VAL_125:[0-9a-zA-Z_\.]+]] = felt.const  256 : <"bn128">
 // CHECK-NEXT:        %[[VAL_126:[0-9a-zA-Z_\.]+]] = felt.const  1 : <"bn128">
-// CHECK-NEXT:        %[[VAL_127:[0-9a-zA-Z_\.]+]] = felt.const  256 : <"bn128">
-// CHECK-NEXT:        %[[VAL_128:[0-9a-zA-Z_\.]+]] = felt.const  0 : <"bn128">
-// CHECK-NEXT:        %[[VAL_129:[0-9a-zA-Z_\.]+]] = felt.const  8 : <"bn128">
+// CHECK-NEXT:        %[[VAL_127:[0-9a-zA-Z_\.]+]] = arith.constant 8 : index
+// CHECK-NEXT:        %[[VAL_128:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_129:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
 // CHECK-NEXT:        %[[VAL_130:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_120]][@high] : <@DecomposeProduct_1>, !array.type<8 x !felt.type<"bn128">>
 // CHECK-NEXT:        %[[VAL_131:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_120]][@low] : <@DecomposeProduct_1>, !array.type<8 x !felt.type<"bn128">>
 // CHECK-NEXT:        %[[VAL_132:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_120]][@u16s] : <@DecomposeProduct_1>, !array.type<8 x !felt.type<"bn128">>
@@ -469,8 +469,8 @@ module attributes {llzk.lang = "circom", llzk.main = !struct.type<@DecomposeProd
 // CHECK-NEXT:        %[[VAL_134:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_120]][@bits_low$inputs_in] : <@DecomposeProduct_1>, !array.type<8 x !felt.type<"bn128">>
 // CHECK-NEXT:        %[[VAL_135:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_120]][@bits_high] : <@DecomposeProduct_1>, !array.type<8 x !struct.type<@Num2Bits_0>>
 // CHECK-NEXT:        %[[VAL_136:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_120]][@bits_high$inputs_in] : <@DecomposeProduct_1>, !array.type<8 x !felt.type<"bn128">>
-// CHECK-NEXT:        %[[VAL_137:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_138:[0-9a-zA-Z_\.]+]] = %[[VAL_128]]) : (!felt.type<"bn128">) -> !felt.type<"bn128"> {
-// CHECK-NEXT:          %[[VAL_139:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_138]], %[[VAL_129]]) : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:        %[[VAL_137:[0-9a-zA-Z_\.]+]] = scf.while (%[[VAL_138:[0-9a-zA-Z_\.]+]] = %[[VAL_124]]) : (!felt.type<"bn128">) -> !felt.type<"bn128"> {
+// CHECK-NEXT:          %[[VAL_139:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_138]], %[[VAL_123]]) : !felt.type<"bn128">, !felt.type<"bn128">
 // CHECK-NEXT:          scf.condition(%[[VAL_139]]) %[[VAL_138]] : !felt.type<"bn128">
 // CHECK-NEXT:        } do {
 // CHECK-NEXT:        ^bb0(%[[VAL_140:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">):
@@ -498,18 +498,18 @@ module attributes {llzk.lang = "circom", llzk.main = !struct.type<@DecomposeProd
 // CHECK-NEXT:          %[[VAL_159:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_131]]{{\[}}%[[VAL_158]]] : <8 x !felt.type<"bn128">>, !felt.type<"bn128">
 // CHECK-NEXT:          %[[VAL_160:[0-9a-zA-Z_\.]+]] = cast.toindex %[[VAL_140]] : !felt.type<"bn128">
 // CHECK-NEXT:          %[[VAL_161:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_130]]{{\[}}%[[VAL_160]]] : <8 x !felt.type<"bn128">>, !felt.type<"bn128">
-// CHECK-NEXT:          %[[VAL_162:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_161]], %[[VAL_127]] : !felt.type<"bn128">, !felt.type<"bn128">
+// CHECK-NEXT:          %[[VAL_162:[0-9a-zA-Z_\.]+]] = felt.mul %[[VAL_161]], %[[VAL_125]] : !felt.type<"bn128">, !felt.type<"bn128">
 // CHECK-NEXT:          %[[VAL_163:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_159]], %[[VAL_162]] : !felt.type<"bn128">, !felt.type<"bn128">
 // CHECK-NEXT:          constrain.eq %[[VAL_157]], %[[VAL_163]] : !felt.type<"bn128">, !felt.type<"bn128">
 // CHECK-NEXT:          %[[VAL_164:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_140]], %[[VAL_126]] : !felt.type<"bn128">, !felt.type<"bn128">
 // CHECK-NEXT:          scf.yield %[[VAL_164]] : !felt.type<"bn128">
 // CHECK-NEXT:        }
-// CHECK-NEXT:        scf.for %[[VAL_165:[0-9a-zA-Z_\.]+]] = %[[VAL_124]] to %[[VAL_125]] step %[[VAL_123]] {
+// CHECK-NEXT:        scf.for %[[VAL_165:[0-9a-zA-Z_\.]+]] = %[[VAL_128]] to %[[VAL_127]] step %[[VAL_129]] {
 // CHECK-NEXT:          %[[VAL_166:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_135]]{{\[}}%[[VAL_165]]] : <8 x !struct.type<@Num2Bits_0>>, !struct.type<@Num2Bits_0>
 // CHECK-NEXT:          %[[VAL_167:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_136]]{{\[}}%[[VAL_165]]] : <8 x !felt.type<"bn128">>, !felt.type<"bn128">
 // CHECK-NEXT:          function.call @Num2Bits_0::@constrain(%[[VAL_166]], %[[VAL_167]]) : (!struct.type<@Num2Bits_0>, !felt.type<"bn128">) -> ()
 // CHECK-NEXT:        }
-// CHECK-NEXT:        scf.for %[[VAL_168:[0-9a-zA-Z_\.]+]] = %[[VAL_124]] to %[[VAL_125]] step %[[VAL_123]] {
+// CHECK-NEXT:        scf.for %[[VAL_168:[0-9a-zA-Z_\.]+]] = %[[VAL_128]] to %[[VAL_127]] step %[[VAL_129]] {
 // CHECK-NEXT:          %[[VAL_169:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_133]]{{\[}}%[[VAL_168]]] : <8 x !struct.type<@Num2Bits_0>>, !struct.type<@Num2Bits_0>
 // CHECK-NEXT:          %[[VAL_170:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_134]]{{\[}}%[[VAL_168]]] : <8 x !felt.type<"bn128">>, !felt.type<"bn128">
 // CHECK-NEXT:          function.call @Num2Bits_0::@constrain(%[[VAL_169]], %[[VAL_170]]) : (!struct.type<@Num2Bits_0>, !felt.type<"bn128">) -> ()

--- a/test/Transforms/PodToScalar/circom_greater_than.llzk
+++ b/test/Transforms/PodToScalar/circom_greater_than.llzk
@@ -1,0 +1,60 @@
+// RUN: llzk-opt -llzk-pod-to-scalar -verify-diagnostics %s | FileCheck --enable-var-scope %s
+
+!F = !felt.type<"bn128">
+module attributes {llzk.lang, llzk.main = !struct.type<@GreaterThan_2>} {
+  struct.def @LessThan_1 {
+    struct.member @out : !F {llzk.pub}
+    function.def @product(%arg0: !array.type<2 x !F>) -> !struct.type<@LessThan_1> attributes {llzk.derived} {
+      %self = struct.new : <@LessThan_1>
+      function.return %self : !struct.type<@LessThan_1>
+    }
+    function.def @compute(%arg0: !array.type<2 x !F>) -> !struct.type<@LessThan_1> attributes {product_source = "compute"} {
+      %self = struct.new : <@LessThan_1>
+      function.return %self : !struct.type<@LessThan_1>
+    }
+    function.def @constrain(%arg0: !struct.type<@LessThan_1>, %arg1: !array.type<2 x !F>) attributes {product_source = "constrain"} {
+      function.return
+    }
+  }
+  struct.def @GreaterThan_2 {
+    struct.member @out : !F {llzk.pub}
+    function.def @product(%arg0: !array.type<2 x !F>) -> !struct.type<@GreaterThan_2> attributes {function.allow_non_native_field_ops} {
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      %c2 = arith.constant 2 : index
+      %self = struct.new : <@GreaterThan_2>
+      %pod = pod.new { @count = %c2 }  : <[@count: index, @comp: !struct.type<@LessThan_1>]>
+      %pod_0 = pod.new : <[@in: !array.type<2 x !F>]>
+      %0 = array.read %arg0[%c1] : <2 x !F>, !F
+      %1 = pod.read %pod_0[@in] : <[@in: !array.type<2 x !F>]>, !array.type<2 x !F>
+      array.write %1[%c0] = %0 : <2 x !F>, !F
+      pod.write %pod_0[@in] = %1 : <[@in: !array.type<2 x !F>]>, !array.type<2 x !F>
+      %2 = pod.read %pod[@count] : <[@count: index, @comp: !struct.type<@LessThan_1>]>, index
+      %3 = arith.subi %2, %c1 : index
+      pod.write %pod[@count] = %3 : <[@count: index, @comp: !struct.type<@LessThan_1>]>, index
+      %4 = arith.cmpi eq, %3, %c0 : index
+      scf.if %4 {
+        %12 = pod.read %pod_0[@in] : <[@in: !array.type<2 x !F>]>, !array.type<2 x !F>
+        %13 = function.call @LessThan_1::@product(%12) : (!array.type<2 x !F>) -> !struct.type<@LessThan_1>
+        pod.write %pod[@comp] = %13 : <[@count: index, @comp: !struct.type<@LessThan_1>]>, !struct.type<@LessThan_1>
+      }
+      %5 = array.read %arg0[%c0] : <2 x !F>, !F
+      %6 = pod.read %pod_0[@in] : <[@in: !array.type<2 x !F>]>, !array.type<2 x !F>
+      array.write %6[%c1] = %5 : <2 x !F>, !F
+      pod.write %pod_0[@in] = %6 : <[@in: !array.type<2 x !F>]>, !array.type<2 x !F>
+      %7 = pod.read %pod[@count] : <[@count: index, @comp: !struct.type<@LessThan_1>]>, index
+      %8 = arith.subi %7, %c1 : index
+      pod.write %pod[@count] = %8 : <[@count: index, @comp: !struct.type<@LessThan_1>]>, index
+      %9 = arith.cmpi eq, %8, %c0 : index
+      scf.if %9 {
+        %12 = pod.read %pod_0[@in] : <[@in: !array.type<2 x !F>]>, !array.type<2 x !F>
+        %13 = function.call @LessThan_1::@product(%12) : (!array.type<2 x !F>) -> !struct.type<@LessThan_1>
+        pod.write %pod[@comp] = %13 : <[@count: index, @comp: !struct.type<@LessThan_1>]>, !struct.type<@LessThan_1>
+      }
+      %10 = pod.read %pod[@comp] : <[@count: index, @comp: !struct.type<@LessThan_1>]>, !struct.type<@LessThan_1>
+      %11 = struct.readm %10[@out] : <@LessThan_1>, !F
+      struct.writem %self[@out] = %11 : <@GreaterThan_2>, !F
+      function.return %self : !struct.type<@GreaterThan_2>
+    }
+  }
+}

--- a/test/Transforms/PodToScalar/circom_greater_than.llzk
+++ b/test/Transforms/PodToScalar/circom_greater_than.llzk
@@ -58,3 +58,37 @@ module attributes {llzk.lang, llzk.main = !struct.type<@GreaterThan_2>} {
     }
   }
 }
+// CHECK-LABEL: module attributes {llzk.lang, llzk.main = !struct.type<@GreaterThan_2>} {
+// CHECK-NEXT:    struct.def @LessThan_1 {
+// CHECK-NEXT:      struct.member @out : !felt.type<"bn128"> {llzk.pub}
+// CHECK-NEXT:      function.def @product(%[[VAL_0:[0-9a-zA-Z_\.]+]]: !array.type<2 x !felt.type<"bn128">>) -> !struct.type<@LessThan_1> attributes {function.allow_constraint, function.allow_witness, llzk.derived} {
+// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = struct.new : <@LessThan_1>
+// CHECK-NEXT:        function.return %[[VAL_1]] : !struct.type<@LessThan_1>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.def @compute(%[[VAL_2:[0-9a-zA-Z_\.]+]]: !array.type<2 x !felt.type<"bn128">>) -> !struct.type<@LessThan_1> attributes {function.allow_witness, product_source = "compute"} {
+// CHECK-NEXT:        %[[VAL_3:[0-9a-zA-Z_\.]+]] = struct.new : <@LessThan_1>
+// CHECK-NEXT:        function.return %[[VAL_3]] : !struct.type<@LessThan_1>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.def @constrain(%[[VAL_4:[0-9a-zA-Z_\.]+]]: !struct.type<@LessThan_1>, %[[VAL_5:[0-9a-zA-Z_\.]+]]: !array.type<2 x !felt.type<"bn128">>) attributes {function.allow_constraint, product_source = "constrain"} {
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:    struct.def @GreaterThan_2 {
+// CHECK-NEXT:      struct.member @out : !felt.type<"bn128"> {llzk.pub}
+// CHECK-NEXT:      function.def @product(%[[VAL_6:[0-9a-zA-Z_\.]+]]: !array.type<2 x !felt.type<"bn128">>) -> !struct.type<@GreaterThan_2> attributes {function.allow_constraint, function.allow_non_native_field_ops, function.allow_witness} {
+// CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_9:[0-9a-zA-Z_\.]+]] = llzk.nondet : !array.type<2 x !felt.type<"bn128">>
+// CHECK-NEXT:        %[[VAL_10:[0-9a-zA-Z_\.]+]] = llzk.nondet : !struct.type<@LessThan_1>
+// CHECK-NEXT:        %[[VAL_11:[0-9a-zA-Z_\.]+]] = struct.new : <@GreaterThan_2>
+// CHECK-NEXT:        %[[VAL_12:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_6]]{{\[}}%[[VAL_7]]] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:        array.write %[[VAL_9]]{{\[}}%[[VAL_8]]] = %[[VAL_12]] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:        %[[VAL_13:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_6]]{{\[}}%[[VAL_8]]] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:        array.write %[[VAL_9]]{{\[}}%[[VAL_7]]] = %[[VAL_13]] : <2 x !felt.type<"bn128">>, !felt.type<"bn128">
+// CHECK-NEXT:        %[[VAL_14:[0-9a-zA-Z_\.]+]] = function.call @LessThan_1::@product(%[[VAL_9]]) : (!array.type<2 x !felt.type<"bn128">>) -> !struct.type<@LessThan_1>
+// CHECK-NEXT:        %[[VAL_15:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_14]][@out] : <@LessThan_1>, !felt.type<"bn128">
+// CHECK-NEXT:        struct.writem %[[VAL_11]][@out] = %[[VAL_15]] : <@GreaterThan_2>, !felt.type<"bn128">
+// CHECK-NEXT:        function.return %[[VAL_11]] : !struct.type<@GreaterThan_2>
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/test/Transforms/PodToScalar/circom_subcmps5b.llzk
+++ b/test/Transforms/PodToScalar/circom_subcmps5b.llzk
@@ -83,7 +83,6 @@ module attributes {llzk.lang = "circom", llzk.main = !struct.type<@SubCmp::@SubC
     }
   }
 }
-
 // CHECK-LABEL: module attributes {llzk.lang = "circom", llzk.main = !struct.type<@SubCmp::@SubCmp<[]>>} {
 // CHECK-NEXT:    module @Nop {
 // CHECK-NEXT:      struct.def @Nop {
@@ -107,27 +106,18 @@ module attributes {llzk.lang = "circom", llzk.main = !struct.type<@SubCmp::@SubC
 // CHECK-NEXT:        struct.member @n$inputs_i : !felt.type<"bn128">
 // CHECK-NEXT:        function.def @compute(%[[VAL_5:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128"> {function.arg_name = "i"}) -> !struct.type<@SubCmp::@SubCmp> attributes {function.allow_non_native_field_ops, function.allow_witness} {
 // CHECK-NEXT:          %[[VAL_6:[0-9a-zA-Z_\.]+]] = llzk.nondet : !struct.type<@Nop::@Nop>
-// CHECK-NEXT:          %[[VAL_7:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:          %[[VAL_8:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:          %[[VAL_9:[0-9a-zA-Z_\.]+]] = struct.new : <@SubCmp::@SubCmp>
-// CHECK-NEXT:          %[[VAL_10:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_8]], %[[VAL_8]] : index
-// CHECK-NEXT:          %[[VAL_11:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_10]], %[[VAL_7]] : index
-// CHECK-NEXT:          %[[VAL_12:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_11]] -> (!struct.type<@Nop::@Nop>) {
-// CHECK-NEXT:            %[[VAL_13:[0-9a-zA-Z_\.]+]] = function.call @Nop::@Nop::@compute(%[[VAL_5]]) : (!felt.type<"bn128">) -> !struct.type<@Nop::@Nop>
-// CHECK-NEXT:            scf.yield %[[VAL_13]] : !struct.type<@Nop::@Nop>
-// CHECK-NEXT:          } else {
-// CHECK-NEXT:            scf.yield %[[VAL_6]] : !struct.type<@Nop::@Nop>
-// CHECK-NEXT:          }
-// CHECK-NEXT:          %[[VAL_14:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_12]][@o] : <@Nop::@Nop>, !felt.type<"bn128">
-// CHECK-NEXT:          struct.writem %[[VAL_9]][@o] = %[[VAL_14]] : <@SubCmp::@SubCmp>, !felt.type<"bn128">
-// CHECK-NEXT:          struct.writem %[[VAL_9]][@n$inputs_i] = %[[VAL_5]] : <@SubCmp::@SubCmp>, !felt.type<"bn128">
-// CHECK-NEXT:          struct.writem %[[VAL_9]][@n] = %[[VAL_12]] : <@SubCmp::@SubCmp>, !struct.type<@Nop::@Nop>
-// CHECK-NEXT:          function.return %[[VAL_9]] : !struct.type<@SubCmp::@SubCmp>
+// CHECK-NEXT:          %[[VAL_7:[0-9a-zA-Z_\.]+]] = struct.new : <@SubCmp::@SubCmp>
+// CHECK-NEXT:          %[[VAL_8:[0-9a-zA-Z_\.]+]] = function.call @Nop::@Nop::@compute(%[[VAL_5]]) : (!felt.type<"bn128">) -> !struct.type<@Nop::@Nop>
+// CHECK-NEXT:          %[[VAL_9:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_8]][@o] : <@Nop::@Nop>, !felt.type<"bn128">
+// CHECK-NEXT:          struct.writem %[[VAL_7]][@o] = %[[VAL_9]] : <@SubCmp::@SubCmp>, !felt.type<"bn128">
+// CHECK-NEXT:          struct.writem %[[VAL_7]][@n$inputs_i] = %[[VAL_5]] : <@SubCmp::@SubCmp>, !felt.type<"bn128">
+// CHECK-NEXT:          struct.writem %[[VAL_7]][@n] = %[[VAL_8]] : <@SubCmp::@SubCmp>, !struct.type<@Nop::@Nop>
+// CHECK-NEXT:          function.return %[[VAL_7]] : !struct.type<@SubCmp::@SubCmp>
 // CHECK-NEXT:        }
-// CHECK-NEXT:        function.def @constrain(%[[VAL_15:[0-9a-zA-Z_\.]+]]: !struct.type<@SubCmp::@SubCmp>, %[[VAL_16:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128"> {function.arg_name = "i"}) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
-// CHECK-NEXT:          %[[VAL_18:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_15]][@n] : <@SubCmp::@SubCmp>, !struct.type<@Nop::@Nop>
-// CHECK-NEXT:          %[[VAL_19:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_15]][@n$inputs_i] : <@SubCmp::@SubCmp>, !felt.type<"bn128">
-// CHECK-NEXT:          function.call @Nop::@Nop::@constrain(%[[VAL_18]], %[[VAL_19]]) : (!struct.type<@Nop::@Nop>, !felt.type<"bn128">) -> ()
+// CHECK-NEXT:        function.def @constrain(%[[VAL_10:[0-9a-zA-Z_\.]+]]: !struct.type<@SubCmp::@SubCmp>, %[[VAL_11:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128"> {function.arg_name = "i"}) attributes {function.allow_constraint, function.allow_non_native_field_ops} {
+// CHECK-NEXT:          %[[VAL_12:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_10]][@n] : <@SubCmp::@SubCmp>, !struct.type<@Nop::@Nop>
+// CHECK-NEXT:          %[[VAL_13:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_10]][@n$inputs_i] : <@SubCmp::@SubCmp>, !felt.type<"bn128">
+// CHECK-NEXT:          function.call @Nop::@Nop::@constrain(%[[VAL_12]], %[[VAL_13]]) : (!struct.type<@Nop::@Nop>, !felt.type<"bn128">) -> ()
 // CHECK-NEXT:          function.return
 // CHECK-NEXT:        }
 // CHECK-NEXT:      }

--- a/test/Transforms/PodToScalar/constraints_and_whole_pod_uses.llzk
+++ b/test/Transforms/PodToScalar/constraints_and_whole_pod_uses.llzk
@@ -174,11 +174,10 @@ module attributes {llzk.lang} {
 // CHECK-SAME:    %[[ELEM_X:[0-9a-zA-Z_\.]+]]: index,
 // CHECK-SAME:    %[[ELEM_Y:[0-9a-zA-Z_\.]+]]: !felt.type
 // CHECK-SAME:    ) attributes {function.allow_constraint} {
-// CHECK-NEXT:      %[[C0:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
 // CHECK-NEXT:      %[[TRUE:[0-9a-zA-Z_\.]+]] = arith.constant true
+// CHECK-NEXT:      %[[C0:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
 // CHECK-NEXT:      %[[IDX:[0-9a-zA-Z_\.]+]] = llzk.nondet : index
-// CHECK-NEXT:      %[[DIM0:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:      %[[LEN:[0-9a-zA-Z_\.]+]] = array.len %[[ARR_X]], %[[DIM0]] : <2 x index>
+// CHECK-NEXT:      %[[LEN:[0-9a-zA-Z_\.]+]] = array.len %[[ARR_X]], %[[C0]] : <2 x index>
 // CHECK-NEXT:      %[[GE0:[0-9a-zA-Z_\.]+]] = arith.cmpi sge, %[[IDX]], %[[C0]] : index
 // CHECK-NEXT:      constrain.eq %[[GE0]], %[[TRUE]] : i1, i1
 // CHECK-NEXT:      %[[LT_LEN:[0-9a-zA-Z_\.]+]] = arith.cmpi slt, %[[IDX]], %[[LEN]] : index

--- a/test/Transforms/PodToScalar/discardable_attrs.llzk
+++ b/test/Transforms/PodToScalar/discardable_attrs.llzk
@@ -68,21 +68,20 @@ module attributes {llzk.lang} {
 }
 // CHECK-LABEL: module attributes {llzk.lang} {
 // CHECK-NEXT:    function.def @constraint_metadata(%[[VAL_0:[0-9a-zA-Z_\.]+]]: index, %[[VAL_1:[0-9a-zA-Z_\.]+]]: index, %[[VAL_2:[0-9a-zA-Z_\.]+]]: index, %[[VAL_3:[0-9a-zA-Z_\.]+]]: index, %[[VAL_4:[0-9a-zA-Z_\.]+]]: !array.type<2 x index>, %[[VAL_5:[0-9a-zA-Z_\.]+]]: !array.type<2 x index>) attributes {function.allow_constraint} {
+// CHECK-NEXT:      %[[VAL_6:[0-9a-zA-Z_\.]+]] = arith.constant true
+// CHECK-NEXT:      %[[VAL_7:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
 // CHECK-NEXT:      constrain.eq %[[VAL_0]], %[[VAL_2]] : index, index {product_source = "eq"}
 // CHECK-NEXT:      constrain.eq %[[VAL_1]], %[[VAL_3]] : index, index {product_source = "eq"}
-// CHECK-NEXT:      %[[VAL_6:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:      %[[VAL_7:[0-9a-zA-Z_\.]+]] = arith.constant true
 // CHECK-NEXT:      %[[VAL_8:[0-9a-zA-Z_\.]+]] = llzk.nondet : index
-// CHECK-NEXT:      %[[VAL_9:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:      %[[VAL_10:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_4]], %[[VAL_9]] : <2 x index>
-// CHECK-NEXT:      %[[VAL_11:[0-9a-zA-Z_\.]+]] = arith.cmpi sge, %[[VAL_8]], %[[VAL_6]] : index
-// CHECK-NEXT:      constrain.eq %[[VAL_11]], %[[VAL_7]] : i1, i1
-// CHECK-NEXT:      %[[VAL_12:[0-9a-zA-Z_\.]+]] = arith.cmpi slt, %[[VAL_8]], %[[VAL_10]] : index
-// CHECK-NEXT:      constrain.eq %[[VAL_12]], %[[VAL_7]] : i1, i1
-// CHECK-NEXT:      %[[VAL_13:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_4]]{{\[}}%[[VAL_8]]] : <2 x index>, index
-// CHECK-NEXT:      constrain.eq %[[VAL_13]], %[[VAL_0]] : index, index {product_source = "in"}
-// CHECK-NEXT:      %[[VAL_14:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_5]]{{\[}}%[[VAL_8]]] : <2 x index>, index
-// CHECK-NEXT:      constrain.eq %[[VAL_14]], %[[VAL_1]] : index, index {product_source = "in"}
+// CHECK-NEXT:      %[[VAL_9:[0-9a-zA-Z_\.]+]] = array.len %[[VAL_4]], %[[VAL_7]] : <2 x index>
+// CHECK-NEXT:      %[[VAL_10:[0-9a-zA-Z_\.]+]] = arith.cmpi sge, %[[VAL_8]], %[[VAL_7]] : index
+// CHECK-NEXT:      constrain.eq %[[VAL_10]], %[[VAL_6]] : i1, i1
+// CHECK-NEXT:      %[[VAL_11:[0-9a-zA-Z_\.]+]] = arith.cmpi slt, %[[VAL_8]], %[[VAL_9]] : index
+// CHECK-NEXT:      constrain.eq %[[VAL_11]], %[[VAL_6]] : i1, i1
+// CHECK-NEXT:      %[[VAL_12:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_4]]{{\[}}%[[VAL_8]]] : <2 x index>, index
+// CHECK-NEXT:      constrain.eq %[[VAL_12]], %[[VAL_0]] : index, index {product_source = "in"}
+// CHECK-NEXT:      %[[VAL_13:[0-9a-zA-Z_\.]+]] = array.read %[[VAL_5]]{{\[}}%[[VAL_8]]] : <2 x index>, index
+// CHECK-NEXT:      constrain.eq %[[VAL_13]], %[[VAL_1]] : index, index {product_source = "in"}
 // CHECK-NEXT:      function.return
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }

--- a/test/Transforms/PodToScalar/function_calls_with_pod.llzk
+++ b/test/Transforms/PodToScalar/function_calls_with_pod.llzk
@@ -152,9 +152,9 @@ module attributes {llzk.lang} {
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }
 // CHECK-NEXT:    function.def @main(%[[VAL_4:[0-9a-zA-Z_\.]+]]: index) -> index attributes {function.allow_witness} {
-// CHECK-NEXT:      %[[VAL_5:[0-9a-zA-Z_\.]+]] = arith.constant 3 : index
-// CHECK-NEXT:      %[[VAL_6:[0-9a-zA-Z_\.]+]] = arith.constant 2 : index
-// CHECK-NEXT:      %[[VAL_7:[0-9a-zA-Z_\.]+]] = function.call @TBox::@Box::@compute(%[[VAL_4]]) {(){{\[}}%[[VAL_6]], %[[VAL_5]]]} : (index) -> !struct.type<@TBox::@Box<[#[[$M]]]>>
+// CHECK-NEXT:      %[[VAL_5:[0-9a-zA-Z_\.]+]] = arith.constant 2 : index
+// CHECK-NEXT:      %[[VAL_6:[0-9a-zA-Z_\.]+]] = arith.constant 3 : index
+// CHECK-NEXT:      %[[VAL_7:[0-9a-zA-Z_\.]+]] = function.call @TBox::@Box::@compute(%[[VAL_4]]) {(){{\[}}%[[VAL_5]], %[[VAL_6]]]} : (index) -> !struct.type<@TBox::@Box<[#[[$M]]]>>
 // CHECK-NEXT:      %[[VAL_8:[0-9a-zA-Z_\.]+]] = struct.readm %[[VAL_7]][@out] : <@TBox::@Box<[#[[$M]]]>>, index
 // CHECK-NEXT:      function.return %[[VAL_8]] : index
 // CHECK-NEXT:    }

--- a/test/Transforms/PodToScalar/scf_with_pod.llzk
+++ b/test/Transforms/PodToScalar/scf_with_pod.llzk
@@ -57,20 +57,11 @@ module attributes {llzk.lang = "circom", llzk.main = !struct.type<@SubCmp>} {
 // CHECK-NEXT:      struct.member @n$inputs_i : !felt.type<"bn128">
 // CHECK-NEXT:      function.def @compute(%[[VAL_4:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) -> !struct.type<@SubCmp> attributes {function.allow_witness} {
 // CHECK-NEXT:        %[[VAL_5:[0-9a-zA-Z_\.]+]] = llzk.nondet : !struct.type<@Nop>
-// CHECK-NEXT:        %[[VAL_6:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = struct.new : <@SubCmp>
-// CHECK-NEXT:        %[[VAL_9:[0-9a-zA-Z_\.]+]] = arith.subi %[[VAL_7]], %[[VAL_7]] : index
-// CHECK-NEXT:        %[[VAL_10:[0-9a-zA-Z_\.]+]] = arith.cmpi eq, %[[VAL_9]], %[[VAL_6]] : index
-// CHECK-NEXT:        %[[VAL_11:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_10]] -> (!struct.type<@Nop>) {
-// CHECK-NEXT:          %[[VAL_12:[0-9a-zA-Z_\.]+]] = function.call @Nop::@compute(%[[VAL_4]]) : (!felt.type<"bn128">) -> !struct.type<@Nop>
-// CHECK-NEXT:          scf.yield %[[VAL_12]] : !struct.type<@Nop>
-// CHECK-NEXT:        } else {
-// CHECK-NEXT:          scf.yield %[[VAL_5]] : !struct.type<@Nop>
-// CHECK-NEXT:        }
-// CHECK-NEXT:        struct.writem %[[VAL_8]][@n$inputs_i] = %[[VAL_4]] : <@SubCmp>, !felt.type<"bn128">
-// CHECK-NEXT:        struct.writem %[[VAL_8]][@n] = %[[VAL_11]] : <@SubCmp>, !struct.type<@Nop>
-// CHECK-NEXT:        function.return %[[VAL_8]] : !struct.type<@SubCmp>
+// CHECK-NEXT:        %[[VAL_6:[0-9a-zA-Z_\.]+]] = struct.new : <@SubCmp>
+// CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = function.call @Nop::@compute(%[[VAL_4]]) : (!felt.type<"bn128">) -> !struct.type<@Nop>
+// CHECK-NEXT:        struct.writem %[[VAL_6]][@n$inputs_i] = %[[VAL_4]] : <@SubCmp>, !felt.type<"bn128">
+// CHECK-NEXT:        struct.writem %[[VAL_6]][@n] = %[[VAL_7]] : <@SubCmp>, !struct.type<@Nop>
+// CHECK-NEXT:        function.return %[[VAL_6]] : !struct.type<@SubCmp>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      function.def @constrain(%[[VAL_13:[0-9a-zA-Z_\.]+]]: !struct.type<@SubCmp>, %[[VAL_14:[0-9a-zA-Z_\.]+]]: !felt.type<"bn128">) attributes {function.allow_constraint} {
 // CHECK-NEXT:        function.return
@@ -157,8 +148,8 @@ module attributes {llzk.lang} {
 }
 // CHECK-LABEL: module attributes {llzk.lang} {
 // CHECK-NEXT:    function.def @nested_if_external_new(%[[VAL_0:[0-9a-zA-Z_\.]+]]: index, %[[VAL_1:[0-9a-zA-Z_\.]+]]: index) -> index {
-// CHECK-NEXT:      %[[VAL_2:[0-9a-zA-Z_\.]+]] = llzk.nondet : index
 // CHECK-NEXT:      %[[VAL_3:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:      %[[VAL_2:[0-9a-zA-Z_\.]+]] = llzk.nondet : index
 // CHECK-NEXT:      %[[VAL_4:[0-9a-zA-Z_\.]+]] = arith.cmpi sgt, %[[VAL_0]], %[[VAL_3]] : index
 // CHECK-NEXT:      %[[VAL_5:[0-9a-zA-Z_\.]+]] = scf.if %[[VAL_4]] -> (index) {
 // CHECK-NEXT:        %[[VAL_6:[0-9a-zA-Z_\.]+]] = arith.cmpi sgt, %[[VAL_1]], %[[VAL_3]] : index
@@ -286,8 +277,8 @@ module attributes {llzk.lang} {
 }
 // CHECK-LABEL: module attributes {llzk.lang} {
 // CHECK-NEXT:    function.def @while_local_pod(%[[VAL_0:[0-9a-zA-Z_\.]+]]: index, %[[VAL_1:[0-9a-zA-Z_\.]+]]: index) -> index {
-// CHECK-NEXT:      %[[VAL_2:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
 // CHECK-NEXT:      %[[VAL_3:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:      %[[VAL_2:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
 // CHECK-NEXT:      %[[VAL_4:[0-9a-zA-Z_\.]+]]:2 = scf.while (%[[VAL_5:[0-9a-zA-Z_\.]+]] = %[[VAL_1]], %[[VAL_6:[0-9a-zA-Z_\.]+]] = %[[VAL_0]]) : (index, index) -> (index, index) {
 // CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = arith.cmpi sgt, %[[VAL_5]], %[[VAL_2]] : index
 // CHECK-NEXT:        scf.condition(%[[VAL_7]]) %[[VAL_5]], %[[VAL_6]] : index, index
@@ -320,9 +311,9 @@ module attributes {llzk.lang} {
 }
 // CHECK-LABEL: module attributes {llzk.lang} {
 // CHECK-NEXT:    function.def @for_local_pod(%[[VAL_0:[0-9a-zA-Z_\.]+]]: index) -> index {
-// CHECK-NEXT:      %[[VAL_1:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:      %[[VAL_2:[0-9a-zA-Z_\.]+]] = arith.constant 4 : index
 // CHECK-NEXT:      %[[VAL_3:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:      %[[VAL_2:[0-9a-zA-Z_\.]+]] = arith.constant 4 : index
+// CHECK-NEXT:      %[[VAL_1:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
 // CHECK-NEXT:      %[[VAL_4:[0-9a-zA-Z_\.]+]] = scf.for %[[VAL_5:[0-9a-zA-Z_\.]+]] = %[[VAL_1]] to %[[VAL_2]] step %[[VAL_3]] iter_args(%[[VAL_6:[0-9a-zA-Z_\.]+]] = %[[VAL_0]]) -> (index) {
 // CHECK-NEXT:        %[[VAL_7:[0-9a-zA-Z_\.]+]] = arith.addi %[[VAL_6]], %[[VAL_5]] : index
 // CHECK-NEXT:        scf.yield %[[VAL_7]] : index
@@ -389,9 +380,9 @@ module attributes {llzk.lang} {
 }
 // CHECK-LABEL: module attributes {llzk.lang} {
 // CHECK-NEXT:    function.def @stateful_pod_accumulator(%[[VAL_0:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_1:[0-9a-zA-Z_\.]+]]: !felt.type) -> !felt.type {
-// CHECK-NEXT:      %[[VAL_2:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
-// CHECK-NEXT:      %[[VAL_3:[0-9a-zA-Z_\.]+]] = arith.constant 8 : index
 // CHECK-NEXT:      %[[VAL_4:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
+// CHECK-NEXT:      %[[VAL_3:[0-9a-zA-Z_\.]+]] = arith.constant 8 : index
+// CHECK-NEXT:      %[[VAL_2:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
 // CHECK-NEXT:      %[[VAL_5:[0-9a-zA-Z_\.]+]] = scf.for %[[VAL_6:[0-9a-zA-Z_\.]+]] = %[[VAL_4]] to %[[VAL_3]] step %[[VAL_2]] iter_args(%[[VAL_7:[0-9a-zA-Z_\.]+]] = %[[VAL_0]]) -> (!felt.type) {
 // CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = felt.add %[[VAL_7]], %[[VAL_1]] : !felt.type, !felt.type
 // CHECK-NEXT:        scf.yield %[[VAL_8]] : !felt.type
@@ -467,8 +458,8 @@ module attributes {llzk.lang} {
 }
 // CHECK-LABEL: module attributes {llzk.lang} {
 // CHECK-NEXT:    function.def @stateful_pod_array_while(%[[VAL_0:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_1:[0-9a-zA-Z_\.]+]]: !felt.type, %[[VAL_2:[0-9a-zA-Z_\.]+]]: !felt.type) -> !felt.type attributes {function.allow_non_native_field_ops} {
-// CHECK-NEXT:      %[[VAL_3:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
 // CHECK-NEXT:      %[[VAL_4:[0-9a-zA-Z_\.]+]] = felt.const  0
+// CHECK-NEXT:      %[[VAL_3:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
 // CHECK-NEXT:      %[[VAL_5:[0-9a-zA-Z_\.]+]] = array.new  : <8 x !felt.type>
 // CHECK-NEXT:      %[[VAL_6:[0-9a-zA-Z_\.]+]]:3 = scf.while (%[[VAL_7:[0-9a-zA-Z_\.]+]] = %[[VAL_0]], %[[VAL_8:[0-9a-zA-Z_\.]+]] = %[[VAL_4]], %[[VAL_9:[0-9a-zA-Z_\.]+]] = %[[VAL_5]]) : (!felt.type, !felt.type, !array.type<8 x !felt.type>) -> (!felt.type, !felt.type, !array.type<8 x !felt.type>) {
 // CHECK-NEXT:        %[[VAL_10:[0-9a-zA-Z_\.]+]] = bool.cmp lt(%[[VAL_7]], %[[VAL_1]]) : !felt.type, !felt.type
@@ -532,9 +523,9 @@ module attributes {llzk.lang} {
 }
 // CHECK-LABEL: module attributes {llzk.lang} {
 // CHECK-NEXT:    function.def @virtual_arg_for_write(%[[VAL_0:[0-9a-zA-Z_\.]+]]: index, %[[VAL_1:[0-9a-zA-Z_\.]+]]: index) -> index {
-// CHECK-NEXT:      %[[VAL_2:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
-// CHECK-NEXT:      %[[VAL_3:[0-9a-zA-Z_\.]+]] = arith.constant 4 : index
 // CHECK-NEXT:      %[[VAL_4:[0-9a-zA-Z_\.]+]] = arith.constant 1 : index
+// CHECK-NEXT:      %[[VAL_3:[0-9a-zA-Z_\.]+]] = arith.constant 4 : index
+// CHECK-NEXT:      %[[VAL_2:[0-9a-zA-Z_\.]+]] = arith.constant 0 : index
 // CHECK-NEXT:      %[[VAL_5:[0-9a-zA-Z_\.]+]] = scf.for %[[VAL_6:[0-9a-zA-Z_\.]+]] = %[[VAL_2]] to %[[VAL_3]] step %[[VAL_4]] iter_args(%[[VAL_7:[0-9a-zA-Z_\.]+]] = %[[VAL_0]]) -> (index) {
 // CHECK-NEXT:        %[[VAL_8:[0-9a-zA-Z_\.]+]] = arith.addi %[[VAL_1]], %[[VAL_6]] : index
 // CHECK-NEXT:        scf.yield %[[VAL_8]] : index


### PR DESCRIPTION
See description in `lib/Dialect/POD/Transforms/PodToScalarPass.cpp`
After updating MLIR ≥22.1.0 this can be reverted because `remove-dead-values` bug is fixed and these additional passes become unnecessary (and do some reordering transformation beyond the scope of the `pod-to-scalar` pass so it would be better to remove them).