### PR TITLE
Fix CMake when BUILD_TESTING=OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -392,11 +392,15 @@ else()
 endif()
 
 # Catch-all target for running all tests
-add_custom_target(
-  check
-  DEPENDS # test targets may not exist if BUILD_TESTING is off
-          $<$<BOOL:BUILD_TESTING>:check-unit>
-          $<$<BOOL:BUILD_TESTING>:check-lit>)
+if(BUILD_TESTING)
+  add_custom_target(
+    check
+    DEPENDS # test targets may not exist if BUILD_TESTING is off
+          $<$<BOOL:GTest_FOUND>:check-unit>
+          check-lit>)
+else()
+  add_custom_target(check) # No-op if BUILD_TESTING is disabled.
+endif()
 
 # Install
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -397,7 +397,7 @@ if(BUILD_TESTING)
     check
     DEPENDS # test targets may not exist if BUILD_TESTING is off
           $<$<BOOL:GTest_FOUND>:check-unit>
-          check-lit>)
+          check-lit)
 else()
   add_custom_target(check) # No-op if BUILD_TESTING is disabled.
 endif()

--- a/changelogs/unreleased/dani__fix-cmake-with-disabled-testing.yaml
+++ b/changelogs/unreleased/dani__fix-cmake-with-disabled-testing.yaml
@@ -1,0 +1,2 @@
+fixed:
+  - CMake misconfiguration that made the project unbuildable when BUILD_TESTING is OFF or BUILD_TESTING is ON but GTest is not found by CMake.


### PR DESCRIPTION
The CMake project was unbuildable if `-DBUILD_TESTING=OFF` or, if it was `ON`, if GTest was not found. This is due to the `check` catch-all target referencing targets that do not actually exists if either of the conditions above are true.

Fixes #688.
